### PR TITLE
Fixed setRange bug in Timeline

### DIFF
--- a/src/timeline/Timeline.js
+++ b/src/timeline/Timeline.js
@@ -290,10 +290,23 @@ Timeline.prototype.setItems = function(items) {
       end = util.convert(this.options.end, 'Date');
     }
 
-    // apply range if there is a min or max available
-    if (start != null || end != null) {
-      this.range.setRange(start, end);
+    // skip range set if there is no start and end date
+    if (start === null && end === null) {
+      return;
     }
+
+    // if start and end dates are set but cannot be satisfyed due to zoom restrictions — correct end date
+    if (start != null && end != null) {
+      var diff = end.valueOf() - start.valueOf();
+      if (this.options.zoomMax != undefined && this.options.zoomMax < diff) {
+        end = new Date(start.valueOf() + this.options.zoomMax);
+      }
+      if (this.options.zoomMin != undefined && this.options.zoomMin > diff) {
+        end = new Date(start.valueOf() + this.options.zoomMin);
+      }
+    }
+
+    this.range.setRange(start, end);
   }
 };
 


### PR DESCRIPTION
Hello! I've found pretty interesting bug: 
we set zoomMax to some value, then we add some items to timeline. If they can't fit in the zoomMax — `Range.prototype._applyRange()` rejects range changes because `(end - start) > zoomMax`. This can't be correct behavior because I end up being at current date instead of being somewhere near to my items.
So I propose this fix — we just check if `end - start` fits in zoomMax (zoomMin) and if it's not — align to the leftmost item.
We can't alter setRange or _applyRange, because for them it is correct behavior. For example, if we try to modify checks in _applyRange we will break zooming.
