### PR TITLE
No longer throw Error when MAX_REDRAWS count has been exceeded.

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -614,8 +614,7 @@ Core.prototype.redraw = function() {
       this.redraw();
     }
     else {
-      console.log('WARNING: infinite loop in redraw?')
-      throw new Error("bla")
+      console.log('WARNING: infinite loop in redraw?');
     }
     this.redrawCount = 0;
   }


### PR DESCRIPTION
Throwing this error was introduced recently, but appears to have been unintentionally committed (since the error message isn't helpful/relevant, and because the unexpected Error will unnecessarily disrupt the display of the timeline if not caught).