### PR TITLE
Select the last (top) overlapping object when showing the popup

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -1336,33 +1336,43 @@ Network.prototype._checkShowPopup = function (pointer) {
   if (this.popupObj == undefined) {
     // search the nodes for overlap, select the top one in case of multiple nodes
     var nodes = this.nodes;
+    var overlappingNodes = [];
     for (id in nodes) {
       if (nodes.hasOwnProperty(id)) {
         var node = nodes[id];
         if (node.isOverlappingWith(obj)) {
           if (node.getTitle() !== undefined) {
-            this.popupObj = node;
-            break;
+            overlappingNodes.push(id);
           }
-          // if you hover over a node, the title of the edge is not supposed to be shown.
-          nodeUnderCursor = true;
         }
       }
+    }
+
+    if (overlappingNodes.length > 0) {
+      // if there are overlapping nodes, select the last one, this is the
+      // one which is drawn on top of the others
+      this.popupObj = this.nodes[overlappingNodes[overlappingNodes.length - 1]];
+      // if you hover over a node, the title of the edge is not supposed to be shown.
+      nodeUnderCursor = true;
     }
   }
 
   if (this.popupObj === undefined && nodeUnderCursor == false) {
     // search the edges for overlap
     var edges = this.edges;
+    var overlappingEdges = [];
     for (id in edges) {
       if (edges.hasOwnProperty(id)) {
         var edge = edges[id];
         if (edge.connected && (edge.getTitle() !== undefined) &&
             edge.isOverlappingWith(obj)) {
-          this.popupObj = edge;
-          break;
+          overlappingEdges.push(id);
         }
       }
+    }
+
+    if (overlappingEdges.length > 0) {
+      this.popupObj = this.edges[overlappingEdges[overlappingEdges.length - 1]];
     }
   }
 


### PR DESCRIPTION
Follow up to #560.

When there are many overlapping objects, pick the last one which
is drawn at the top of the others. This is the same way the
_getNodeAt() / _getEdgeAt() methods of the SelectionMixin work.