### PR TITLE
fix "TypeError: Cannot read property '_bound' of undefined" in angular2 environment

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -265,7 +265,7 @@ Core.prototype.setOptions = function (options) {
           onRender: options.drawPoints
       };
     }
-    
+
     if ('hiddenDates' in this.options) {
       DateUtil.convertHiddenOptions(this.options.moment, this.body, this.options.hiddenDates);
     }
@@ -900,8 +900,10 @@ Core.prototype._stopAutoResize = function () {
   }
 
   // remove event listener on window.resize
-  util.removeEventListener(window, 'resize', this._onResize);
-  this._onResize = null;
+  if (this._onResize) {
+    util.removeEventListener(window, 'resize', this._onResize);
+    this._onResize = null;
+  }
 };
 
 /**


### PR DESCRIPTION
The PR (https://github.com/almende/vis/pull/1131) in the correct branch now :)