### PR TITLE
timeline: fix vis-item-content width

### DIFF
--- a/dist/vis.js
+++ b/dist/vis.js
@@ -22462,6 +22462,7 @@ return /******/ (function(modules) { // webpackBootstrap
           this.dom.content.style.right = contentStartPosition + 'px';
         } else {
           this.dom.content.style.left = contentStartPosition + 'px';
+          this.dom.content.style.width = 'calc(100% - ' + contentStartPosition + 'px)';
         }
     }
   };


### PR DESCRIPTION
In order to place content in bars, `timeline` pushes `vis-item-content` to the right with things like:

```html
<div class="vis-item-content" style="left: 564.664px;"
```

When using large content, this leads to the content overflowing the div:

![screenshot from 2016-05-14 15-27-10](https://cloud.githubusercontent.com/assets/650430/15268754/ab88daec-19e9-11e6-8055-421eafeabde5.png)


By adjusting the width, this can be fixed:


```html
<div class="vis-item-content" style="left: 564.664px;width: calc(100% - 564.664px);"
```

![screenshot from 2016-05-14 15-37-10](https://cloud.githubusercontent.com/assets/650430/15268760/c045aa5a-19e9-11e6-8bc4-ace9a87c122a.png)
