### PR TITLE
Timeline options object getting reset to {}

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -39,6 +39,10 @@ function Timeline (container, items, groups, options) {
   }
 
   var me = this;
+
+  // Create the DOM, props, and emitter
+  this._create(container);
+
   this.defaultOptions = {
     start: null,
     end:   null,
@@ -59,9 +63,6 @@ function Timeline (container, items, groups, options) {
     minHeight: null
   };
   this.options = util.deepExtend({}, this.defaultOptions);
-
-  // Create the DOM, props, and emitter
-  this._create(container);
 
   // all components listed here will be repainted automatically
   this.components = [];


### PR DESCRIPTION
This fixes a bug in ```Timeline.js``` where ```this.options``` gets reset back to an empty object ```{}```.

Bug was introduced in this commit: https://github.com/almende/vis/commit/8f4e9e9c8f5ff2c2c56cd0df8ee1395aa49f379b

This bug can be reproduced in the following pages:

1. http://visjs.org/examples/timeline/groups/groups.html
2. http://visjs.org/examples/timeline/groups/groupsOrdering.html
3. http://visjs.org/examples/timeline/groups/groupsEditable.html

The issue is the wrong ordering of method calls.

In https://github.com/almende/vis/blob/master/lib/timeline/Timeline.js#L61

we set the default options then the call to ```this._create``` resets the ```this.options``` back to ```{}```
