### PR TITLE
Fixed updating directions of the arrows with the string type

### DIFF
--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -142,9 +142,9 @@ class Edge {
     if (newOptions.arrows !== undefined && newOptions.arrows !== null) {
       if (typeof newOptions.arrows === 'string') {
         let arrows = newOptions.arrows.toLowerCase();
-        if (arrows.indexOf("to")     != -1) {parentOptions.arrows.to.enabled     = true;}
-        if (arrows.indexOf("middle") != -1) {parentOptions.arrows.middle.enabled = true;}
-        if (arrows.indexOf("from")   != -1) {parentOptions.arrows.from.enabled   = true;}
+        parentOptions.arrows.to.enabled     = arrows.indexOf("to")     != -1;
+        parentOptions.arrows.middle.enabled = arrows.indexOf("middle") != -1;
+        parentOptions.arrows.from.enabled   = arrows.indexOf("from")   != -1;
       }
       else if (typeof newOptions.arrows === 'object') {
         util.mergeOptions(parentOptions.arrows, newOptions.arrows, 'to',     allowDeletion, globalOptions.arrows);


### PR DESCRIPTION
Fixed a small bug in the update of the directions of arrows with the String type.

If I have A -> B, and I do :
```javascript
edges.update({id: "1", from: "A", to: "B", arrows: "from"});
```
for A <- B but the result was A <-> B.