### PR TITLE
fix "TypeError: Cannot read property '_bound' of undefined" in angular2 environment

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -265,7 +265,7 @@ Core.prototype.setOptions = function (options) {
           onRender: options.drawPoints
       };
     }
-    
+
     if ('hiddenDates' in this.options) {
       DateUtil.convertHiddenOptions(this.options.moment, this.body, this.options.hiddenDates);
     }
@@ -900,8 +900,10 @@ Core.prototype._stopAutoResize = function () {
   }
 
   // remove event listener on window.resize
-  util.removeEventListener(window, 'resize', this._onResize);
-  this._onResize = null;
+  if (this._onResize) {
+    util.removeEventListener(window, 'resize', this._onResize);
+    this._onResize = null;
+  }
 };
 
 /**


### PR DESCRIPTION
... since zone.js (provided by angular2) implements a custom removeEventListener function and access the listener in any case also in case the listener is undefined:
```javascript
obj.removeEventListener = function (eventName, fn) {
    // arguments[1] is the listener function (fn) and undefined in that case
    if(arguments[1]._bound && arguments[1]._bound[eventName]) {
      var _bound = arguments[1]._bound;
      arguments[1] = _bound[eventName];
      delete _bound[eventName];
    }
    var result = removeDelegate.apply(this, arguments);
    global.zone.dequeueTask(fn);
    return result;
  };
```
Since `Core#_startAutoResize` calls `Core#_stopAutoResize` BEFORE `Core#_onResize` is set the error occurs.