### PR TITLE
Fix "sources" relative location in sourcemap file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,7 +148,7 @@ gulp.task('minify', ['bundle-js'], function (cb) {
   //       any issues when concatenating the file downstream (the file ends
   //       with a comment).
   fs.writeFileSync(DIST + '/' + VIS_MIN_JS, result.code + '\n');
-  fs.writeFileSync(DIST + '/' + VIS_MAP, result.map);
+  fs.writeFileSync(DIST + '/' + VIS_MAP, result.map.replace(/"\.\/dist\//g, '"'));
 
   cb();
 });


### PR DESCRIPTION
Including `vis.min.js` as dependency in an [ember-cli](http://ember-cli.com/) app crashes its build, as `sources` key in `vis.map` includes `dist` relative path, it needs to be in the same path. 

UglifyJS2 supports `prefix` option for removing relative paths when using it as a command line tool, doesn't support it in the API though.