### PR TITLE
Fixed onAdd/onUpdate callbacks not working when using DataView in Timeline

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1343,7 +1343,7 @@ ItemSet.prototype._onAddItem = function (event) {
     var itemData = me.itemsData.get(item.id); // get a clone of the data from the dataset
     this.options.onUpdate(itemData, function (itemData) {
       if (itemData) {
-        me.itemsData.update(itemData);
+        me.itemsData.getDataSet().update(itemData);
       }
     });
   }
@@ -1373,7 +1373,7 @@ ItemSet.prototype._onAddItem = function (event) {
     // execute async handler to customize (or cancel) adding an item
     this.options.onAdd(newItem, function (item) {
       if (item) {
-        me.itemsData.add(item);
+        me.itemsData.getDataSet().add(item);
         // TODO: need to trigger a redraw?
       }
     });


### PR DESCRIPTION
onAdd/onUpdate callbacks throw an error when using DataView in Timeline.

```
Uncaught TypeError: undefined is not a function vis.js:12312
(anonymous function) vis.js:12312
ItemSet.defaultOptions.onAdd vis.js:10981
ItemSet._onAddItem vis.js:12310
triggerEvent vis.js:27847
tapGesture vis.js:28366
triggerGesture vis.js:27556
each vis.js:26782
detect vis.js:27553
doDetect vis.js:27265
onTouchHandler vis.js:27184
```

It looks like a handler tries to call add()/update() functions directly on DataView object, which doesn't have ones.
