### PR TITLE
feat: call the "addEdgeStart" handler when the user begins to create …

### DIFF
--- a/docs/network/manipulation.html
+++ b/docs/network/manipulation.html
@@ -100,6 +100,7 @@ var options = {
     initiallyActive: false,
     addNode: true,
     addEdge: true,
+    addEdgeStart: undefined,
     editNode: undefined,
     editEdge: true,
     deleteNode: true,
@@ -163,6 +164,7 @@ var options = {
 }
 </pre>
             This example code will show a popup if you connect a node to itself to ask you if that was what you wanted. If you do not want the edge created, do not call the callback function or call the callback function <code>null</code> or no argument.</td></tr>
+        <tr><td>addEdgeStart</td>               <td>Function</td>               <td><code>undefined</code></td> <td>If a function is defined, this function is called when the user start to add an edge, i.e. he clicks on a node in addEdgeMode. This function gives the clicked node's id as it unique argument.</td></tr>
         <tr><td>editNode</td>                   <td>Function</td>               <td><code>undefined</code></td> <td>Editing of nodes is only possible when a handling function is supplied. If this is not the case, editing of nodes will be disabled. The function will be called when a node is selected and the 'Edit Node' button on the toolbar is pressed. This function will be called like the <code>addNode</code> function with the node's data and a callback function.</td></tr>
         <tr><td>editEdge</td>                   <td>Boolean or Function</td>    <td><code>true</code></td>      <td>If boolean, toggle the editing of edges in the GUI. When a function is supplied, it will be called when an edge is selected and the 'Edit Edge' button on the toolbar is pressed. This function will be called in the same way the <code>addEdge</code> function was called. If the callback is not performed, the edge will remain hanging where it was released. <b>To cancel, call the callback function with <code>null</code> as argument or without arguments</b>.</td></tr>
         <tr><td>deleteNode</td>                 <td>Boolean or Function</td>    <td><code>true</code></td>      <td>If boolean, toggle the deletion of nodes in the GUI. If function, it will be called when a node is selected and the 'Delete selected' button is pressed. When using a function, it will receive a callback and an object with an array of selected nodeIds and an array of selected edges Ids. These are the items that will be deleted if the callback is performed.</td></tr>

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -35,6 +35,7 @@ class ManipulationSystem {
       initiallyActive: false,
       addNode: true,
       addEdge: true,
+      addEdgeStart: undefined,
       editNode: undefined,
       editEdge: true,
       deleteNode: true,
@@ -971,6 +972,12 @@ class ManipulationSystem {
 
           this.temporaryIds.nodes.push(targetNode.id);
           this.temporaryIds.edges.push(connectionEdge.id);
+        }
+
+        // Call the specific "addEdgeStart" handler
+        // with the selected node's id in parameter.
+        if (typeof this.options.addEdgeStart === 'function') {
+          this.options.addEdgeStart(node.id);
         }
       }
       this.touchTime = new Date().valueOf();

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -131,6 +131,7 @@ let allOptions = {
     initiallyActive: { boolean },
     addNode: { boolean, 'function': 'function' },
     addEdge: { boolean, 'function': 'function' },
+    addEdgeStart: {'function': 'function'},
     editNode: { 'function': 'function' },
     editEdge: { boolean, 'function': 'function' },
     deleteNode: { boolean, 'function': 'function' },


### PR DESCRIPTION
…an edge.

If the "addEdgeStart" function is defined by user, call it when the user starts to create an edge between two nodes. The handler gives the clicked node's id as unique argument.