### PR TITLE
Fix browserify bundling as app

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "uglify-js": "^2.4.20",
     "webpack": "^1.8.5",
     "yargs": "^3.7.2"
+  },
+  "browserify": {
+    "transform": ["babelify"]
   }
 }


### PR DESCRIPTION
Fixes #874
See https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed