### PR TITLE
Fix for BoxItem line left position

### DIFF
--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -186,7 +186,7 @@ BoxItem.prototype.repositionX = function() {
   this.dom.box.style.left = this.left + 'px';
 
   // reposition line
-  this.dom.line.style.left = (start - this.props.line.width / 2) + 'px';
+  this.dom.line.style.left = this.left + 'px';
 
   // reposition dot
   this.dom.dot.style.left = (start - this.props.dot.width / 2) + 'px';


### PR DESCRIPTION
Sometimes the line at left of the BoxItem gets misaligned, see the screenshot. didn't find any issue related to that, please relate it if it exists.

![screen shot 2016-02-26 at 10 13 43 am](https://cloud.githubusercontent.com/assets/4020905/13353231/b11d14ec-dc71-11e5-8a69-25f4b006d694.jpg)
