### PR TITLE
Point main field in package.json to non-minified script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "network",
     "browser"
   ],
-  "main": "./dist/vis.min.js",
+  "main": "./dist/vis.js",
   "scripts": {
     "test": "mocha",
     "build": "gulp",


### PR DESCRIPTION
I think a bad practice to use minified files as a “main” script and it makes life of Webpack users more difficult because we have to use hacks like this:

![](https://s3.amazonaws.com/f.cl.ly/items/1i0k1d1h0r0H0A1D2y23/Image%202016-01-15%20at%209.21.54%20AM.png?v=83d3ccd0)