### PR TITLE
Timeline: Axis using minor measure element to calculate size of major axis label

### DIFF
--- a/lib/timeline/component/TimeAxis.js
+++ b/lib/timeline/component/TimeAxis.js
@@ -385,7 +385,7 @@ TimeAxis.prototype._calculateCharSize = function () {
   // determine the char width and height on the major axis
   if (!this.dom.measureCharMajor) {
     this.dom.measureCharMajor = document.createElement('DIV');
-    this.dom.measureCharMajor.className = 'text minor measure';
+    this.dom.measureCharMajor.className = 'text major measure';
     this.dom.measureCharMajor.style.position = 'absolute';
 
     this.dom.measureCharMajor.appendChild(document.createTextNode('0'));


### PR DESCRIPTION
When the axis label sizes are calculated, the minor measure element is used for both minor and major axis calculations. So when the major axis label has a different css font-size, it gets clipped. 
