### PR TITLE
Change RGB/Hex conversions to not use eval.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -737,50 +737,6 @@ exports.option.asElement = function (value, defaultValue) {
   return value || defaultValue || null;
 };
 
-
-
-exports.GiveDec = function(Hex) {
-  var Value;
-
-  if (Hex == "A")
-    Value = 10;
-  else if (Hex == "B")
-    Value = 11;
-  else if (Hex == "C")
-    Value = 12;
-  else if (Hex == "D")
-    Value = 13;
-  else if (Hex == "E")
-    Value = 14;
-  else if (Hex == "F")
-    Value = 15;
-  else
-    Value = eval(Hex);
-
-  return Value;
-};
-
-exports.GiveHex = function(Dec) {
-  var Value;
-
-  if(Dec == 10)
-    Value = "A";
-  else if (Dec == 11)
-    Value = "B";
-  else if (Dec == 12)
-    Value = "C";
-  else if (Dec == 13)
-    Value = "D";
-  else if (Dec == 14)
-    Value = "E";
-  else if (Dec == 15)
-    Value = "F";
-  else
-    Value = "" + Dec;
-
-  return Value;
-};
-
 /**
  * Parse a color property into an object with border, background, and
  * highlight colors
@@ -863,38 +819,28 @@ exports.parseColor = function(color) {
 };
 
 /**
- * http://www.yellowpipe.com/yis/tools/hex-to-rgb/color-converter.php
+ * http://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
  *
  * @param {String} hex
  * @returns {{r: *, g: *, b: *}}
  */
 exports.hexToRGB = function(hex) {
-  hex = hex.replace("#","").toUpperCase();
+  // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+  var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+  hex = hex.replace(shorthandRegex, function(m, r, g, b) {
+    return r + r + g + g + b + b;
+  });
 
-  var a = exports.GiveDec(hex.substring(0, 1));
-  var b = exports.GiveDec(hex.substring(1, 2));
-  var c = exports.GiveDec(hex.substring(2, 3));
-  var d = exports.GiveDec(hex.substring(3, 4));
-  var e = exports.GiveDec(hex.substring(4, 5));
-  var f = exports.GiveDec(hex.substring(5, 6));
-
-  var r = (a * 16) + b;
-  var g = (c * 16) + d;
-  var b = (e * 16) + f;
-
-  return {r:r,g:g,b:b};
+  var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result ? {
+    r: parseInt(result[1], 16),
+    g: parseInt(result[2], 16),
+    b: parseInt(result[3], 16)
+  } : null;
 };
 
 exports.RGBToHex = function(red,green,blue) {
-  var a = exports.GiveHex(Math.floor(red / 16));
-  var b = exports.GiveHex(red % 16);
-  var c = exports.GiveHex(Math.floor(green / 16));
-  var d = exports.GiveHex(green % 16);
-  var e = exports.GiveHex(Math.floor(blue / 16));
-  var f = exports.GiveHex(blue % 16);
-
-  var hex = a + b + c + d + e + f;
-  return "#" + hex;
+  return "#" + ((1 << 24) + (red << 16) + (green << 8) + blue).toString(16).slice(1);
 };
 
 


### PR DESCRIPTION
When using the library in an environment with strict Content Security Policy configuration calls to "eval()" are forbidden. This patch eliminates two of the existing calls to ensure custom coloring can be used in such configurations.