### PR TITLE
added breadcrumbs generator

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -189,3 +189,18 @@ pre.options {
 pre.hidden {
     display:none;
 }
+
+#breadcrumbs {
+  font-size: 0.85em;
+}
+
+#breadcrumbs::before {
+  content: "You are here:";
+  padding-right: 5px;
+}
+
+#breadcrumbs > *:not(:first-child)::before{
+  content: "▸";
+  padding: 0 2px 0 5px;
+  display:inline-block;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0;url=../index.html#modules">
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        If you are not redirected automatically, follow this <a href="../index.html#modules">link</a>.
+    </body>
+</html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,0 +1,46 @@
+$(document).ready(function() {
+
+  vis.createBreadcrumbs($(".container.full").first());
+  
+});
+
+// namespace
+var vis = {};
+
+/**
+ * Adds a breadcrumb as first child to the specified container.
+ * 
+ * @author felixhayashi
+ */
+vis.createBreadcrumbs = function(container) {
+    
+  // use the url to infer the path
+  var crumbs = location.pathname.split('/');
+  
+  // number of ancestor directories
+  var stepbackIndex = crumbs.length-1;
+  var breadcrumbs = $.map(crumbs, function(crumb, i) {
+    
+    // first and last element of the split
+    if(!crumb) return;
+    
+    stepbackIndex--;
+    
+    if(/\.html$/.test(crumb)) {
+      
+      // strip the .html to make it look prettier
+      return "<span>" + crumb.replace(/\.html$/, "") + "</span>";
+      
+    } else {
+            
+      // calculate the relative url
+      for(var ref=crumb+"/", j=0; j<stepbackIndex; j++, ref="../"+ref);
+      
+      return "<a href='" + ref + "'>" + crumb + "</a>";
+    }
+  }).join("") || "Home";
+
+  // insert into the container at the beginning.
+  $(container).prepend("<div id=\"breadcrumbs\">" + breadcrumbs + "</div>");
+  
+};

--- a/docs/network/configure.html
+++ b/docs/network/configure.html
@@ -79,9 +79,7 @@
 
 <div class="container full">
     <h1>Network - configure</h1>
-
     <p>Handles the HTML part of the canvas.</p>
-    <a class="btn btn-primary" role="button" onclick="history.back()">Back to overview.</a>
     <h3>Options</h3>
     <p>The options for the canvas have to be contained in an object titled 'configure'.</p>
     <p>Click on the full options or shorthand options to show how these options are supposed to be used.</p>
@@ -169,3 +167,5 @@ function (option, path) {
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>

--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -79,11 +79,8 @@
 
 <div class="container full">
     <h1>Network - edges</h1>
-
     <p>Handles the creation and deletion of edges and contains the global edge options and styles.</p>
-    <a class="btn btn-primary" role="button" onclick="history.back()">Back to overview.</a>
     <h3>Options</h3>
-
     <p>The options for the edges have to be contained in an object titled 'edges'. All of these options can be supplied per edge as well. Obviously, 'id' should not be defined globally but per edge. Options defined
     in the global edges object, are applied to all edges. If an edge has options of its own, those will be used instead of the global options.</p>
     <p><b><i>When you have given an edge an option, you will override the global option for that property. If you then set that option to <code>null</code>,
@@ -651,3 +648,5 @@ var options: {
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>

--- a/docs/network/groups.html
+++ b/docs/network/groups.html
@@ -24,7 +24,6 @@
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-
     <script src="../js/smooth-scroll.min.js"></script>
     <script language="JavaScript">
         smoothScroll.init();
@@ -75,13 +74,12 @@
         alt="Fork me on GitHub"
         data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
 
+
+
 <div class="container full">
     <h1>Network - groups</h1>
-
     <p>Handles the group styling.</p>
-    <a class="btn btn-primary" role="button" onclick="history.back()">Back to overview.</a>
     <h3>Options</h3>
-
     <p>The options for the canvas have to be contained in an object titled 'groups'.</p>
     <p>Click on the options shown to show how these options are supposed to be used.</p>
     <ul class="nav nav-tabs">
@@ -153,3 +151,5 @@ var options = {
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>

--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -109,7 +109,6 @@
 
 <div class="container full">
     <h1>Network</h1>
-
     <p>Network is a visualization to display networks and networks consisting of nodes and edges. The visualization
         is easy to use and supports custom shapes, styles, colors, sizes, images, and more.
 
@@ -1545,3 +1544,5 @@ var network = new vis.Network(container, data, options);
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>

--- a/docs/network/interaction.html
+++ b/docs/network/interaction.html
@@ -67,7 +67,6 @@
 <div class="container full">
     <h1>Network - interaction</h1>
     <p>Used for all user interaction with the network. Handles mouse and touch events as well as the navigation buttons and the popups.</p>
-    <a class="btn btn-primary" role="button" onclick="history.back()">Back to overview.</a>
     <h3>Options</h3>
     <p>The options for the interaction module have to be contained in an object titled 'interaction'.</p>
     <p>Click on the full options or shorthand options to show how these options are supposed to be used.</p>
@@ -147,3 +146,5 @@ network.setOptions(options);
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>

--- a/docs/network/layout.html
+++ b/docs/network/layout.html
@@ -68,7 +68,6 @@
 <div class="container full">
     <h1>Network - layout</h1>
     <p>Acts as the camera that looks on the canvas. Does the animation, zooming and focusing.</p>
-    <a class="btn btn-primary" role="button" onclick="history.back()">Back to overview.</a>
     <h3>Options</h3>
     <p>The options for the layout module have to be contained in an object titled 'layout'.</p>
     <p>Click on the full options or shorthand options to show how these options are supposed to be used.</p>
@@ -127,3 +126,5 @@ network.setOptions(options);
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>

--- a/docs/network/manipulation.html
+++ b/docs/network/manipulation.html
@@ -67,7 +67,6 @@
 <div class="container full">
     <h1>Network - manipulation</h1>
     <p>Acts as the camera that looks on the canvas. Does the animation, zooming and focusing.</p>
-    <a class="btn btn-primary" role="button" onclick="history.back()">Back to overview.</a>
     <h3>Options</h3>
     <p>The options for the manipulation module have to be contained in an object titled 'manipulation'.</p>
     <p>Click on the full options or shorthand options to show how these options are supposed to be used.</p>
@@ -179,3 +178,5 @@ var options = {
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>

--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -71,7 +71,6 @@
 
 <div class="container full">
     <h1>Network - nodes</h1>
-
     <p>Handles the creation and deletion of nodes and contains the global node options and styles.</p>
     <a class="btn btn-primary" role="button" onclick="history.back()">Back to overview.</a>
     <h3>Options</h3>
@@ -638,3 +637,5 @@ mySize = minSize + diff * scale;
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>

--- a/docs/network/physics.html
+++ b/docs/network/physics.html
@@ -68,7 +68,6 @@
 <div class="container full">
     <h1>Network - physics</h1>
     <p>Handles the physics simulation, moving the nodes and edges to show them clearly.</p>
-    <a class="btn btn-primary" role="button" onclick="history.back()">Back to overview.</a>
     <h3>Options</h3>
     <p>The options for the physics have to be contained in an object titled 'physics'.</p>
     <p>Click on the full options or shorthand options to show how these options are supposed to be used.</p>
@@ -197,3 +196,5 @@ network.setOptions(options);
 <script src="../js/bootstrap.min.js"></script>
 <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 <script src="../js/ie10-viewport-bug-workaround.js"></script>
+<!-- controller -->
+<script src="../js/main.js"></script>


### PR DESCRIPTION
Hi @AlexDM0 

I now added breadcrumbs to the *network* pages to demonstrate it (see demo link below). It works for static sites like yours (regardless of whether it is served or loaded as file). It breaks the url into single components and generates links.

Never wrote a breadcrumb script for a static site and never thought it would be that cumbersome :)

For a demo visit e.g http://felixhayashi.github.io/vis/docs/network/edges.html

Hope you like it.

-Felix