### PR TITLE
make group keep orderedItems order every times instead of call group.order after every change

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -350,6 +350,7 @@ Group.prototype.add = function(item) {
     this.subgroups[item.data.subgroup].items.push(item);
   }
   this.orderSubgroups();
+  this._addToOrderedItems(item);
 
   if (this.visibleItems.indexOf(item) == -1) {
     var range = this.itemSet.body.range; // TODO: not nice accessing the range like this
@@ -391,6 +392,11 @@ Group.prototype.resetSubgroups = function() {
   }
 };
 
+Group.prototype.reorderItem = function(item,oldData){
+    this._removeFromOrderedItems(item,oldData);
+    this._addToOrderedItems(item);
+};
+
 /**
  * Remove an item from the group
  * @param {Item} item
@@ -402,6 +408,8 @@ Group.prototype.remove = function(item) {
   // remove from visible items
   var index = this.visibleItems.indexOf(item);
   if (index != -1) this.visibleItems.splice(index, 1);
+
+  this._removeFromOrderedItems(item,item.data);
 
   if(item.data.subgroup !== undefined){
     var subgroup = this.subgroups[item.data.subgroup];
@@ -426,29 +434,33 @@ Group.prototype.removeFromDataSet = function(item) {
   this.itemSet.removeItem(item.id);
 };
 
-
-/**
- * Reorder the items
- */
-Group.prototype.order = function() {
-  var array = util.toArray(this.items);
-  var startArray = [];
-  var endArray = [];
-
-  for (var i = 0; i < array.length; i++) {
-    if (array[i].data.end !== undefined) {
-      endArray.push(array[i]);
+Group.prototype._addToOrderedItems = function(item){
+    if(item.data.end !== undefined){
+        var endIndex = util.binaryIndexBy(this.orderedItems.byEnd,{data:{end:item.data.end}},function(x){return x.data.end;});
+        this.orderedItems.byEnd.splice(endIndex,0,item);
     }
-    startArray.push(array[i]);
-  }
-  this.orderedItems = {
-    byStart: startArray,
-    byEnd: endArray
-  };
-
-  stack.orderByStart(this.orderedItems.byStart);
-  stack.orderByEnd(this.orderedItems.byEnd);
+    var startIndex = util.binaryIndexBy(this.orderedItems.byStart,{data:{start:item.data.start}},function(x){return x.data.start;});
+    this.orderedItems.byStart.splice(startIndex,0,item);
 };
+
+Group.prototype._removeFromOrderedItems = function(item,itemData){
+    if(itemData.end !== undefined){
+        var endIndex = util.binaryIndexBy(this.orderedItems.byEnd,{data:{end:itemData.end}},function(x){return x.data.end;});
+        for(endIndex;endIndex < this.orderedItems.byEnd.length;endIndex++){
+            if(this.orderedItems.byEnd[endIndex] == item){
+                this.orderedItems.byEnd.splice(endIndex,1);
+            }
+        }
+    }
+    var startIndex = util.binaryIndexBy(this.orderedItems.byStart,{data:{start:itemData.start}},function(x){return x.data.start;});
+    for(startIndex;startIndex < this.orderedItems.byStart.length;startIndex++){
+        if(this.orderedItems.byStart[startIndex] == item){
+            this.orderedItems.byStart.splice(startIndex,1);
+        }
+    }
+};
+
+
 
 
 /**

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -781,9 +781,6 @@ ItemSet.prototype.setGroups = function(groups) {
   // update the group holding all ungrouped items
   this._updateUngrouped();
 
-  // update the order of all items in each group
-  this._order();
-
   this.body.emitter.emit('change', {queue: true});
 };
 
@@ -893,7 +890,6 @@ ItemSet.prototype._onUpdate = function(ids) {
     }
   }.bind(this));
 
-  this._order();
   this.stackDirty = true; // force re-stacking of all items next redraw
   this.body.emitter.emit('change', {queue: true});
 };
@@ -922,23 +918,9 @@ ItemSet.prototype._onRemove = function(ids) {
   });
 
   if (count) {
-    // update order
-    this._order();
     this.stackDirty = true; // force re-stacking of all items next redraw
     this.body.emitter.emit('change', {queue: true});
   }
-};
-
-/**
- * Update the order of item in all groups
- * @private
- */
-ItemSet.prototype._order = function() {
-  // reorder the items in all groups
-  // TODO: optimization: only reorder groups affected by the changed items
-  util.forEach(this.groups, function (group) {
-    group.order();
-  });
 };
 
 /**
@@ -986,7 +968,6 @@ ItemSet.prototype._onAddGroups = function(ids) {
         }
       }
 
-      group.order();
       group.show();
     }
     else {
@@ -1078,6 +1059,7 @@ ItemSet.prototype._updateItem = function(item, itemData) {
   var oldGroupId = item.data.group;
   var oldSubGroupId = item.data.subgroup;
 
+  var oldData = item.data;
   // update the items data (will redraw the item when displayed)
   item.setData(itemData);
 
@@ -1089,6 +1071,10 @@ ItemSet.prototype._updateItem = function(item, itemData) {
     var groupId = this._getGroupId(item.data);
     var group = this.groups[groupId];
     if (group) group.add(item);
+  }else{
+      var groupId = this._getGroupId(item.data);
+      var group = this.groups[groupId];
+      if (group) group.reorderItem(item,oldData);
   }
 };
 
@@ -1404,9 +1390,7 @@ ItemSet.prototype._moveToGroup = function(item, groupId) {
   if (group && group.groupId != item.data.group) {
     var oldGroup = item.parent;
     oldGroup.remove(item);
-    oldGroup.order();
     group.add(item);
-    group.order();
 
     item.data.group = group.groupId;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1363,6 +1363,53 @@ exports.binarySearchValue = function (orderedItems, target, field, sidePreferenc
   return -1;
 };
 
+/**
+ * This function is like `binaryIndex` except that it invokes `iteratee` for
+ * `value` and each element of `array` to compute their sort ranking. The
+ * iteratee is invoked with one argument; (value).
+ *
+ * @private
+ * @param {Array} array The sorted array to inspect.
+ * @param {*} value The value to evaluate.
+ * @param {Function} iteratee The function invoked per iteration.
+ * @param {boolean} [retHighest] Specify returning the highest qualified index.
+ * @returns {number} Returns the index at which `value` should be inserted into `array`.
+ */
+exports.binaryIndexBy = function(array, value, iteratee, retHighest) {
+    value = iteratee(value);
+
+    var low = 0,
+        high = array ? array.length : 0,
+        valIsNaN = value !== value,
+        valIsNull = value === null,
+        valIsUndef = value === undefined;
+
+    while (low < high) {
+        var mid = Math.floor((low + high) / 2),
+            computed = iteratee(array[mid]),
+            isDef = computed !== undefined,
+            isReflexive = computed === computed;
+
+        if (valIsNaN) {
+            var setLow = isReflexive || retHighest;
+        } else if (valIsNull) {
+            setLow = isReflexive && isDef && (retHighest || computed != null);
+        } else if (valIsUndef) {
+            setLow = isReflexive && (retHighest || isDef);
+        } else if (computed == null) {
+            setLow = false;
+        } else {
+            setLow = retHighest ? (computed <= value) : (computed < value);
+        }
+        if (setLow) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+    return high;
+}
+
 /*
  * Easing Functions - inspired from http://gizma.com/easing/
  * only considering the t value for the range [0, 1] => [0, 1]


### PR DESCRIPTION
as mentiod in #1207 .
Im using binaryIndex to keep the orderedItems always ordered.
It help with performance when update/remove/add items.

Need to decide if using this method or keep with the exisiting one , 
or use some kind of hybrid method that decide based of how many items changed the best option.

I pull request it so you can see changes and decide if we could improve it to some hybrid mode.