### PR TITLE
remove subgroup from subgroups list if there is no more items in the …

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -401,9 +401,14 @@ Group.prototype.remove = function(item) {
 
   if(item.data.subgroup !== undefined){
     var subgroup = this.subgroups[item.data.subgroup];
-    if(subgroup){
+    if (subgroup){
       var itemIndex = subgroup.items.indexOf(item);
       subgroup.items.splice(itemIndex,1);
+      if (!subgroup.items.length){
+        delete this.subgroups[item.data.subgroup];
+        this.subgroupIndex--;
+      }
+      this.orderSubgroups();
     }
   }
 };


### PR DESCRIPTION
I found a bug that  happens cuz my prev commit.
I forget to delete the subgroup if there is no more items in it , that cause the orderSubgroups function to throw cuz it go to items[0].
Im also reduce the subgroupIndex member and call orderSubgroups after remove item from the group
