### PR TITLE
Fixed mis-spelling of clone.mllseconds.

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -353,7 +353,7 @@ TimeStep.snap = function(date, scale, step) {
     clone.hours(0);
     clone.minutes(0);
     clone.seconds(0);
-    clone.mlliseconds(0);
+    clone.milliseconds(0);
   }
   else if (scale == 'month') {
     if (clone.date() > 15) {


### PR DESCRIPTION
Fix a mis-spelling of clone.milliseconds as clone.mlliseconds that results in exceptions.