### PR TITLE
Update references to moment.js in the examples

### DIFF
--- a/examples/timeline/02_dataset.html
+++ b/examples/timeline/02_dataset.html
@@ -20,7 +20,7 @@
     </style>
 
     <!-- note: moment.js must be loaded before vis.js, else vis.js uses its embedded version of moment.js -->
-    <script src="https://rawgithub.com/moment/moment/2.2.1/min/moment.min.js"></script>
+    <script src="https://rawgithub.com/moment/moment/2.3.1/min/moment.min.js"></script>
 
     <script src="../../vis.js"></script>
 </head>

--- a/examples/timeline/03_much_data.html
+++ b/examples/timeline/03_much_data.html
@@ -11,7 +11,7 @@
     </style>
 
     <!-- note: moment.js must be loaded before vis.js, else vis.js uses its embedded version of moment.js -->
-    <script src="https://rawgithub.com/moment/moment/2.2.1/min/moment.min.js"></script>
+    <script src="https://rawgithub.com/moment/moment/2.3.1/min/moment.min.js"></script>
 
     <script src="../../vis.js"></script>
 </head>

--- a/examples/timeline/05_groups.html
+++ b/examples/timeline/05_groups.html
@@ -17,7 +17,7 @@
     </style>
 
     <!-- note: moment.js must be loaded before vis.js, else vis.js uses its embedded version of moment.js -->
-    <script src="https://rawgithub.com/moment/moment/2.2.1/min/moment.min.js"></script>
+    <script src="https://rawgithub.com/moment/moment/2.3.1/min/moment.min.js"></script>
 
     <script src="../../vis.js"></script>
 </head>


### PR DESCRIPTION
Reference to version 2.2.1 was not available, so examples using moment.js stopped working.
