### PR TITLE
Fix dataSet parsing of Moment objects

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -171,7 +171,7 @@ util.convert = function convert(object, type) {
                 return moment(object.valueOf());
             }
             else if (moment.isMoment(object)) {
-                return moment.clone();
+                return moment(object);
             }
             if (util.isString(object)) {
                 match = ASPDateRegex.exec(object);


### PR DESCRIPTION
Calling just moment.clone() won't do anything but error. Since moment.isMoment(object) guarantees object is already a moment instance, just calling moment(object) will clone
it per the moment docs http://momentjs.com/docs/#/parsing/moment-clone/
