### PR TITLE
Added possibility to rename fields on a DataSet.get()

### DIFF
--- a/docs/dataset.html
+++ b/docs/dataset.html
@@ -740,9 +740,10 @@ DataSet.map(callback [, options]);
 
   <tr>
     <td>fields</td>
-    <td>String[&nbsp;]</td>
+    <td>String[&nbsp;] | Object.&lt;String,&nbsp;String&gt;</td>
     <td>
-      An array with field names.
+      An array with field names, or an object with current field name and 
+      new field name that the field is returned as.
       By default, all properties of the items are emitted.
       When <code>fields</code> is defined, only the properties
       whose name is specified in <code>fields</code> will be included

--- a/docs/dataview.html
+++ b/docs/dataview.html
@@ -129,9 +129,10 @@ var data = new vis.DataView(dataset, options)
 
       <tr>
         <td>fields</td>
-        <td>String[&nbsp;]</td>
+        <td>String[&nbsp;] | Object.&lt;String,&nbsp;String&gt;</td>
         <td>
-          An array with field names.
+          An array with field names, or an object with current field name and 
+          new field name that the field is returned as. 
           By default, all properties of the items are emitted.
           When <code>fields</code> is defined, only the properties
           whose name is specified in <code>fields</code> will be included

--- a/lib/DataSet.js
+++ b/lib/DataSet.js
@@ -664,8 +664,14 @@ DataSet.prototype._filterFields = function (item, fields) {
   var filteredItem = {};
 
   for (var field in item) {
-    if (item.hasOwnProperty(field) && (fields.indexOf(field) != -1)) {
-      filteredItem[field] = item[field];
+  	if(Array.isArray(fields)){
+  		if (item.hasOwnProperty(field) && (fields.indexOf(field) != -1)) {
+  			filteredItem[field] = item[field];
+   	   }
+    }else{
+      	if (item.hasOwnProperty(field) && fields.hasOwnProperty(field)) {
+  			filteredItem[fields[field]] = item[field];
+   	   }  
     }
   }
 

--- a/lib/DataSet.js
+++ b/lib/DataSet.js
@@ -663,15 +663,17 @@ DataSet.prototype._filterFields = function (item, fields) {
 
   var filteredItem = {};
 
-  for (var field in item) {
-  	if(Array.isArray(fields)){
-  		if (item.hasOwnProperty(field) && (fields.indexOf(field) != -1)) {
-  			filteredItem[field] = item[field];
-   	   }
-    }else{
-      	if (item.hasOwnProperty(field) && fields.hasOwnProperty(field)) {
-  			filteredItem[fields[field]] = item[field];
-   	   }  
+  if(Array.isArray(fields)){
+    for (var field in item) {
+      if (item.hasOwnProperty(field) && (fields.indexOf(field) != -1)) {
+        filteredItem[field] = item[field];
+      }
+    }
+  }else{
+    for (var field in item) {
+      if (item.hasOwnProperty(field) && fields.hasOwnProperty(field)) {
+        filteredItem[fields[field]] = item[field];
+      }
     }
   }
 


### PR DESCRIPTION
Added functionality to extend the fields array, to a fields object, similar to the type declaration. This makes it possible rename properties when you get them from a dataset or data view.

This would make it possible to easily plot a Timeline dataset to a Graph2d and the other way around. You can as before set the options to {fields:["start","value"]}, but it would also be possible to set it to {fields:[start:"x",value:"y"]} to rename start to x and value to y. What do you think?