### PR TITLE
fix #1723 (Strange behaviour in the time axis bar when hiddenDates setted)

### DIFF
--- a/lib/timeline/DateUtil.js
+++ b/lib/timeline/DateUtil.js
@@ -378,7 +378,7 @@ exports.getHiddenDurationBeforeStart = function (hiddenDates, start, end) {
     var startDate = hiddenDates[i].start;
     var endDate = hiddenDates[i].end;
 
-  if (startDate >= start && endDate <= end) {
+    if (startDate >= start && endDate <= end) {
       duration += endDate - startDate;
     }
   }

--- a/lib/timeline/DateUtil.js
+++ b/lib/timeline/DateUtil.js
@@ -286,24 +286,37 @@ exports.stepOverHiddenDates = function(moment, timeStep, previousTime) {
  * @param width
  * @returns {number}
  */
-exports.toScreen = function(Core, time, width) {
-  if (Core.body.hiddenDates.length == 0) {
-    var conversion = Core.range.conversion(width);
-    return (time.valueOf() - conversion.offset) * conversion.scale;
-  }
-  else {
-    var hidden = exports.isHidden(time, Core.body.hiddenDates);
-    if (hidden.hidden == true) {
-      time = hidden.startDate;
+exports.toScreen = function (Core, time, width) {
+    if (Core.body.hiddenDates.length == 0) {
+      var conversion = Core.range.conversion(width);
+      return (time.valueOf() - conversion.offset) * conversion.scale;
+    } else {
+      var hidden = exports.isHidden(time, Core.body.hiddenDates);
+      if (hidden.hidden == true) {
+        time = hidden.startDate;
+      }
+
+      var duration = exports.getHiddenDurationBetween(Core.body.hiddenDates, Core.range.start, Core.range.end);
+      if (time < Core.range.start) {
+        var conversion = Core.range.conversion(width, duration);
+        var durationAfter = exports.getHiddenDurationBeforeStart(Core.body.hiddenDates, time, conversion.offset);
+        time = Core.options.moment(time).toDate().valueOf();
+        time = time + durationAfter;
+        return -(conversion.offset - time.valueOf()) * conversion.scale;
+        
+      } else if (time > Core.range.end) {
+        var rangeAfterEnd = {start: Core.range.start, end: time};
+        time = exports.correctTimeForHidden(Core.options.moment, Core.body.hiddenDates, rangeAfterEnd, time);
+        var conversion = Core.range.conversion(width, duration);
+        return (time.valueOf() - conversion.offset) * conversion.scale;
+
+      } else {
+        time = exports.correctTimeForHidden(Core.options.moment, Core.body.hiddenDates, Core.range, time);
+        var conversion = Core.range.conversion(width, duration);
+        return (time.valueOf() - conversion.offset) * conversion.scale;
+      }
     }
-
-    var duration = exports.getHiddenDurationBetween(Core.body.hiddenDates, Core.range.start, Core.range.end);
-    time = exports.correctTimeForHidden(Core.options.moment, Core.body.hiddenDates, Core.range, time);
-
-    var conversion = Core.range.conversion(width, duration);
-    return (time.valueOf() - conversion.offset) * conversion.scale;
-  }
-};
+  };
 
 
 /**
@@ -345,6 +358,27 @@ exports.getHiddenDurationBetween = function(hiddenDates, start, end) {
     var endDate = hiddenDates[i].end;
     // if time after the cutout, and the
     if (startDate >= start && endDate < end) {
+      duration += endDate - startDate;
+    }
+  }
+  return duration;
+};
+
+/**
+   * Support function
+   *
+   * @param hiddenDates
+   * @param start
+   * @param end
+   * @returns {number}
+   */
+exports.getHiddenDurationBeforeStart = function (hiddenDates, start, end) {
+  var duration = 0;
+  for (var i = 0; i < hiddenDates.length; i++) {
+    var startDate = hiddenDates[i].start;
+    var endDate = hiddenDates[i].end;
+
+  if (startDate >= start && endDate <= end) {
       duration += endDate - startDate;
     }
   }

--- a/lib/timeline/DateUtil.js
+++ b/lib/timeline/DateUtil.js
@@ -299,9 +299,9 @@ exports.toScreen = function (Core, time, width) {
       var duration = exports.getHiddenDurationBetween(Core.body.hiddenDates, Core.range.start, Core.range.end);
       if (time < Core.range.start) {
         var conversion = Core.range.conversion(width, duration);
-        var durationAfter = exports.getHiddenDurationBeforeStart(Core.body.hiddenDates, time, conversion.offset);
+        var hiddenBeforeStart = exports.getHiddenDurationBeforeStart(Core.body.hiddenDates, time, conversion.offset);
         time = Core.options.moment(time).toDate().valueOf();
-        time = time + durationAfter;
+        time = time + hiddenBeforeStart;
         return -(conversion.offset - time.valueOf()) * conversion.scale;
         
       } else if (time > Core.range.end) {


### PR DESCRIPTION
Hi,

this is a fix for the 1723 issue (link https://github.com/almende/vis/issues/1723)

this strange behaviour happened because the hidden time, before the timeline range, was not excluded from the calculation.  

Also the same thing happened with time after the timeline range. 

this can potentially fix other visualization issues using timeline with hidden time, like having an item dragged before the starting range. 

Thanks,
Nikola