### PR TITLE
Allow partial edge editing without reconnecting the nodes

### DIFF
--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -128,6 +128,7 @@ var options = {
       opacity:1.0
     },
     dashes: false,
+    editEdgeNodes: undefined,
     font: {
       color: '#343434',
       size: 14, // px
@@ -325,6 +326,12 @@ network.setOptions(options);
                 repeated until the distance is filled.
                 <i>When using dashed lines in IE versions older than 11, the line will be drawn straight, not smooth</i>.
             </td>
+        </tr>
+        <tr>
+            <td>editEdgeNodes</td>
+            <td>Boolean</td>
+            <td><code>undefined</code></td>
+            <td>When true, the edge will offer the option to reconnect to different nodes in edit-mode.</td>
         </tr>
         <tr class='toggle collapsible' onclick="toggleTable('optionTable','font', this);">
             <td><span parent="font" class="right-caret"></span> font</td>

--- a/docs/network/manipulation.html
+++ b/docs/network/manipulation.html
@@ -102,6 +102,7 @@ var options = {
     addEdge: true,
     editNode: undefined,
     editEdge: true,
+    editEdgeNodes: true,
     deleteNode: true,
     deleteEdge: true,
     controlNodeStyle:{

--- a/examples/network/other/manipulation.html
+++ b/examples/network/other/manipulation.html
@@ -86,8 +86,8 @@
           addNode: function (data, callback) {
             // filling in the popup DOM elements
             document.getElementById('operation').innerHTML = "Add Node";
-            document.getElementById('node-id').value = data.id;
-            document.getElementById('node-label').value = data.label;
+            document.getElementById('obj-id').value = data.id;
+            document.getElementById('obj-label').value = data.label;
             document.getElementById('saveButton').onclick = saveData.bind(this, data, callback);
             document.getElementById('cancelButton').onclick = clearPopUp.bind();
             document.getElementById('network-popUp').style.display = 'block';
@@ -95,8 +95,17 @@
           editNode: function (data, callback) {
             // filling in the popup DOM elements
             document.getElementById('operation').innerHTML = "Edit Node";
-            document.getElementById('node-id').value = data.id;
-            document.getElementById('node-label').value = data.label;
+            document.getElementById('obj-id').value = data.id;
+            document.getElementById('obj-label').value = data.label;
+            document.getElementById('saveButton').onclick = saveData.bind(this, data, callback);
+            document.getElementById('cancelButton').onclick = cancelEdit.bind(this,callback);
+            document.getElementById('network-popUp').style.display = 'block';
+          },
+          //editEdgeNodes: false, /* To suppress reconnecting the edge in editMode */
+          editEdge: function (data, callback) {
+            document.getElementById('operation').innerHTML = "Edit Edge";
+            document.getElementById('obj-id').value = data.id;
+            document.getElementById('obj-label').value = data.label;
             document.getElementById('saveButton').onclick = saveData.bind(this, data, callback);
             document.getElementById('cancelButton').onclick = cancelEdit.bind(this,callback);
             document.getElementById('network-popUp').style.display = 'block';
@@ -129,8 +138,8 @@
     }
 
     function saveData(data,callback) {
-      data.id = document.getElementById('node-id').value;
-      data.label = document.getElementById('node-label').value;
+      data.id = document.getElementById('obj-id').value;
+      data.label = document.getElementById('obj-label').value;
       clearPopUp();
       callback(data);
     }
@@ -156,10 +165,10 @@
 <div id="network-popUp">
   <span id="operation">node</span> <br>
   <table style="margin:auto;"><tr>
-    <td>id</td><td><input id="node-id" value="new value" /></td>
+    <td>id</td><td><input id="obj-id" value="new value" /></td>
   </tr>
     <tr>
-      <td>label</td><td><input id="node-label" value="new value" /></td>
+      <td>label</td><td><input id="obj-label" value="new value" /></td>
     </tr></table>
   <input type="button" value="save" id="saveButton" />
   <input type="button" value="cancel" id="cancelButton" />

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -37,6 +37,7 @@ class ManipulationSystem {
       addEdge: true,
       editNode: undefined,
       editEdge: true,
+      editEdgeNodes: true,
       deleteNode: true,
       deleteEdge: true,
       controlNodeStyle:{
@@ -354,41 +355,48 @@ class ManipulationSystem {
     this.edgeBeingEditedId = this.selectionHandler.getSelectedEdges()[0];
     if (this.edgeBeingEditedId !== undefined) {
       let edge = this.body.edges[this.edgeBeingEditedId];
+      let allowEditEdgeNodes = edge.editEdgeNodes ||
+                               (edge.editEdgeNodes == null && this.options.editEdgeNodes);
 
-      // create control nodes
-      let controlNodeFrom = this._getNewTargetNode(edge.from.x, edge.from.y);
-      let controlNodeTo = this._getNewTargetNode(edge.to.x, edge.to.y);
+      if (allowEditEdgeNodes) {
+        // create control nodes
+        let controlNodeFrom = this._getNewTargetNode(edge.from.x, edge.from.y);
+        let controlNodeTo = this._getNewTargetNode(edge.to.x, edge.to.y);
 
-      this.temporaryIds.nodes.push(controlNodeFrom.id);
-      this.temporaryIds.nodes.push(controlNodeTo.id);
+        this.temporaryIds.nodes.push(controlNodeFrom.id);
+        this.temporaryIds.nodes.push(controlNodeTo.id);
 
-      this.body.nodes[controlNodeFrom.id] = controlNodeFrom;
-      this.body.nodeIndices.push(controlNodeFrom.id);
-      this.body.nodes[controlNodeTo.id] = controlNodeTo;
-      this.body.nodeIndices.push(controlNodeTo.id);
+        this.body.nodes[controlNodeFrom.id] = controlNodeFrom;
+        this.body.nodeIndices.push(controlNodeFrom.id);
+        this.body.nodes[controlNodeTo.id] = controlNodeTo;
+        this.body.nodeIndices.push(controlNodeTo.id);
 
-      // temporarily overload UI functions, cleaned up automatically because of _temporaryBindUI
-      this._temporaryBindUI('onTouch', this._controlNodeTouch.bind(this));    // used to get the position
-      this._temporaryBindUI('onTap', () => {});                             // disabled
-      this._temporaryBindUI('onHold', () => {});                             // disabled
-      this._temporaryBindUI('onDragStart', this._controlNodeDragStart.bind(this));// used to select control node
-      this._temporaryBindUI('onDrag', this._controlNodeDrag.bind(this));     // used to drag control node
-      this._temporaryBindUI('onDragEnd', this._controlNodeDragEnd.bind(this));  // used to connect or revert control nodes
-      this._temporaryBindUI('onMouseMove', () => {});                             // disabled
+        // temporarily overload UI functions, cleaned up automatically because of _temporaryBindUI
+        this._temporaryBindUI('onTouch', this._controlNodeTouch.bind(this));    // used to get the position
+        this._temporaryBindUI('onTap', () => {});                             // disabled
+        this._temporaryBindUI('onHold', () => {});                             // disabled
+        this._temporaryBindUI('onDragStart', this._controlNodeDragStart.bind(this));// used to select control node
+        this._temporaryBindUI('onDrag', this._controlNodeDrag.bind(this));     // used to drag control node
+        this._temporaryBindUI('onDragEnd', this._controlNodeDragEnd.bind(this));  // used to connect or revert control nodes
+        this._temporaryBindUI('onMouseMove', () => {});                             // disabled
 
-      // create function to position control nodes correctly on movement
-      // automatically cleaned up because we use the temporary bind
-      this._temporaryBindEvent('beforeDrawing', (ctx) => {
-        let positions = edge.edgeType.findBorderPositions(ctx);
-        if (controlNodeFrom.selected === false) {
-          controlNodeFrom.x = positions.from.x;
-          controlNodeFrom.y = positions.from.y;
-        }
-        if (controlNodeTo.selected === false) {
-          controlNodeTo.x = positions.to.x;
-          controlNodeTo.y = positions.to.y;
-        }
-      });
+        // create function to position control nodes correctly on movement
+        // automatically cleaned up because we use the temporary bind
+        this._temporaryBindEvent('beforeDrawing', (ctx) => {
+          let positions = edge.edgeType.findBorderPositions(ctx);
+          if (controlNodeFrom.selected === false) {
+            controlNodeFrom.x = positions.from.x;
+            controlNodeFrom.y = positions.from.y;
+          }
+          if (controlNodeTo.selected === false) {
+            controlNodeTo.x = positions.to.x;
+            controlNodeTo.y = positions.to.y;
+          }
+        });
+      }
+      else {
+        this._performEditEdge(edge.from.id, edge.to.id);
+      }
 
       this.body.emitter.emit('_redraw');
     }

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -49,6 +49,8 @@ class Edge {
 
     this.connected = false;
 
+    this.editEdgeNodes = undefined;
+
     this.labelModule = new Label(this.body, this.options);
 
     this.setOptions(options);
@@ -73,6 +75,7 @@ class Edge {
     if (options.to !== undefined)   {this.toId = options.to;}
     if (options.title !== undefined) {this.title = options.title;}
     if (options.value !== undefined)  {options.value = parseFloat(options.value);}
+    if (options.editEdgeNodes !== undefined) {this.editEdgeNodes = options.editEdgeNodes;}
 
 
     // update label Module
@@ -96,6 +99,7 @@ class Edge {
   static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}) {
     var fields = [
       'arrowStrikethrough',
+      'editEdgeNodes',
       'id',
       'from',
       'hidden',

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -39,6 +39,7 @@ let allOptions = {
       __type__: { object, string }
     },
     dashes: { boolean, array },
+    editEdgeNodes: { boolean },
     font: {
       color: { string },
       size: { number }, // px
@@ -141,6 +142,7 @@ let allOptions = {
     addEdge: { boolean, 'function': 'function' },
     editNode: { 'function': 'function' },
     editEdge: { boolean, 'function': 'function' },
+    editEdgeNodes: { boolean },
     deleteNode: { boolean, 'function': 'function' },
     deleteEdge: { boolean, 'function': 'function' },
     controlNodeStyle: 'get from nodes, will be overwritten below',


### PR DESCRIPTION
Add the boolean option `editEdgeNodes` to the `Edge` and the
`ManipulationSystem`, in such a way we can just edit link properties
in editMode without necessarily touching the nodes it connects.

Given that the property is both global at the manipulation level
and local per-edge, we should have enough flexibility for
different use-cases.

The behavior fallbacks to the current one in case nothing is set.