### PR TITLE
Fix issue #1156: Vertical scrolling when dragging

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -547,4 +547,25 @@ Timeline.prototype.getEventProperties = function (event) {
   }
 };
 
+ /**
+ * Extend the drag event handler from Core, move the timeline vertically
+ * @param {Event} event
+ * @private
+ */
+  Timeline.prototype._onDrag = function (event) {
+      // refuse to drag when we where pinching to prevent the timeline make a jump
+      // when releasing the fingers in opposite order from the touch screen, and refuse
+      // to drag when an item is already being dragged
+      if (!this.touch.allowDragging || this.itemSet.touchParams.itemIsDragging) return;
+
+      var delta = event.deltaY;
+
+      var oldScrollTop = this._getScrollTop();
+      var newScrollTop = this._setScrollTop(this.touch.initialScrollTop + delta);
+
+      if (newScrollTop != oldScrollTop) {
+          this.emit("verticalDrag");
+      }
+  };
+
 module.exports = Timeline;

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1211,6 +1211,7 @@ ItemSet.prototype._onDragStart = function (event) {
 
     var dragLeftItem = this.touchParams.dragLeftItem;
     var dragRightItem = this.touchParams.dragRightItem;
+    this.touchParams.itemIsDragging = true;
 
     if (dragLeftItem) {
       props = {
@@ -1494,6 +1495,7 @@ ItemSet.prototype._onDragEnd = function (event) {
     var dataset = this.itemsData.getDataSet();
     var itemProps = this.touchParams.itemProps ;
     this.touchParams.itemProps = null;
+    this.touchParams.itemIsDragging = false;
 
     itemProps.forEach(function (props) {
       var id = props.item.id;


### PR DESCRIPTION
Added a flag to check whether an item in the Itemset is currently being dragged, this is used to stop the timeline from scrolling when an item is being dragged.

A better solution might be to change some of the drag event handlers, and stop certain mouse events from propogating, but this fix worked for me :)