### PR TITLE
Fixes bug where new Timeline Items are created in the wrong group...

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1599,6 +1599,8 @@ ItemSet.prototype.itemFromTarget = function(event) {
  */
 ItemSet.prototype.groupFromTarget = function(event) {
   var clientY = event.gesture ? event.gesture.center.clientY : event.clientY;
+  clientY = clientY + window.pageYOffset;
+  
   for (var i = 0; i < this.groupIds.length; i++) {
     var groupId = this.groupIds[i];
     var group = this.groups[groupId];


### PR DESCRIPTION
...when client is scrolled.

The ItemSet.prototype.groupFromTarget function did not take into
account the if the client view was scrolled when calculating where the
user clicks.

How to reproduce:
- Open http://visjs.org/examples/timeline/09_order_groups.html
- Add a couple of events in the first group at the same time, make sure they stack.
- Resize the window so that only group one is visible
- Scroll down to the third group and try to add an item.
- The Item will be added to either the first or the second group, depending on your scroll offset. 