### PR TITLE
Reflect dual licensed vis.js in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,14 +279,14 @@ Then run the tests:
 
 Copyright (C) 2010-2014 Almende B.V.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Vis.js is dual licensed under both
 
-   http://www.apache.org/licenses/LICENSE-2.0
+  * The Apache 2.0 License
+    http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+and
+
+  * The MIT License
+    http://opensource.org/licenses/MIT
+
+Vis.js may be distributed under either license.


### PR DESCRIPTION
Further to #285, it seems the `README.md` wasn't changed in https://github.com/almende/vis/commit/191bb159eae06f482e849747e7b739eaa0bf5df8 to reflect the dual license status.
