### PR TITLE
Add specific class with value to major gird lines

### DIFF
--- a/lib/timeline/component/DataAxis.js
+++ b/lib/timeline/component/DataAxis.js
@@ -392,7 +392,7 @@ DataAxis.prototype._redrawLabels = function () {
       }
       if (this.master === true) {
         if (isMajor) {
-          this._redrawLine(y, orientation, 'vis-grid vis-horizontal vis-major', this.options.majorLinesOffset, this.props.majorLineWidth);
+          this._redrawLine(y, orientation, 'vis-grid vis-horizontal vis-major vis-val-' + line.val, this.options.majorLinesOffset, this.props.majorLineWidth);
         }
         else {
           this._redrawLine(y, orientation, 'vis-grid vis-horizontal vis-minor', this.options.minorLinesOffset, this.props.minorLineWidth);


### PR DESCRIPTION
It will be possible to highlight specific lines, for example in rpercentage chart 100%, by adding `.vis-val-100 {}` to css...