### PR TITLE
Don't change backgroundColor if not requested on setOptions

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -876,6 +876,7 @@ Graph3d.prototype.setOptions = function (options) {
     if (options.zMax !== undefined) this.defaultZMax = options.zMax;
     if (options.valueMin !== undefined) this.defaultValueMin = options.valueMin;
     if (options.valueMax !== undefined) this.defaultValueMax = options.valueMax;
+    if (options.backgroundColor !== undefined) this._setBackgroundColor(options.backgroundColor);
 
     if (options.cameraPosition !== undefined) cameraPosition = options.cameraPosition;
 
@@ -904,7 +905,7 @@ Graph3d.prototype.setOptions = function (options) {
         }
       }
     }
-    this._setBackgroundColor(options.backgroundColor);
+    
   }
 
   this.setSize(this.width, this.height);


### PR DESCRIPTION
When backgroundColor is not specified in setOptions, the existing method was setting the backgroundColor to undefined, which defaults to white, regardless of current value. Other options in this method are assumed to not be changed if not specified, which is a reasonable mode for backgroundColor as well.