### PR TITLE
[Network] Added support for a broken image fallback when node image fails to load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .settings/org.eclipse.wst.jsdt.ui.superType.name
 npm-debug.log
 examples/graph/24_hierarchical_layout_userdefined2.html
+.DS_Store

--- a/lib/network/Images.js
+++ b/lib/network/Images.js
@@ -20,9 +20,10 @@ Images.prototype.setOnloadCallback = function(callback) {
 /**
  *
  * @param {string} url          Url of the image
+ * @param {string} brokenUrl	Url of an image to use if the url image is not found
  * @return {Image} img          The image object
  */
-Images.prototype.load = function(url) {
+Images.prototype.load = function(url, brokenUrl) {
   var img = this.images[url];
   if (img == undefined) {
     // create the image
@@ -34,6 +35,14 @@ Images.prototype.load = function(url) {
         images.callback(this);
       }
     };
+    
+    img.onerror = function () {
+      this.src = brokenUrl;
+      if (images.callback) {
+        images.callback(this);
+      }
+    };
+    
     img.src = url;
   }
 

--- a/lib/network/Node.js
+++ b/lib/network/Node.js
@@ -135,7 +135,7 @@ Node.prototype.setProperties = function(properties, constants) {
     return;
   }
 
-  var fields = ['borderWidth','borderWidthSelected','shape','image','radius','fontColor',
+  var fields = ['borderWidth','borderWidthSelected','shape','image','brokenImage','radius','fontColor',
     'fontSize','fontFace','group','mass'
   ];
   util.selectiveDeepExtend(fields, this.options, properties);
@@ -176,7 +176,7 @@ Node.prototype.setProperties = function(properties, constants) {
 
   if (this.options.image!== undefined && this.options.image!= "") {
     if (this.imagelist) {
-      this.imageObj = this.imagelist.load(this.options.image);
+      this.imageObj = this.imagelist.load(this.options.image, this.options.brokenImage);
     }
     else {
       throw "No imagelist provided";


### PR DESCRIPTION
I updated the network/node image code to accept a broken image url to use when a node image fails to load.  The broke image url to use can be specified via a _brokenImage_ property on a node.

``` javascript
var nodeProperties = {
     ...
     shape: 'image',
     image: 'some url',
     brokenImage: 'fallback url to use'
}
```

Let me know what you think.  Basically this stemmed out of viewing networks in social media where the node image being used is a person's thumbnail.  Occasionally these thumbnail images fail to load.

I didn't rebuild the files in the _dist_ directory.  Let me know if you want me to do that.  Thanks!
