### PR TITLE
Select the closest edge, not just any nearby

### DIFF
--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -219,15 +219,32 @@ class SelectionHandler {
    * @returns {undefined}
    */
   getEdgeAt(pointer, returnEdge = true) {
-    let positionObject = this._pointerToPositionObject(pointer);
-    let overlappingEdges = this._getAllEdgesOverlappingWith(positionObject);
-
-    if (overlappingEdges.length > 0) {
+    // Iterate over edges, pick closest within 10
+    var canvasPos = this.canvas.DOMtoCanvas(pointer);
+    var mindist = 10;
+    var overlappingEdge = null;
+    var edges = this.body.edges;
+    for (var i = 0; i < this.body.edgeIndices.length; i++) {
+      var edgeId = this.body.edgeIndices[i];
+      var edge = edges[edgeId];
+      if (edge.connected) {
+        var xFrom = edge.from.x;
+        var yFrom = edge.from.y;
+        var xTo = edge.to.x;
+        var yTo = edge.to.y;
+        var dist = edge.edgeType.getDistanceToEdge(xFrom, yFrom, xTo, yTo, canvasPos.x, canvasPos.y);
+        if(dist < mindist){
+          overlappingEdge = edgeId;
+          mindist = dist;
+        }
+      }
+    }
+    if (overlappingEdge) {
       if (returnEdge === true) {
-        return this.body.edges[overlappingEdges[overlappingEdges.length - 1]];
+        return this.body.edges[overlappingEdge];
       }
       else {
-        return overlappingEdges[overlappingEdges.length - 1];
+        return overlappingEdge;
       }
     }
     else {


### PR DESCRIPTION
This helps quite a bit for complex graphs with dense connections, where many edges are packed into a small space. With the default algorithm, any edge within 10 of the mouse will get selected, so there are often edges you are unable to select at all even though you can see them, because others are nearby. With this patch, you can be much more precise with where you are clicking and which edge you are selecting.