### PR TITLE
Resolve issue #1857 Fixed node positioning with improvedLayout:true

### DIFF
--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -234,8 +234,11 @@ class LayoutEngine {
         // perturb the nodes a little bit to force the physics to kick in
         let offset = 70;
         for (let i = 0; i < this.body.nodeIndices.length; i++) {
-          this.body.nodes[this.body.nodeIndices[i]].x += (0.5 - this.seededRandom())*offset;
-          this.body.nodes[this.body.nodeIndices[i]].y += (0.5 - this.seededRandom())*offset;
+          // Only perturb the nodes that aren't fixed
+          if (this.body.nodes[this.body.nodeIndices[i]].predefinedPosition === false) {
+            this.body.nodes[this.body.nodeIndices[i]].x += (0.5 - this.seededRandom())*offset;
+            this.body.nodes[this.body.nodeIndices[i]].y += (0.5 - this.seededRandom())*offset;
+          }
         }
 
         // uncluster all clusters


### PR DESCRIPTION
Resolve #1857 
When improvedLayout was true, perturbing the nodes was being performed on all nodes regardless of whether they were set as fixed.

Using http://visjs.org/examples/network/exampleApplications/nodeLegend.html as an example
_before patch_
![image](https://cloud.githubusercontent.com/assets/4494301/17083458/24a5b3b4-5199-11e6-8048-3db6edc29765.png)

_after patch_
![image](https://cloud.githubusercontent.com/assets/4494301/17083457/10926278-5199-11e6-8291-a371882fbc48.png)
