### PR TITLE
Timestep setMoment fix

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -93,9 +93,9 @@ TimeStep.prototype.setMoment = function (moment) {
   this.moment = moment;
 
   // update the date properties, can have a new utcOffset
-  this.current = this.moment(this.current);
-  this._start = this.moment(this._start);
-  this._end = this.moment(this._end);
+  this.current = this.moment(this.current.valueOf());
+  this._start = this.moment(this._start.valueOf());
+  this._end = this.moment(this._end.valueOf());
 };
 
 /**


### PR DESCRIPTION
#### Explanation

In TimeStep's setMoment function, the TimeStep accepts a new `moment` instance, and then uses it to clone new values for its `current`, `_start`, and `_end` values. The problem is that if the new moment instance has a different locale, these values do not get the new locale since they were cloned from the old instances. 

#### Changes

The fix is to instead pass the new moment instance the date values of the variables. This will create new moment instances for the variables that have the new locale. 

**Note:** this bug won't be apparent in examples that set window's moment, as this is the instance originally required by the TimeStep, so locale changes would, in that case, be reflected.