### PR TITLE
Restore toolbar if delete callback not called

### DIFF
--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -438,14 +438,10 @@ class ManipulationSystem {
           if (finalizedData !== null && finalizedData !== undefined && this.inMode === 'delete') { // if for whatever reason the mode has changes (due to dataset change) disregard the callback) {
             this.body.data.edges.getDataSet().remove(finalizedData.edges);
             this.body.data.nodes.getDataSet().remove(finalizedData.nodes);
-            this.body.emitter.emit('startSimulation');
-            this.showManipulatorToolbar();
-          }
-          else {
-            this.body.emitter.emit('startSimulation');
-            this.showManipulatorToolbar();
           }
         });
+        this.body.emitter.emit('startSimulation');
+        this.showManipulatorToolbar();
       }
       else {
         throw new Error('The function for delete does not support two arguments (data, callback)')


### PR DESCRIPTION
When the function given for the manipulation.deleteNode or manipulation.deleteEdge options did not call the callback provided (due to not wanting to delete after all), the manipulation toolbar was not being redrawn after _clean because the call to showManipulatorToolbar only occurred within the callback. To fix it I just moved the call outside of the callback. I also moved the startSimulation emit because the former logic did it if even if nothing was deleted, but I'm not completely sure this is necessary.