### PR TITLE
Core.prototype.fit and Core.prototype.getDataRange fixes

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -459,7 +459,7 @@ Core.prototype.getVisibleItems = function() {
 Core.prototype.fit = function(options) {
   var range = this.getDataRange();
 
-  // skip range set if there is no start and end date
+  // skip range set if there is no min and max date
   if (range.min === null && range.max === null) {
     return;
   }

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -496,8 +496,8 @@ Core.prototype.getDataRange = function() {
   }
 
   return {
-    start: start,
-    end: end
+    min: start,
+    max: end
   }
 };
 

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -496,8 +496,8 @@ Core.prototype.getDataRange = function() {
   }
 
   return {
-    start: null,
-    end: null
+    start: start,
+    end: end
   }
 };
 


### PR DESCRIPTION
Hi,

I stumbled upon some errors after upgrading to vis-4.2.0. Traced the bug down to these two functions:

    Core.prototype.getDataRange
    Core.prototype.fit


1.) `fit` accessed the wrong property of the variable `range`. Instead of `min` and `max` it did access `start` and `end`.

2.) `getDataRange` returned always `null` as `start` and `end`.

3.) Renamed the properties of `getDataRange` from `start` and `end` to `min` and `max` as the other functions were expecting such properties, and the documentation states it as well.

Regards