### PR TITLE
Fixed getPoint for same node edges

### DIFF
--- a/lib/network/modules/components/edges/BezierEdgeDynamic.js
+++ b/lib/network/modules/components/edges/BezierEdgeDynamic.js
@@ -133,8 +133,16 @@ class BezierEdgeDynamic extends BezierEdgeBase {
    */
   getPoint(percentage, viaNode = this.via) {
     let t = percentage;
-    let x = Math.pow(1 - t, 2) * this.fromPoint.x + (2 * t * (1 - t)) * viaNode.x + Math.pow(t, 2) * this.toPoint.x;
-    let y = Math.pow(1 - t, 2) * this.fromPoint.y + (2 * t * (1 - t)) * viaNode.y + Math.pow(t, 2) * this.toPoint.y;
+    let x, y;
+    if (this.from === this.to){
+      let [cx,cy,cr]  = this._getCircleData(this.from)
+      let a = 2 * Math.PI * (1 - t);
+      x = cx + cr * Math.sin(a);
+      y = cy + cr - cr * (1 - Math.cos(a));
+    } else {
+      x = Math.pow(1 - t, 2) * this.fromPoint.x + 2 * t * (1 - t) * viaNode.x + Math.pow(t, 2) * this.toPoint.x;
+      y = Math.pow(1 - t, 2) * this.fromPoint.y + 2 * t * (1 - t) * viaNode.y + Math.pow(t, 2) * this.toPoint.y;
+    }
 
     return {x: x, y: y};
   }


### PR DESCRIPTION
If an edge was point out to the same node, the `getPoint` returns the wrong coordinates.

Signed-off-by: André Martins <aanm90@gmail.com>