### PR TITLE
Fix Problem with click events on timeline items

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1371,6 +1371,7 @@ ItemSet.prototype._onDragEnd = function (event) {
  * @private
  */
 ItemSet.prototype._onSelectItem = function (event) {
+  event.target.click();
   if (!this.options.selectable) return;
 
   var ctrlKey  = event.gesture.srcEvent && event.gesture.srcEvent.ctrlKey;


### PR DESCRIPTION
The click events for timeline items do not fire. (Seems to
be catched by Hammer) So manualy call the click event on the item
wich had been clicked.

Seems related to https://github.com/almende/vis/issues/331

Not sure if this is the best solution or bring other unwanted side effects.