### PR TITLE
allow custom label formatting via functions

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -509,6 +509,8 @@ TimeStep.prototype.getLabelMinor = function(date) {
   if (date == undefined) {
     date = this.current;
   }
+  if (typeof(this.format.minorLabels) === "function")
+    return this.format.minorLabels(date, this.scale);
 
   var format = this.format.minorLabels[this.scale];
   return (format && format.length > 0) ? moment(date).format(format) : '';
@@ -524,6 +526,8 @@ TimeStep.prototype.getLabelMajor = function(date) {
   if (date == undefined) {
     date = this.current;
   }
+  if (typeof(this.format.majorLabels) === "function")
+    return this.format.majorLabels(date, this.scale);
 
   var format = this.format.majorLabels[this.scale];
   return (format && format.length > 0) ? moment(date).format(format) : '';

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -47,7 +47,7 @@ let allOptions = {
       day: {string,'undefined': 'undefined'},
       month: {string,'undefined': 'undefined'},
       year: {string,'undefined': 'undefined'},
-      __type__: {object}
+      __type__: {object, 'function': 'function'}
     },
     majorLabels: {
       millisecond: {string,'undefined': 'undefined'},
@@ -58,7 +58,7 @@ let allOptions = {
       day: {string,'undefined': 'undefined'},
       month: {string,'undefined': 'undefined'},
       year: {string,'undefined': 'undefined'},
-      __type__: {object}
+      __type__: {object, 'function': 'function'}
     },
     __type__: {object}
   },


### PR DESCRIPTION
This allows you to use another formatter than format.js or use functions like `fromNow()` like
```
    function formatter(date, scale) {
      moment(date).fromNow(); //gives you sth. like '4 days ago'
   }
```
Or you could do any integerbased axis by giving the timeline integers
```
var items = VisDataSet([{id: 0, content: 'item 0', start: 1, end: 300000}]);
```
 and use a custom formater and get the integer back via `date.getTime()`. Now you would be able to do any integer based axis. So this should enable a workaround for #92 