### PR TITLE
Use SVGElement.getBoundingClientRect() instead of .offstHeight

### DIFF
--- a/lib/timeline/component/DataAxis.js
+++ b/lib/timeline/component/DataAxis.js
@@ -59,7 +59,7 @@ function DataAxis (body, options, svg, linegraphOptions) {
   this.setOptions(options);
   this.width = Number(('' + this.options.width).replace("px",""));
   this.minWidth = this.width;
-  this.height = this.linegraphSVG.offsetHeight;
+  this.height = this.linegraphSVG.getBoundingClientRect().height;
   this.hidden = false;
 
   this.stepPixels = 25;


### PR DESCRIPTION
Fixes DOM API deprecation warning in Chrome.
Please see: https://www.chromestatus.com/features/5724912467574784

This is an improved version of PR #1501 that only actually involves an SVGElement.