### PR TITLE
Ability to select edges / nodes without unselecting all

### DIFF
--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -922,10 +922,10 @@ function releaseFunction (clusterPosition, containedNodesPositions) {
             </tr>
             <tr class="hidden" parent="selectNodes">
                 <td class="midMethods">Returns: none</td>
-                <td>Selects the nodes corresponding to the id's in the input array. If highlightEdges is true or
-                    undefined,
-                    the neighbouring edges will also be selected. If unselectAll is true or undefined, this method unselects all other objects 
-                    before selecting
+                <td>Selects the nodes corresponding to the id's in the input array. If highlightEdges is true,
+                    the neighbouring edges will also be selected. If highlightEdges is undefined, the value of <code>selectConnectedEdges</code>
+                    is used (defaults to true).
+                    If unselectAll is true or undefined, this method unselects all other objects before selecting
                     its own objects. <i>Does not fire events</i>.
                 </td>
             </tr>

--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -916,27 +916,29 @@ function releaseFunction (clusterPosition, containedNodesPositions) {
             <tr class="collapsible toggle" onclick="toggleTable('methodTable','selectNodes', this);">
                 <td colspan="2"><span parent="selectNodes" class="right-caret" id="method_selectNodes"></span> selectNodes(<code><i>Array with
                     nodeIds</i></code>,<code><i>[Boolean
-                    highlightEdges]</i></code>)
+                    highlightEdges]</i></code>,<code><i>[Boolean
+                    unselectAll]</i></code>)
                 </td>
             </tr>
             <tr class="hidden" parent="selectNodes">
                 <td class="midMethods">Returns: none</td>
                 <td>Selects the nodes corresponding to the id's in the input array. If highlightEdges is true or
                     undefined,
-                    the neighbouring edges will also be selected. This method unselects all other objects before
-                    selecting
+                    the neighbouring edges will also be selected. If unselectAll is true or undefined, this method unselects all other objects 
+                    before selecting
                     its own objects. <i>Does not fire events</i>.
                 </td>
             </tr>
             <tr class="collapsible toggle" onclick="toggleTable('methodTable','selectEdges', this);">
                 <td colspan="2"><span parent="selectEdges" class="right-caret" id="method_selectEdges"></span> selectEdges(<code><i>Array with
-                    edgeIds</i></code>)
+                    edgeIds</i></code>,<code><i>[Boolean
+                    unselectAll]</i></code>)
                 </td>
             </tr>
             <tr class="hidden" parent="selectEdges">
                 <td class="midMethods">Returns: none</td>
-                <td>Selects the edges corresponding to the id's in the input array. This method unselects all other
-                    objects
+                <td>Selects the edges corresponding to the id's in the input array. If unselectAll is true or undefined, this method unselects 
+                    all other objects
                     before selecting its own objects. <i>Does not fire events</i>.
                 </td>
             </tr>

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -300,7 +300,7 @@ class SelectionHandler {
         this.selectionObj.edges[edgeId].unselect();
       }
     }
-  
+
     this.selectionObj = {nodes:{},edges:{}};
   }
 
@@ -607,19 +607,22 @@ class SelectionHandler {
    * @param {Number[] | String[]} selection     An array with the ids of the
    *                                            selected nodes.
    * @param {boolean} [highlightEdges]
+   * @param {boolean} [unselectAll]
    */
-  selectNodes(selection, highlightEdges = true) {
+  selectNodes(selection, highlightEdges = true, unselectAll = true) {
     let i, id;
-  
+
     if (!selection || (selection.length === undefined))
       throw 'Selection must be an array with ids';
-  
+
     // first unselect any selected node
-    this.unselectAll();
-  
+    if (unselectAll) {
+      this.unselectAll();
+    }
+
     for (i = 0; i < selection.length; i++) {
       id = selection[i];
-  
+
       let node = this.body.nodes[id];
       if (!node) {
         throw new RangeError('Node with id "' + id + '" not found');
@@ -634,19 +637,22 @@ class SelectionHandler {
    * select zero or more edges
    * @param {Number[] | String[]} selection     An array with the ids of the
    *                                            selected nodes.
+   * @param {boolean} [unselectAll]
    */
-  selectEdges(selection) {
+  selectEdges(selection, unselectAll = true) {
     let i, id;
-  
+
     if (!selection || (selection.length === undefined))
       throw 'Selection must be an array with ids';
-  
+
     // first unselect any selected objects
-    this.unselectAll();
-  
+    if (unselectAll) {
+      this.unselectAll();
+    }
+
     for (i = 0; i < selection.length; i++) {
       id = selection[i];
-  
+
       let edge = this.body.edges[id];
       if (!edge) {
         throw new RangeError('Edge with id "' + id + '" not found');

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -609,7 +609,7 @@ class SelectionHandler {
    * @param {boolean} highlightEdges
    * @param {boolean} [unselectAll]
    */
-  selectNodes(selection, highlightEdges, unselectAll = true) {
+  selectNodes(selection, highlightEdges = this.options.selectConnectedEdges, unselectAll = true) {
     let i, id;
 
     if (!selection || (selection.length === undefined))
@@ -618,10 +618,6 @@ class SelectionHandler {
     // first unselect any selected node
     if (unselectAll) {
       this.unselectAll();
-    }
-
-    if (undefined === highlightEdges) {
-      highlightEdges = this.options.selectConnectedEdges;
     }
 
     for (i = 0; i < selection.length; i++) {

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -606,10 +606,10 @@ class SelectionHandler {
    * select zero or more nodes with the option to highlight edges
    * @param {Number[] | String[]} selection     An array with the ids of the
    *                                            selected nodes.
-   * @param {boolean} [highlightEdges]
+   * @param {boolean} highlightEdges
    * @param {boolean} [unselectAll]
    */
-  selectNodes(selection, highlightEdges = true, unselectAll = true) {
+  selectNodes(selection, highlightEdges, unselectAll = true) {
     let i, id;
 
     if (!selection || (selection.length === undefined))
@@ -618,6 +618,10 @@ class SelectionHandler {
     // first unselect any selected node
     if (unselectAll) {
       this.unselectAll();
+    }
+
+    if (undefined === highlightEdges) {
+      highlightEdges = this.options.selectConnectedEdges;
     }
 
     for (i = 0; i < selection.length; i++) {


### PR DESCRIPTION
Hello,

I'm using your wonderfull library (the network / dataset parts) in a project, and was needing the ability to memorize a selection (both nodes and edges) to be able to reuse it later.

I propose in this pull request to add an optional parameter in `selectNodes` / `selectEdges` methods so that the selection is not lost if that parameter is set to false (`unselectAll`).

Hope this can help someone too. If something is wrong I'll be glad to make it better.