### PR TITLE
BugFix - Network.options.nodes

### DIFF
--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -171,6 +171,7 @@ let allOptions = {
       __type__: { object, boolean }
     },
     font: {
+      align: { string },
       color: { string },
       size: { number }, // px
       face: { string },


### PR DESCRIPTION
As the documentation on vis.js nodes can be styled with align: left|center

allOptions does not include this option and throw an error on option validation.