### PR TITLE
Allow bold font in network node labels

### DIFF
--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -335,6 +335,12 @@ network.setOptions(options);
             </td>
         </tr>
         <tr parent="font" class="hidden">
+            <td class="indent">font.bold</td>
+            <td>Boolean</td>
+            <td><code>true</code></td>
+            <td>When true, the label text font will be bold.</td>
+        </tr>
+        <tr parent="font" class="hidden">
             <td class="indent">font.color</td>
             <td>String</td>
             <td><code>'#343434'</code></td>

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -49,7 +49,8 @@ class NodesHandler {
         background: 'none',
         strokeWidth: 0, // px
         strokeColor: '#ffffff',
-        align: 'center'
+        align: 'center',
+        bold: false
       },
       group: undefined,
       hidden: false,

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -119,6 +119,7 @@ class Label {
    */
   _drawText(ctx, selected, x, y, baseline = 'middle') {
     let fontSize = this.fontOptions.size;
+    let fontBold = (selected && this.nodeOptions.labelHighlightBold) || this.fontOptions.bold;
     let viewFontSize = fontSize * this.body.view.scale;
     // this ensures that there will not be HUGE letters on screen by setting an upper limit on the visible text size (regardless of zoomLevel)
     if (viewFontSize >= this.nodeOptions.scaling.label.maxVisible) {
@@ -130,7 +131,7 @@ class Label {
     [x, yLine] = this._setAlignment(ctx, x, yLine, baseline);
 
     // configure context for drawing the text
-    ctx.font = (selected && this.nodeOptions.labelHighlightBold ? 'bold ' : '') + fontSize + "px " + this.fontOptions.face;
+    ctx.font = (fontBold ? 'bold ' : '') + fontSize + "px " + this.fontOptions.face;
     ctx.fillStyle = fontColor;
     // When the textAlign property is 'left', make label left-justified
     if ((!this.isEdgeLabel) && this.fontOptions.align === 'left') {


### PR DESCRIPTION
For some reason I needed to display bold labels in network nodes not only on hover and I didn't find such feature.