### PR TITLE
Use parseFloat instead of Number.parseFloat

### DIFF
--- a/lib/timeline/component/DataAxis.js
+++ b/lib/timeline/component/DataAxis.js
@@ -29,12 +29,12 @@ function DataAxis (body, options, svg, linegraphOptions) {
     alignZeros: true,
     left:{
       range: {min:undefined,max:undefined},
-      format: function (value) {return ''+Number.parseFloat(value.toPrecision(3));},
+      format: function (value) {return ''+parseFloat(value.toPrecision(3));},
       title: {text:undefined,style:undefined}
     },
     right:{
       range: {min:undefined,max:undefined},
-      format: function (value) {return ''+Number.parseFloat(value.toPrecision(3));},
+      format: function (value) {return ''+parseFloat(value.toPrecision(3));},
       title: {text:undefined,style:undefined}
     }
   };


### PR DESCRIPTION
Internet Explorer does not support the ES6 Number.parseFloat (see http://caniuse.com/#feat=es6-number). Instead, substitute the regular parseFloat method.