### PR TITLE
Added possibility to change (or hide) the title of a CustomTime element.

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1197,6 +1197,15 @@ document.getElementById('myTimeline').onclick = function (event) {
     </tr>
 
     <tr>
+      <td>setCustomTimeTitle(title [, id])</td>
+      <td>none</td>
+      <td>Adjust the title attribute of a custom time bar.
+        Parameter <code>title</code> is the string to be set as title. Use empty string to hide the title completely.
+        Parameter <code>id</code> is the id of the custom time bar, and is <code>undefined</code> by default.
+      </td>
+    </tr>
+
+    <tr>
       <td>setData({<br>&nbsp;&nbsp;groups: groups,<br>&nbsp;&nbsp;items: items<br>})</td>
       <td>none</td>
       <td>Set both groups and items at once. Both properties are optional. This is a convenience method for individually calling both <code>setItems(items)</code> and <code>setGroups(groups)</code>.

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -410,6 +410,24 @@ Core.prototype.getCustomTime = function(id) {
 };
 
 /**
+ * Set a custom title for the custom time bar.
+ * @param {String} [title] Custom title
+ * @param {number} [id=undefined]    Id of the custom time bar.
+ */
+Core.prototype.setCustomTimeTitle = function(title, id) {
+  var customTimes = this.customTimes.filter(function (component) {
+    return component.options.id === id;
+  });
+
+  if (customTimes.length === 0) {
+    throw new Error('No custom time bar found with id ' + JSON.stringify(id))
+  }
+  if (customTimes.length > 0) {
+    return customTimes[0].setCustomTitle(title);
+  }
+};
+
+/**
  * Retrieve meta information from an event.
  * Should be overridden by classes extending Core
  * @param {Event} event

--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -23,16 +23,17 @@ function CustomTime (body, options) {
     moment: moment,
     locales: locales,
     locale: 'en',
-    id: undefined
+    id: undefined,
+    title: undefined
   };
   this.options = util.extend({}, this.defaultOptions);
 
   if (options && options.time) {
     this.customTime = options.time;
   } else {
-    this.customTime = new Date();  
+    this.customTime = new Date();
   }
-  
+
   this.eventParams = {}; // stores state parameters while dragging the bar
 
   this.setOptions(options);
@@ -123,8 +124,12 @@ CustomTime.prototype.redraw = function () {
     locale = this.options.locales['en']; // fall back on english when not available
   }
 
-  var title = locale.time + ': ' + this.options.moment(this.customTime).format('dddd, MMMM Do YYYY, H:mm:ss');
-  title = title.charAt(0).toUpperCase() + title.substring(1);
+  var title = this.options.title;
+  // To hide the title completely use empty string ''.
+  if (title === undefined) {
+    title = locale.time + ': ' + this.options.moment(this.customTime).format('dddd, MMMM Do YYYY, H:mm:ss');
+    title = title.charAt(0).toUpperCase() + title.substring(1);
+  }
 
   this.bar.style.left = x + 'px';
   this.bar.title = title;
@@ -157,6 +162,14 @@ CustomTime.prototype.setCustomTime = function(time) {
  */
 CustomTime.prototype.getCustomTime = function() {
   return new Date(this.customTime.valueOf());
+};
+
+/**
+  * Set custom title.
+  * @param {Date | number | string} title
+  */
+CustomTime.prototype.setCustomTitle = function(title) {
+  this.options.title = title;
 };
 
 /**


### PR DESCRIPTION
Hi all,

I propose to add the possibility to change the title (visible when hovering) of a custom time bar.
Now it shows the current date of the bar by default (Time: 'dddd, MMMM Do YYYY, H:mm:ss'), but there is no option to change this behavior. We could also integrate this feature in the 'current' time bar.
(See issue 1288 - https://github.com/almende/vis/issues/1288)
@josdejong proposed to do this pull request in the issue.

Kind regards,
Arno
