### PR TITLE
Fixing usage of dataManipulation.initiallyVisible option.

### DIFF
--- a/src/graph/Graph.js
+++ b/src/graph/Graph.js
@@ -191,7 +191,6 @@ function Graph (container, data, options) {
     hover: false
   };
   this.hoverObj = {nodes:{},edges:{}};
-  this.editMode = this.constants.dataManipulation.initiallyVisible;
 
   // Node variables
   var graph = this;
@@ -643,6 +642,7 @@ Graph.prototype.setOptions = function (options) {
           this.constants.dataManipulation[prop] = options.dataManipulation[prop];
         }
       }
+	  this.editMode = this.constants.dataManipulation.initiallyVisible;
     }
     else if (options.dataManipulation !== undefined)  {
       this.constants.dataManipulation.enabled = false;


### PR DESCRIPTION
As per the Graph documentation, the dataManipulation.initiallyVisible option can "Initially hide or show the data manipulation toolbar.", but in practice this does not seem to work, and there is no way to make the toolbar visible initially. I think the fix to this is to set editMode after the user's options have been merged with the constants, instead of setting it immediately after the constants are initialized.
