### PR TITLE
docs: the function's name was wrong

### DIFF
--- a/docs/data/dataview.html
+++ b/docs/data/dataview.html
@@ -307,7 +307,7 @@ var view = new vis.DataView(data, {
 
     <tr>
       <td>
-        setDataSet(data)
+        setData(data)
       </td>
       <td>none</td>
       <td>


### PR DESCRIPTION
I changed the documentation, because the real name of this function is "setData", but the documentation talked about "setDataSet".
However, as there is a "getDataSet" function, you may wan't to change the "setData" function to "setDataSet".