### PR TITLE
Removed all build-related stuff from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,8 +9,11 @@
     "url": "git://github.com/almende/vis.git"
   },
   "ignore": [
+    "gulpfile.js",
+    "index*.js",
     "misc",
     "node_modules",
+    "package.json",
     "test",
     "tools",
     "lib",

--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,19 @@
     "type": "git",
     "url": "git://github.com/almende/vis.git"
   },
+  "keywords": [
+    "vis",
+    "visualization",
+    "web based",
+    "browser based",
+    "javascript",
+    "chart",
+    "linechart",
+    "timeline",
+    "graph",
+    "network",
+    "browser"
+  ],
   "ignore": [
     "gulpfile.js",
     "index*.js",


### PR DESCRIPTION
(Custom) builds are not possible with bower because the neccessary dependemcies are missing (see https://github.com/almende/vis/pull/1961#issuecomment-232942494). Therefor all build-related files are useless and should not be distributed with bower. 

*  Removed everything build related. Only deliver `dist`, `docs`, `examples`, `Readme` and Licenses.
*  Added keywords because it is [recommended](/bower/spec/blob/master/json.md#keywords)