### PR TITLE
Fix the example link in timeline docs

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -115,7 +115,7 @@
   <h2 id="Example">Example</h2>
   <p>
     The following code shows how to create a Timeline and provide it with data.
-    More examples can be found in the <a href="../examples">examples</a> directory.
+    More examples can be found in the <a href="../../timeline_examples.html">timeline examples</a> page.
   </p>
 
 <pre class="prettyprint lang-html">&lt;!DOCTYPE HTML&gt;


### PR DESCRIPTION
Ping @AlexDM0

This has the same fix as #1413. Now with the timeline examples instead of time examples.  :)