### PR TITLE
Allow groups to gather nodes around respective gravity centers.

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -111,7 +111,7 @@ function Network(container, data, options) {
   this.interactionHandler  = new InteractionHandler(this.body, this.canvas, this.selectionHandler);  // Interaction handler handles all the hammer bindings (that are bound by canvas), key
   this.view                = new View(this.body, this.canvas);              // camera handler, does animations and zooms
   this.renderer            = new CanvasRenderer(this.body, this.canvas);    // renderer, starts renderloop, has events that modules can hook into
-  this.physics             = new PhysicsEngine(this.body);                  // physics engine, does all the simulations
+  this.physics             = new PhysicsEngine(this.body, this.groups);     // physics engine, does all the simulations
   this.layoutEngine        = new LayoutEngine(this.body);                   // layout engine for inital layout and hierarchical layout
   this.clustering          = new ClusterEngine(this.body);                  // clustering api
   this.manipulation        = new ManipulationSystem(this.body, this.canvas, this.selectionHandler); // data manipulation system

--- a/lib/network/modules/PhysicsEngine.js
+++ b/lib/network/modules/PhysicsEngine.js
@@ -11,8 +11,9 @@ var util = require('../../util');
 
 
 class PhysicsEngine {
-  constructor(body) {
+  constructor(body, groups) {
     this.body = body;
+    this.groups = groups;
     this.physicsBody = {physicsNodeIndices:[], physicsEdgeIndices:[], forces: {}, velocities: {}};
 
     this.physicsEnabled = true;
@@ -136,25 +137,25 @@ class PhysicsEngine {
       options = this.options.forceAtlas2Based;
       this.nodesSolver = new ForceAtlas2BasedRepulsionSolver(this.body, this.physicsBody, options);
       this.edgesSolver = new SpringSolver(this.body, this.physicsBody, options);
-      this.gravitySolver = new ForceAtlas2BasedCentralGravitySolver(this.body, this.physicsBody, options);
+      this.gravitySolver = new ForceAtlas2BasedCentralGravitySolver(this.body, this.physicsBody, options, this.groups);
     }
     else if (this.options.solver === 'repulsion') {
       options = this.options.repulsion;
       this.nodesSolver = new Repulsion(this.body, this.physicsBody, options);
       this.edgesSolver = new SpringSolver(this.body, this.physicsBody, options);
-      this.gravitySolver = new CentralGravitySolver(this.body, this.physicsBody, options);
+      this.gravitySolver = new CentralGravitySolver(this.body, this.physicsBody, options, this.groups);
     }
     else if (this.options.solver === 'hierarchicalRepulsion') {
       options = this.options.hierarchicalRepulsion;
       this.nodesSolver = new HierarchicalRepulsion(this.body, this.physicsBody, options);
       this.edgesSolver = new HierarchicalSpringSolver(this.body, this.physicsBody, options);
-      this.gravitySolver = new CentralGravitySolver(this.body, this.physicsBody, options);
+      this.gravitySolver = new CentralGravitySolver(this.body, this.physicsBody, options, this.groups);
     }
     else { // barnesHut
       options = this.options.barnesHut;
       this.nodesSolver = new BarnesHutSolver(this.body, this.physicsBody, options);
       this.edgesSolver = new SpringSolver(this.body, this.physicsBody, options);
-      this.gravitySolver = new CentralGravitySolver(this.body, this.physicsBody, options);
+      this.gravitySolver = new CentralGravitySolver(this.body, this.physicsBody, options, this.groups);
     }
 
     this.modelOptions = options;
@@ -518,7 +519,7 @@ class PhysicsEngine {
       this._freezeNodes();
     }
     this.stabilizationIterations = 0;
-  
+
     setTimeout(() => this._stabilizationBatch(),0);
   }
 
@@ -529,7 +530,7 @@ class PhysicsEngine {
       this.stabilizationIterations++;
       count++;
     }
-  
+
     if (this.stabilized === false && this.stabilizationIterations < this.targetIterations) {
       this.body.emitter.emit('stabilizationProgress', {iterations: this.stabilizationIterations, total: this.targetIterations});
       setTimeout(this._stabilizationBatch.bind(this),0);
@@ -548,7 +549,7 @@ class PhysicsEngine {
     if (this.options.stabilization.onlyDynamicEdges === true) {
       this._restoreFrozenNodes();
     }
-    
+
     this.body.emitter.emit('stabilizationIterationsDone');
     this.body.emitter.emit('_requestRedraw');
 
@@ -561,7 +562,7 @@ class PhysicsEngine {
 
     this.ready = true;
   }
-  
+
 }
 
 export default PhysicsEngine;

--- a/lib/network/modules/components/physics/CentralGravitySolver.js
+++ b/lib/network/modules/components/physics/CentralGravitySolver.js
@@ -1,12 +1,30 @@
+'use strict'
+
+var util = require('../../../../util');
+
 class CentralGravitySolver {
-  constructor(body, physicsBody, options) {
+  constructor(body, physicsBody, options, groups) {
     this.body = body;
     this.physicsBody = physicsBody;
+    this.groups = groups;
+    this.gravityGroups = {};
     this.setOptions(options);
   }
 
   setOptions(options) {
     this.options = options;
+
+    // Iterates through the groups and looks for the ones defining 'groupCentralGravity'
+    if (this.groups != null) {
+      self = this;
+      util.forEach(this.groups.groups, function(groupDefinition, groupName) {
+        let gravityStrength = parseInt(groupDefinition.groupGravityStrength);
+        if (gravityStrength > 0) {
+          self.gravityGroups[groupName] = {name: groupName, strength: gravityStrength};
+        }
+      });
+    }
+    this._positionGroupCentersInitially(this.gravityGroups);
   }
 
   solve() {
@@ -23,6 +41,7 @@ class CentralGravitySolver {
       distance = Math.sqrt(dx * dx + dy * dy);
 
       this._calculateForces(distance, dx, dy, forces, node);
+      this._calculateGroupForces(this.gravityGroups[node.options.group], forces, node);
     }
   }
 
@@ -35,6 +54,43 @@ class CentralGravitySolver {
     forces[node.id].x = dx * gravityForce;
     forces[node.id].y = dy * gravityForce;
   }
+
+  /**
+   * Calculate the forces the group center puts on the nodes based on the distance.
+   * @private
+   */
+  _calculateGroupForces(group, forces, node) {
+    if (group != null) {
+      let dx = group.centerX - node.x;
+      let dy = group.centerY - node.y;
+      let distance = Math.sqrt(dx * dx + dy * dy);
+      let gravityForce = (distance === 0) ? 0 : (group.strength / distance);
+      forces[node.id].x += dx * gravityForce;
+      forces[node.id].y += dy * gravityForce;
+    }
+  }
+
+  /**
+   * Position the gravity groups centers in a circle around the central gravity.
+   * @private
+   */
+  _positionGroupCentersInitially(groups) {
+    var noOfGroups = Object.keys(groups).length;
+    var radius = 30 * noOfGroups + 150;
+    var angleStep = 2 * Math.PI / noOfGroups;
+    var i = 0;
+    util.forEach(groups, function(group, groupName) {
+      let angle = (Math.PI / 2) + angleStep * i;
+      if (group.centerX === undefined) {
+        group.centerX = radius * Math.cos(angle);
+      }
+      if (group.centerY === undefined) {
+        group.centerY = radius * Math.sin(angle);
+      }
+      i += 1;
+    });
+  }
+
 }
 
 


### PR DESCRIPTION
I use the option 'groupGravityStrength' (which is an Int) to set if a group should gather its nodes around it.
```javascript
var network = new vis.Network(container, data, {
  ....
  groups: {
    people: {
      color: 'blue',
      groupGravityStrength: 2,
    },
    companies: {
      color: 'red',
      groupGravityStrength: 2.5,
    }
  },
  ...
});
```