### PR TITLE
Added option zoomKey

### DIFF
--- a/docs/graph2d/index.html
+++ b/docs/graph2d/index.html
@@ -1026,6 +1026,26 @@ function (option, path) {
             <td>The width of the timeline in pixels or as a percentage.</td>
         </tr>
 
+		<tr>
+      		<td>zoomable</td>
+      		<td>boolean</td>
+      		<td><code>true</code></td>
+      		<td>
+        		Specifies whether the Timeline can be zoomed by pinching or scrolling in the window.
+        		Only applicable when option <code>moveable</code> is set <code><code>true</code></code>.
+      		</td>
+    	</tr>
+
+		<tr>
+		    <td>zoomKey</td>
+		    <td>String</td>
+		    <td><code>''</code></td>
+		    <td>Specifies whether the Timeline is only zoomed when an additional key is down.
+		      	Available values are '' (does not apply), 'altKey', 'ctrlKey', or 'metaKey'.
+		        Only applicable when option <code>moveable</code> is set <code><code>true</code></code>.
+		    </td>
+		</tr>
+
         <tr>
             <td>zoomMax</td>
             <td>Number</td>

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -907,6 +907,16 @@ function (option, path) {
       </td>
     </tr>
 
+	<tr>
+      <td>zoomKey</td>
+      <td>String</td>
+      <td><code>''</code></td>
+      <td>Specifies whether the Timeline is only zoomed when an additional key is down.
+      	Available values are '' (does not apply), 'altKey', 'ctrlKey', or 'metaKey'.
+        Only applicable when option <code>moveable</code> is set <code><code>true</code></code>.
+      </td>
+    </tr>
+
     <tr>
       <td>zoomMax</td>
       <td>number</td>

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -475,7 +475,7 @@ Range.prototype._onMouseWheel = function(event) {
   // only zoom when the mouse is inside the current range
   if (!this._isInsideRange(event)) return;
   
-  // only zoom when the according key is pressed and the zoom_key option is set
+  // only zoom when the according key is pressed and the zoomKey option is set
   if (this.options.zoomKey && !event[this.options.zoomKey]) return;
 
   // retrieve delta

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -78,7 +78,7 @@ Range.prototype = new Component();
 Range.prototype.setOptions = function (options) {
   if (options) {
     // copy the options that we know
-    var fields = ['direction', 'min', 'max', 'zoomMin', 'zoomMax', 'moveable', 'zoomable', 'activate', 'hiddenDates'];
+    var fields = ['direction', 'min', 'max', 'zoomMin', 'zoomMax', 'moveable', 'zoomable', 'activate', 'hiddenDates', 'zoomKey'];
     util.selectiveExtend(fields, this.options, options);
 
     if ('start' in options || 'end' in options) {
@@ -474,6 +474,9 @@ Range.prototype._onMouseWheel = function(event) {
 
   // only zoom when the mouse is inside the current range
   if (!this._isInsideRange(event)) return;
+  
+  // only zoom when the according key is pressed and the zoom_key option is set
+  if (this.options.zoomKey && !event[this.options.zoomKey]) return;
 
   // retrieve delta
   var delta = 0;

--- a/lib/timeline/optionsGraph2d.js
+++ b/lib/timeline/optionsGraph2d.js
@@ -150,6 +150,7 @@ let allOptions = {
   },
   width: {string, number},
   zoomable: {boolean},
+  zoomKey: {string: ['ctrlKey', 'altKey', 'metaKey', '']},
   zoomMax: {number},
   zoomMin: {number},
   __type__: {object}
@@ -251,6 +252,7 @@ let configureOptions = {
     start: '',
     width: '100%',
     zoomable: true,
+    zoomKey: ['ctrlKey', 'altKey', 'metaKey', ''],
     zoomMax: [315360000000000, 10, 315360000000000, 1],
     zoomMin: [10, 10, 315360000000000, 1]
   }

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -113,6 +113,7 @@ let allOptions = {
   type: {string},
   width: {string, number},
   zoomable: {boolean},
+  zoomKey: {string},
   zoomMax: {number},
   zoomMin: {number},
 
@@ -197,6 +198,7 @@ let configureOptions = {
     type: ['box', 'point', 'range', 'background'],
     width: '100%',
     zoomable: true,
+    zoomKey: ['ctrlKey', 'altKey', 'metaKey', ''],
     zoomMax: [315360000000000, 10, 315360000000000, 1],
     zoomMin: [10, 10, 315360000000000, 1]
   }

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -113,7 +113,7 @@ let allOptions = {
   type: {string},
   width: {string, number},
   zoomable: {boolean},
-  zoomKey: {string},
+  zoomKey: {string: ['ctrlKey', 'altKey', 'metaKey', '']},
   zoomMax: {number},
   zoomMin: {number},
 


### PR DESCRIPTION
The option `zoomKey` can hold one of the wheel events properties to check whether alt, ctrl or meta was down ('pressed'). If set, the specified key must be down (evaluate to true) to apply zooming.
I have one question though: how are the available values for this option validated? I tried setting this in https://github.com/hansmaulwurf23/vis/blob/zoom_key/lib/timeline/optionsTimeline.js#L201 but when specifying 'bla' it does not show any error when instantiating the timeline. Is `optionsTimeline` the wrong file for this or is there no validation for available values for this kind of option?

Cheers
Martin