### PR TITLE
Movable Current Time bar

### DIFF
--- a/examples/timeline/34_current_time_bar.html
+++ b/examples/timeline/34_current_time_bar.html
@@ -1,0 +1,84 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Timeline | Show current and custom time bars</title>
+
+  <style type="text/css">
+    body, html {
+      font-family: sans-serif;
+      font-size: 11pt;
+    }
+  </style>
+
+  <script src="../../dist/vis.js"></script>
+  <link href="../../dist/vis.css" rel="stylesheet" type="text/css" />
+</head>
+<body>
+
+<p>
+  <input type="text" id="setTime" value="2014-02-07" />
+  <input type="button" id="set" value="Set custom time" />
+</p>
+<p>
+  <input type="button" id="get" value="Get custom time" />
+  <span id="getTime"></span>
+</p>
+<p>
+  <code>timechange</code> event: <span id="timechangeEvent"></span>
+</p>
+<p>
+  <code>timechanged</code> event: <span id="timechangedEvent"></span>
+</p>
+<p>
+  <code>currentTimechange</code> event: <span id="currentTimechangeEvent"></span>
+</p>
+<p>
+  <code>currentTimechanged</code> event: <span id="currentTimechangedEvent"></span>
+</p>
+
+<div id="visualization"></div>
+
+<script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
+
+<script type="text/javascript">
+  var container = document.getElementById('visualization');
+  var items = new vis.DataSet();
+  var options = {
+    showCurrentTime: true,
+    moveCurrentTime: true,
+    showCustomTime: true,
+    start: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    end: new Date(Date.now() + 1000 * 60 * 60 * 24 * 6)
+  };
+  var timeline = new vis.Timeline(container, items, options);
+
+  document.getElementById('set').onclick = function () {
+    var time = document.getElementById('setTime').value;
+    timeline.setCustomTime(time);
+  };
+  document.getElementById('setTime').value = new Date().toISOString().substring(0, 10);
+
+  document.getElementById('get').onclick = function () {
+    document.getElementById('getTime').innerHTML = timeline.getCustomTime();
+  };
+
+  timeline.on('timechange', function (properties) {
+    document.getElementById('timechangeEvent').innerHTML = properties.time;
+  });
+  timeline.on('timechanged', function (properties) {
+    document.getElementById('timechangedEvent').innerHTML = properties.time;
+  });
+
+  timeline.on('currenttimechange', function (properties) {
+    document.getElementById('currentTimechangeEvent').innerHTML = properties.time;
+  });
+
+  timeline.on('currenttimechanged', function (properties) {
+    document.getElementById('currentTimechangedEvent').innerHTML = properties.time;
+  });
+
+  timeline.setCustomTime(new Date(Date.now() - 1000 * 60 * 60 * 12));
+
+</script>
+</body>
+</html>

--- a/examples/timeline/index.html
+++ b/examples/timeline/index.html
@@ -44,6 +44,7 @@
   <p><a href="31_background_areas_with_groups.html">31_background_areas_with_groups.html</a></p>
   <p><a href="32_grid_styling.html">32_grid_styling.html</a></p>
   <p><a href="33_custom_snapping.html">33_custom_snapping.html</a></p>
+  <p><a href="34_current_time_bar.html">34_current_time_bar.html</a></p>
 
   <p><a href="requirejs/requirejs_example.html">requirejs_example.html</a></p>
 


### PR DESCRIPTION
Hello,
I'm currently working on an enterprise project where one of the requirements is the timeline implementation. Since vis.js allows for high degree of customization, we agreed to try to implement it into our environment. 
However, since the requirements for the timeline itself reach beyond the current vis.js capabilities, I would like to join the project and offer my contribution to it.
Current requirement is the ability to dynamically change the current time setting, i.e. move the current time vertical bar the same way the custom bar can be moved. So the list of my changes is as follows: 
1. Feature is enabled via moveCurrentTime attribute, which defaults to false.
2. If enabled, the draggable current time vertical bar is added asynchronously (since CurrentTime setOptions method is asynchronous and options are constructed after the _create method is called)
3. Dynamic update of the current time bar (as time progresses) is paused during drag, resumed on release.
4. Added "cursor: move" CSS style to the moveable current time bar (disabled if moveCurrentTime is false);
5. Added Hammer instance to the CurrentTime object

Overall, the functionality was mostly copied from CustomTime object and adjusted to the CurrentTime object with as minimal code change as possible.

Thank you,
Oleg 