### PR TITLE
Use icons for nodes (Font Awesome, ...)

### DIFF
--- a/lib/network/Node.js
+++ b/lib/network/Node.js
@@ -13,7 +13,7 @@ var util = require('../util');
  *                                              "database", "circle", "ellipse",
  *                                              "box", "image", "text", "dot",
  *                                              "star", "triangle", "triangleDown",
- *                                              "square"
+ *                                              "square", "icon"
  *                              {string} image  An image url
  *                              {string} title  An title text, can be HTML
  *                              {anytype} group A group name or number
@@ -141,7 +141,7 @@ Node.prototype.setProperties = function(properties, constants) {
   }
 
   var fields = ['borderWidth','borderWidthSelected','shape','image','brokenImage','radius','fontColor',
-    'fontSize','fontFace','fontFill','group','mass'
+    'fontSize','fontFace','fontFill','group','mass','iconFontFace','icon','iconColor','iconSize'
   ];
   util.selectiveDeepExtend(fields, this.options, properties);
 
@@ -227,6 +227,7 @@ Node.prototype.setProperties = function(properties, constants) {
     case 'triangle':      this.draw = this._drawTriangle; this.resize = this._resizeShape; break;
     case 'triangleDown':  this.draw = this._drawTriangleDown; this.resize = this._resizeShape; break;
     case 'star':          this.draw = this._drawStar; this.resize = this._resizeShape; break;
+    case 'icon':          this.draw = this._drawIcon; this.resize = this._resizeShape; break;
     default:              this.draw = this._drawEllipse; this.resize = this._resizeEllipse; break;
   }
   // reset the size of the node, this can be changed
@@ -871,6 +872,47 @@ Node.prototype._drawText = function (ctx) {
   this._label(ctx, this.label, this.x, this.y);
 };
 
+Node.prototype._resizeIcon = function (ctx) {
+      if (!this.width) {
+          var margin = 5;
+          var textSize =
+          {
+              width: 1,
+              height: Number(this.options.iconSize) + 4
+          };
+          this.width = textSize.width + 2 * margin;
+          this.height = textSize.height + 2 * margin;
+
+          // scaling used for clustering
+          this.width += Math.min(this.clusterSize - 1, this.maxNodeSizeIncrements) * this.clusterSizeWidthFactor;
+          this.height += Math.min(this.clusterSize - 1, this.maxNodeSizeIncrements) * this.clusterSizeHeightFactor;
+          this.options.radius += Math.min(this.clusterSize - 1, this.maxNodeSizeIncrements) * this.clusterSizeRadiusFactor;
+          this.growthIndicator = this.width - (textSize.width + 2 * margin);
+      }
+  };
+
+Node.prototype._drawIcon = function (ctx) {
+    this._resizeIcon(ctx);
+    this.left = this.x - this.width / 2;
+    this.top = this.y - this.height / 2;
+    this._icon(ctx, this.options.icon, this.x, this.y);
+
+    if (this.label) {
+        this._label(ctx, this.label, this.x, this.y + this.height / 2, 'top', true);
+    }
+};
+
+Node.prototype._icon = function (ctx, icon, x, y) {
+  if (icon && Number(this.options.iconSize) * this.networkScale > this.fontDrawThreshold) {
+      ctx.font = (this.selected ? "bold " : "") + this.options.iconSize + "px " + this.options.iconFontFace;
+
+      // draw icon
+      ctx.fillStyle = this.options.iconColor || "black";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(icon, x, y);
+  }
+};
 
 Node.prototype._label = function (ctx, text, x, y, align, baseline, labelUnderNode) {
   if (text && Number(this.options.fontSize) * this.networkScale > this.fontDrawThreshold) {


### PR DESCRIPTION
Added the ability to use icons as node-symbol. 
Parameters are for example:
shape: 'icon',
iconFontFace: 'FontAwesome',
icon: '\uf013', // cog
iconSize: 50,
iconColor: '#1b6eae' // dark cyan