### PR TITLE
timeline: make end optional on range

### DIFF
--- a/dist/vis.js
+++ b/dist/vis.js
@@ -22236,7 +22236,7 @@ return /******/ (function(modules) { // webpackBootstrap
         throw new Error('Property "start" missing in item ' + data.id);
       }
       if (data.end == undefined) {
-        throw new Error('Property "end" missing in item ' + data.id);
+        data.end = new Date();
       }
     }
 


### PR DESCRIPTION
When setting up ranges, `end` is mandatory. It would be useful if it could default to the current date.