### PR TITLE
Use Axis Labels for Tooltip

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -2237,9 +2237,9 @@ Graph3d.prototype._showTooltip = function (dataPoint) {
   }
   else {
     content.innerHTML = '<table>' +
-      '<tr><td>x:</td><td>' + dataPoint.point.x + '</td></tr>' +
-      '<tr><td>y:</td><td>' + dataPoint.point.y + '</td></tr>' +
-      '<tr><td>z:</td><td>' + dataPoint.point.z + '</td></tr>' +
+      '<tr><td>'+this.xLabel+':</td><td>' + dataPoint.point.x + '</td></tr>' +
+      '<tr><td>'+this.yLabel+':</td><td>' + dataPoint.point.y + '</td></tr>' +
+      '<tr><td>'+this.zLabel+':</td><td>' + dataPoint.point.z + '</td></tr>' +
       '</table>';
   }
 


### PR DESCRIPTION
Simple change to show the axis labels on the tooltip instead of x,y,z. Even though the tooltip html is modifiable, seems like this should be the default.