### PR TITLE
Move babelify to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "watch-dev": "gulp watch --bundle"
   },
   "dependencies": {
+    "babelify": "^6.0.2",
     "emitter-component": "^1.1.1",
     "hammerjs": "^2.0.4",
     "keycharm": "^0.2.0",
@@ -39,7 +40,6 @@
   "devDependencies": {
     "babel": "^5.1.11",
     "babel-loader": "^5.0.0",
-    "babelify": "^6.0.2",
     "clean-css": "^3.2.1",
     "gulp": "^3.8.11",
     "gulp-concat": "^2.5.2",


### PR DESCRIPTION
As devDependencies are loaded only for top level npm modules, and transforms are applied along the dependency chain, babelify has to be provided.

This is to scope babelify at vis level – and to avoid parent apps to install babelify as well.

Cf. https://github.com/substack/node-browserify#browserifytransform

> Make sure to add transforms to your package.json dependencies field.