### PR TITLE
fixed timeline examples preview images

### DIFF
--- a/timeline_examples.html
+++ b/timeline_examples.html
@@ -20,10 +20,13 @@
     <script type="text/javascript" src="./js/prettify/prettify.js"></script>
     <link href="./css/examples.css" rel="stylesheet" type="text/css" />
 
+    <script src="./dist/vis.js"></script>
+    <link href="./dist/vis.css" rel="stylesheet" type="text/css" />
+
     <script src="./js/imagesNetwork.js"></script>
     <link href="./css/imagesNetwork.css" rel="stylesheet" type="text/css" />
 </head>
-<body>
+<body onload="loadVis(220);">
 
 
 <div class="navbar-wrapper">


### PR DESCRIPTION
This reserves a change done in 2657ba15ac5a548a988dec577030bbc22a86e4bc because the preview images on the timeline example disappeared.