### PR TITLE
Expose publicly setSelection method

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -466,6 +466,7 @@ Network.prototype.startSimulation     = function() {return this.physics.startSim
 Network.prototype.stopSimulation      = function() {return this.physics.stopSimulation.apply(this.physics,arguments);};
 Network.prototype.stabilize           = function() {return this.physics.stabilize.apply(this.physics,arguments);};
 Network.prototype.getSelection        = function() {return this.selectionHandler.getSelection.apply(this.selectionHandler,arguments);};
+Network.prototype.setSelection        = function() {return this.selectionHandler.setSelection.apply(this.selectionHandler,arguments);};
 Network.prototype.getSelectedNodes    = function() {return this.selectionHandler.getSelectedNodes.apply(this.selectionHandler,arguments);};
 Network.prototype.getSelectedEdges    = function() {return this.selectionHandler.getSelectedEdges.apply(this.selectionHandler,arguments);};
 Network.prototype.getNodeAt           = function() {


### PR DESCRIPTION
Hello,
I my previous PR #1421 I forgot to expose publicly the method in the Network object.

Will you release a bugfix anytime soon ?

Kind regards.
