### PR TITLE
Bad call to getHiddenDurationBetween

### DIFF
--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -551,7 +551,7 @@ Range.prototype._onPinch = function (event) {
   var scale = 1 / (event.scale + this.scaleOffset);
   var centerDate = this._pointerToDate(this.props.touch.center);
 
-  var hiddenDuration = DateUtil.getHiddenDurationBetween(this.options.moment, this.body.hiddenDates, this.start, this.end);
+  var hiddenDuration = DateUtil.getHiddenDurationBetween(this.body.hiddenDates, this.start, this.end);
   var hiddenDurationBefore = DateUtil.getHiddenDurationBefore(this.options.moment, this.body.hiddenDates, this, centerDate);
   var hiddenDurationAfter = hiddenDuration - hiddenDurationBefore;
 


### PR DESCRIPTION
Bug in Range.js call to DateUtil.getHiddenDurationBetween. It was passing in this.options.moment which is not expected by getHiddenDurationBetween.