### PR TITLE
reset switched{Day,Month,Year} in next function, not in isMajor function

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -245,6 +245,11 @@ TimeStep.prototype.next = function() {
     this.current = this._end.clone();
   }
 
+  // Reset switches for year, month and day. Will get set to true where appropriate in DateUtil.stepOverHiddenDates
+  this.switchedDay = false;
+  this.switchedMonth = false;
+  this.switchedYear = false;
+
   DateUtil.stepOverHiddenDates(this.moment, this, prev);
 };
 
@@ -443,7 +448,7 @@ TimeStep.snap = function(date, scale, step) {
     var _step = step > 5 ? step / 2 : 1;
     clone.milliseconds(Math.round(clone.milliseconds() / _step) * _step);
   }
-  
+
   return clone;
 };
 
@@ -454,7 +459,6 @@ TimeStep.snap = function(date, scale, step) {
  */
 TimeStep.prototype.isMajor = function() {
   if (this.switchedYear == true) {
-    this.switchedYear = false;
     switch (this.scale) {
       case 'year':
       case 'month':
@@ -470,7 +474,6 @@ TimeStep.prototype.isMajor = function() {
     }
   }
   else if (this.switchedMonth == true) {
-    this.switchedMonth = false;
     switch (this.scale) {
       case 'weekday':
       case 'day':
@@ -484,7 +487,6 @@ TimeStep.prototype.isMajor = function() {
     }
   }
   else if (this.switchedDay == true) {
-    this.switchedDay = false;
     switch (this.scale) {
       case 'millisecond':
       case 'second':


### PR DESCRIPTION
resetting these variables inside the isMajor function caused subsequent calls to falsely report not being major labels.

This lead to problems in the TimeAxis _repaintLabels function where nextIsMajor is defined by calling isMajor, which resets switched{Day,Month,Year} and causes the isMajor of the next loop to always return false.