### PR TITLE
Allow edge label fill color customization

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -574,6 +574,14 @@ var edges = [
   </tr>
 
   <tr>
+    <td>fontFill</td>
+    <td>string</td>
+    <td>no</td>
+    <td>Font fill for the background color of the text label of the edge.
+      Only applicable when property <code>label</code> is defined.</td>
+  </tr>
+
+  <tr>
     <td>from</td>
     <td>Number | String</td>
     <td>yes</td>

--- a/src/graph/Edge.js
+++ b/src/graph/Edge.js
@@ -81,10 +81,12 @@ Edge.prototype.setProperties = function(properties, constants) {
     this.fontSize = constants.edges.fontSize;
     this.fontFace = constants.edges.fontFace;
     this.fontColor = constants.edges.fontColor;
+    this.fontFill = constants.edges.fontFill;
 
     if (properties.fontColor !== undefined)  {this.fontColor = properties.fontColor;}
     if (properties.fontSize !== undefined)   {this.fontSize = properties.fontSize;}
     if (properties.fontFace !== undefined)   {this.fontFace = properties.fontFace;}
+    if (properties.fontFill !== undefined)   {this.fontFill = properties.fontFill;}
   }
 
   if (properties.title !== undefined)        {this.title = properties.title;}
@@ -348,7 +350,7 @@ Edge.prototype._label = function (ctx, text, x, y) {
     // TODO: cache the calculated size
     ctx.font = ((this.from.selected || this.to.selected) ? "bold " : "") +
         this.fontSize + "px " + this.fontFace;
-    ctx.fillStyle = 'white';
+    ctx.fillStyle = this.fontFill;
     var width = ctx.measureText(text).width;
     var height = this.fontSize;
     var left = x - width / 2;

--- a/src/graph/Graph.js
+++ b/src/graph/Graph.js
@@ -72,6 +72,7 @@ function Graph (container, data, options) {
       fontColor: '#343434',
       fontSize: 14, // px
       fontFace: 'arial',
+      fontFill: 'white',
       dash: {
         length: 10,
         gap: 5,


### PR DESCRIPTION
Hello,

I was creating a graph with a non-white background with edge labels and they use fixed white backgound.

I created a backwards-compatible property for modifying this value and modified the documentation.

Let me know what you think!

Before and after example:

![Before](http://i.imgur.com/95391sY.png)

![After](http://i.imgur.com/9c2eIM3.png)
