### PR TITLE
decrease whitespace in ellipses having long text

### DIFF
--- a/lib/network/modules/components/nodes/shapes/Ellipse.js
+++ b/lib/network/modules/components/nodes/shapes/Ellipse.js
@@ -11,11 +11,8 @@ class Ellipse extends NodeBase {
     if (this.width === undefined) {
       var textSize = this.labelModule.getTextSize(ctx, selected);
 
-      this.width = textSize.width * 1.5;
       this.height = textSize.height * 2;
-      if (this.width < this.height) {
-        this.width = this.height;
-      }
+      this.width = textSize.width + this.height;
       this.radius = 0.5*this.width;
     }
   }


### PR DESCRIPTION
When the text inside of an ellipses node is long (> ~10 characters), the ellipse is created too wide.  I've replaced the 1.5x the text width to adding a constant.  The height of the text is a good value.