### PR TITLE
Change _getNodeAt/_getEdgeAt to return the first matched object

### DIFF
--- a/lib/network/mixins/SelectionMixin.js
+++ b/lib/network/mixins/SelectionMixin.js
@@ -66,7 +66,7 @@ exports._getNodeAt = function (pointer) {
   // if there are overlapping nodes, select the last one, this is the
   // one which is drawn on top of the others
   if (overlappingNodes.length > 0) {
-     return this.nodes[overlappingNodes[overlappingNodes.length - 1]];
+     return this.nodes[overlappingNodes[0]];
   }
   else {
     return null;
@@ -117,7 +117,7 @@ exports._getEdgeAt = function(pointer) {
   var overlappingEdges = this._getAllEdgesOverlappingWith(positionObject);
 
   if (overlappingEdges.length > 0) {
-    return this.edges[overlappingEdges[overlappingEdges.length - 1]];
+    return this.edges[overlappingEdges[0]];
   }
   else {
     return null;


### PR DESCRIPTION
There's a small issue on a busy network with many edges. If hover is enabled and the edges have titles, hover is picking one edge while the popup is shown for another edge.

The reason is that the `_getNodeAt()` and `_getEdgeAt()` methods return the *last* of all the matches objects, while the code in the `_checkShowPopup()` method picks the first match.

This changes `_getNodeAt()` and `_getEdgeAt()` to return the first match.