### PR TITLE
Introduced the Graph2d group option 'excludeFromLegend'.

### DIFF
--- a/docs/graph2d/index.html
+++ b/docs/graph2d/index.html
@@ -782,6 +782,12 @@ onRender: function(item, group, graph2d) {
             <td>This defines with which axis, left or right, the graph is coupled. <a href="../../examples/graph2d/05_bothAxis.html">Example 5</a> shows groups with different Y axis. If no groups are coupled
                 with an axis, it will not be shown.</td>
         </tr>
+        <tr>
+            <td class="greenField">excludeFromLegend</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Group option only. Excludes the the group from beeing listed in the legend.</td>
+        </tr>
     </table>
 
     <h3 id="timelineOptions">Timeline Options</h3>

--- a/lib/timeline/component/GraphGroup.js
+++ b/lib/timeline/component/GraphGroup.js
@@ -66,7 +66,7 @@ GraphGroup.prototype.setZeroPosition = function(pos) {
  */
 GraphGroup.prototype.setOptions = function(options) {
   if (options !== undefined) {
-    var fields = ['sampling','style','sort','yAxisOrientation','barChart'];
+    var fields = ['sampling','style','sort','yAxisOrientation','barChart','excludeFromLegend'];
     util.selectiveDeepExtend(fields, this.options, options);
 
     // if the group's drawPoints is a function delegate the callback to the onRender property

--- a/lib/timeline/component/Legend.js
+++ b/lib/timeline/component/Legend.js
@@ -43,10 +43,13 @@ Legend.prototype.clear = function() {
 
 Legend.prototype.addGroup = function(label, graphOptions) {
 
-  if (!this.groups.hasOwnProperty(label)) {
-    this.groups[label] = graphOptions;
+  // Include a group only if the group option 'excludeFromLegend: false' is not set.
+  if (graphOptions.options.excludeFromLegend != true) {
+    if (!this.groups.hasOwnProperty(label)) {
+      this.groups[label] = graphOptions;
+    }
+    this.amountOfGroups += 1;
   }
-  this.amountOfGroups += 1;
 };
 
 Legend.prototype.updateGroup = function(label, graphOptions) {


### PR DESCRIPTION
It should be possible to exclude a group from the legend. The group option 'excludeFromLegend: false' excludes the group.

I updated the docs as well. I added the new flag in the "Graph2d options" section. It uses the green field style. Not sure if that is right, as there is no equal option for graph2d.