### PR TITLE
Add decimal option for formatting axis labels

### DIFF
--- a/lib/timeline/DataStep.js
+++ b/lib/timeline/DataStep.js
@@ -178,19 +178,59 @@ DataStep.prototype.previous = function() {
  * Get the current datetime
  * @return {String}  current The current date
  */
-DataStep.prototype.getCurrent = function() {
+DataStep.prototype.getCurrent = function(decimals) {
   var toPrecision = '' + Number(this.current).toPrecision(5);
-  if (toPrecision.indexOf(",") != -1 || toPrecision.indexOf(".") != -1) {
-    for (var i = toPrecision.length-1; i > 0; i--) {
-      if (toPrecision[i] == "0") {
-        toPrecision = toPrecision.slice(0,i);
+  // If decimals is specified, then limit or extend the string as required
+  if(decimals !== undefined && !isNaN(Number(decimals))) {
+    // If string includes exponent, then we need to add it to the end
+    var exp = "";
+    var index = toPrecision.indexOf("e");
+    if(index != -1) {
+      // Get the exponent
+      exp = toPrecision.slice(index);
+      // Remove the exponent in case we need to zero-extend
+      toPrecision = toPrecision.slice(0, index);
+    }
+    index = Math.max(toPrecision.indexOf(","), toPrecision.indexOf("."));
+    if(index === -1) {
+      // No decimal found - if we want decimals, then we need to add it
+      if(decimals !== 0) {
+        toPrecision += '.';
       }
-      else if (toPrecision[i] == "." || toPrecision[i] == ",") {
-        toPrecision = toPrecision.slice(0,i);
-        break;
+      // Calculate how long the string should be
+      index = toPrecision.length + decimals;
+    }
+    else if(decimals !== 0) {
+      // Calculate how long the string should be - accounting for the decimal place
+      index += decimals + 1;
+    }
+    if(index > toPrecision.length) {
+      // We need to add zeros!
+      for(var cnt = index - toPrecision.length; cnt > 0; cnt--) {
+        toPrecision += '0';
       }
-      else{
-        break;
+    }
+    else {
+      // we need to remove characters
+      toPrecision = toPrecision.slice(0, index);
+    }
+    // Add the exponent if there is one
+    toPrecision += exp;
+  }
+  else {
+    if (toPrecision.indexOf(",") != -1 || toPrecision.indexOf(".") != -1) {
+      // If no decimal is specified, and there are decimal places, remove trailing zeros
+      for (var i = toPrecision.length - 1; i > 0; i--) {
+        if (toPrecision[i] == "0") {
+          toPrecision = toPrecision.slice(0, i);
+        }
+        else if (toPrecision[i] == "." || toPrecision[i] == ",") {
+          toPrecision = toPrecision.slice(0, i);
+          break;
+        }
+        else {
+          break;
+        }
       }
     }
   }

--- a/lib/timeline/component/DataAxis.js
+++ b/lib/timeline/component/DataAxis.js
@@ -30,6 +30,10 @@ function DataAxis (body, options, svg, linegraphOptions) {
     customRange: {
       left: {min:undefined, max:undefined},
       right: {min:undefined, max:undefined}
+    },
+    format: {
+      left: {decimals: undefined},
+      right: {decimals: undefined}
     }
   };
 
@@ -108,7 +112,8 @@ DataAxis.prototype.setOptions = function (options) {
       'iconWidth',
       'width',
       'visible',
-      'customRange'
+      'customRange',
+      'format'
     ];
     util.selectiveExtend(fields, this.options, options);
 
@@ -326,6 +331,12 @@ DataAxis.prototype._redrawLabels = function () {
   // do not draw the first label
   var max = 1;
 
+  // Get the number of decimal places
+  var decimals;
+  if(this.options.format[orientation] !== undefined) {
+    decimals = this.options.format[orientation].decimals;
+  }
+
   this.maxLabelSize = 0;
   var y = 0;
   while (max < Math.round(amountOfSteps)) {
@@ -335,13 +346,13 @@ DataAxis.prototype._redrawLabels = function () {
     var isMajor = step.isMajor();
 
     if (this.options['showMinorLabels'] && isMajor == false || this.master == false && this.options['showMinorLabels'] == true) {
-      this._redrawLabel(y - 2, step.getCurrent(), orientation, 'yAxis minor', this.props.minorCharHeight);
+      this._redrawLabel(y - 2, step.getCurrent(decimals), orientation, 'yAxis minor', this.props.minorCharHeight);
     }
 
     if (isMajor && this.options['showMajorLabels'] && this.master == true ||
         this.options['showMinorLabels'] == false && this.master == false && isMajor == true) {
       if (y >= 0) {
-        this._redrawLabel(y - 2, step.getCurrent(), orientation, 'yAxis major', this.props.majorCharHeight);
+        this._redrawLabel(y - 2, step.getCurrent(decimals), orientation, 'yAxis major', this.props.majorCharHeight);
       }
       this._redrawLine(y, orientation, 'grid horizontal major', this.options.majorLinesOffset, this.props.majorLineWidth);
     }


### PR DESCRIPTION
This adds a dataAxis.format.left.decimals option for formatting the labels of the axis. It extends the getCurrent member of DataStep. If decimals is undefined, it reverts to the original implementation. Otherwise, it will remove numbers, or add 0's as required to set the decimal places.

One point to note (and the reason I've not added doc) is that for this, and the title option I added in a separate PR, in my opinion this isn't the nicest way to add the options. However, I've effectively extended the way the options are currently implemented (ie `customRange.left`, and `customRange.right`). This ends up with a lot of objects, and I think it would be better to change this to `dataAxis.left.customRange` etc so that all options for an axis are in a single object.

Just my thoughts though - I'm happy with whatever you prefer... If you're happy with this, I'll add doc.
