### PR TITLE
improvements of the bower delivery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,11 +8,25 @@
     "type": "git",
     "url": "git://github.com/almende/vis.git"
   },
+  "keywords": [
+    "vis",
+    "visualization",
+    "web based",
+    "browser based",
+    "javascript",
+    "chart",
+    "linechart",
+    "timeline",
+    "graph",
+    "network",
+    "browser"
+  ],
   "ignore": [
+    "gulpfile.js",
     "misc",
     "node_modules",
+    "package.json",
     "test",
-    "tools",
     ".idea",
     ".npmignore",
     ".gitignore"

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
     "node_modules",
     "test",
     "tools",
-    "lib",
     ".idea",
     ".npmignore",
     ".gitignore"


### PR DESCRIPTION
There are some improvements to the bower delivery:
* removed `package.json` and `gulpfile.js` because if you really want to build your own dist files, bower is maybe not the right package-manager to do this!?
* reverted https://github.com/almende/vis/pull/906/commits/856348d108d8eacd0726637239373d18417f9e0e by re-adding the `lib` folder to the bower delivery (see https://github.com/almende/vis/pull/906#commitcomment-18069283). This is necessary if you want to use the still existing `index*.js` files e.g. with webpack. (see https://github.com/almende/vis/issues/1602#issuecomment-232595261).
* added `keywords` because they are [recommended](https://github.com/bower/spec/blob/master/json.md#keywords).