### PR TITLE
Fix typo in Timeline.js for stack option

### DIFF
--- a/src/timeline/Timeline.js
+++ b/src/timeline/Timeline.js
@@ -15,7 +15,7 @@ function Timeline (container, items, options) {
     orientation: 'bottom',
     direction: 'horizontal', // 'horizontal' or 'vertical'
     autoResize: true,
-    stacking: true,
+    stack: true,
 
     editable: {
       updateTime: false,


### PR DESCRIPTION
Correct type for stack option, docs and code use stack, but Timeline.js used stacking for the default, making it not stack by default which is opposite of the docs.
