### PR TITLE
fix : selectEdge was fired even if user clicked on a node

### DIFF
--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -205,20 +205,18 @@ class InteractionHandler {
       selected = true;
     }
 
-    if (selectedEdgesCount - previouslySelectedEdgeCount > 0) { // edge was selected
-      this.selectionHandler._generateClickEvent('selectEdge', event, pointer);
-      selected = true;
-    }
-    else if (selectedEdgesCount - previouslySelectedEdgeCount < 0) { // edge was deselected
-      this.selectionHandler._generateClickEvent('deselectEdge', event, pointer, previousSelection);
-      selected = true;
-    }
-    else if (selectedEdgesCount === previouslySelectedEdgeCount && edgesChanges === true) {
-      this.selectionHandler._generateClickEvent('deselectEdge', event, pointer, previousSelection);
-      this.selectionHandler._generateClickEvent('selectEdge', event, pointer);
-      selected = true;
+    if (selectedEdgesCount - previouslySelectedEdgeCount < 0 || (selectedEdgesCount === previouslySelectedEdgeCount && edgesChanges === true)) { // edge was deselected
+        this.selectionHandler._generateClickEvent('deselectEdge', event, pointer, previousSelection);
+        selected = true;
     }
 
+    // Check if the user clicked on an edge
+    let selectedNode = this.selectionHandler._getSelectedNode();
+    let selectedEdge = this.selectionHandler._getSelectedEdge();
+    if (selectedNode === undefined && selectedEdge !== undefined) {
+      this.selectionHandler._generateClickEvent('selectEdge', event, pointer);
+      selected = true;
+    }
 
     if (selected === true) { // select or unselect
       this.selectionHandler._generateClickEvent('select', event, pointer);


### PR DESCRIPTION
 The selectEdge handler is now fired only if user clicked on an edge, in order to select it.
 It's not fired if the node are selected because there are connected to the selected node.