### PR TITLE
Network: edge-endpoint 'circle'

### DIFF
--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -115,9 +115,9 @@
 var options = {
   edges:{
     arrows: {
-      to:     {enabled: false, scaleFactor:1},
-      middle: {enabled: false, scaleFactor:1},
-      from:   {enabled: false, scaleFactor:1}
+      to:     {enabled: false, scaleFactor:1, type:'arrow'},
+      middle: {enabled: false, scaleFactor:1, type:'arrow'},
+      from:   {enabled: false, scaleFactor:1, type:'arrow'}
     },
     arrowStrikethrough: true,
     color: {
@@ -242,6 +242,12 @@ network.setOptions(options);
             <td>Number</td>
             <td><code>1</code></td>
             <td>The scale factor allows you to change the size of the arrowhead.</td>
+        </tr>
+        <tr parent="arrows" class="hidden">
+            <td class="indent2">arrows.to.type</td>
+            <td>String</td>
+            <td><code>arrow</code></td>
+            <td>The type of endpoint. Default is <code>arrow</code>. Also possible is <code>circle</code>.</td>
         </tr>
         <tr parent="arrows" class="hidden">
             <td class="indent">arrows.middle</td>

--- a/examples/network/edgeStyles/arrowTypes.html
+++ b/examples/network/edgeStyles/arrowTypes.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+<head>
+  <title>Network | Basic usage</title>
+
+  <script type="text/javascript" src="../../../dist/vis.js"></script>
+  <link href="../../../dist/vis.css" rel="stylesheet" type="text/css" />
+
+  <style type="text/css">
+    #mynetwork {
+      width: 600px;
+      height: 400px;
+      border: 1px solid lightgray;
+    }
+  </style>
+</head>
+<body>
+
+<p>
+  There two type of liner endings. The classical "arrow" (default) and "circle".
+</p>
+
+<div id="mynetwork"></div>
+
+<script type="text/javascript">
+  // create an array with nodes
+  var nodes = new vis.DataSet([
+    {id: 1, label: 'X'},
+    {id: 2, label: 'Y'},
+    {id: 3, label: 'Z'}
+  ]);
+
+  // create an array with edges
+  var edges = new vis.DataSet([
+    {from: 1, to: 2, arrows:'to'},
+    {from: 2, to: 3, arrows:{
+      to: {
+        type: 'circle'
+      }
+    }},
+  ]);
+
+  // create a network
+  var container = document.getElementById('mynetwork');
+  var data = {
+    nodes: nodes,
+    edges: edges
+  };
+  var options = {};
+  var network = new vis.Network(container, data, options);
+</script>
+
+<script src="../../googleAnalytics.js"></script>
+</body>
+</html>

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -23,9 +23,9 @@ class EdgesHandler {
     this.options = {};
     this.defaultOptions = {
       arrows: {
-        to:     {enabled: false, scaleFactor:1}, // boolean / {arrowScaleFactor:1} / {enabled: false, arrowScaleFactor:1}
-        middle: {enabled: false, scaleFactor:1},
-        from:   {enabled: false, scaleFactor:1}
+        to:     {enabled: false, scaleFactor:1, type: 'arrow'}, // boolean / {arrowScaleFactor:1} / {enabled: false, arrowScaleFactor:1}
+        middle: {enabled: false, scaleFactor:1, type: 'arrow'},
+        from:   {enabled: false, scaleFactor:1, type: 'arrow'}
       },
       arrowStrikethrough: true,
       color: {

--- a/lib/network/modules/PhysicsEngine.js
+++ b/lib/network/modules/PhysicsEngine.js
@@ -628,7 +628,7 @@ class PhysicsEngine {
       this._freezeNodes();
     }
     this.stabilizationIterations = 0;
-  
+
     setTimeout(() => this._stabilizationBatch(),0);
   }
 
@@ -649,7 +649,7 @@ class PhysicsEngine {
       this.physicsTick();
       count++;
     }
-  
+
     if (this.stabilized === false && this.stabilizationIterations < this.targetIterations) {
       this.body.emitter.emit('stabilizationProgress', {iterations: this.stabilizationIterations, total: this.targetIterations});
       setTimeout(this._stabilizationBatch.bind(this),0);
@@ -710,11 +710,11 @@ class PhysicsEngine {
 
       let angle = Math.atan2(force.y, force.x);
       ctx.fillStyle = color;
-      ctx.arrow(node.x + factor*force.x + Math.cos(angle)*arrowSize, node.y + factor*force.y+Math.sin(angle)*arrowSize, angle, arrowSize);
+      ctx.arrowEndpoint(node.x + factor*force.x + Math.cos(angle)*arrowSize, node.y + factor*force.y+Math.sin(angle)*arrowSize, angle, arrowSize);
       ctx.fill();
     }
   }
-  
+
 }
 
 export default PhysicsEngine;

--- a/lib/network/modules/components/edges/util/EdgeBase.js
+++ b/lib/network/modules/components/edges/util/EdgeBase.js
@@ -412,6 +412,7 @@ class EdgeBase {
     let node2;
     let guideOffset;
     let scaleFactor;
+    let type;
     let lineWidth = this.getLineWidth(selected, hover);
 
     if (position === 'from') {
@@ -419,17 +420,20 @@ class EdgeBase {
       node2 = this.to;
       guideOffset = 0.1;
       scaleFactor = this.options.arrows.from.scaleFactor;
+      type = this.options.arrows.from.type;
     }
     else if (position === 'to') {
       node1 = this.to;
       node2 = this.from;
       guideOffset = -0.1;
       scaleFactor = this.options.arrows.to.scaleFactor;
+      type = this.options.arrows.to.type;
     }
     else {
       node1 = this.to;
       node2 = this.from;
       scaleFactor = this.options.arrows.middle.scaleFactor;
+      type = this.options.arrows.middle.type;
     }
 
     // if not connected to itself
@@ -475,7 +479,7 @@ class EdgeBase {
     var yi = arrowPoint.y - length * 0.9 * Math.sin(angle);
     let arrowCore = {x: xi, y: yi};
 
-    return {point: arrowPoint, core: arrowCore, angle: angle, length: length};
+    return {point: arrowPoint, core: arrowCore, angle: angle, length: length, type: type};
   }
 
   /**
@@ -491,8 +495,13 @@ class EdgeBase {
     ctx.fillStyle = ctx.strokeStyle;
     ctx.lineWidth = this.getLineWidth(selected, hover);
 
-    // draw arrow at the end of the line
-    ctx.arrow(arrowData.point.x, arrowData.point.y, arrowData.angle, arrowData.length);
+    if (arrowData.type && arrowData.type.toLowerCase() === 'circle') {
+      // draw circle at the end of the line
+      ctx.circleEndpoint(arrowData.point.x, arrowData.point.y, arrowData.angle, arrowData.length);
+    } else {
+      // draw arrow at the end of the line
+      ctx.arrowEndpoint(arrowData.point.x, arrowData.point.y, arrowData.angle, arrowData.length);
+    }
 
     // draw shadow if enabled
     this.enableShadow(ctx);

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -24,9 +24,9 @@ let allOptions = {
   },
   edges: {
     arrows: {
-      to: { enabled: { boolean }, scaleFactor: { number }, __type__: { object, boolean } },
-      middle: { enabled: { boolean }, scaleFactor: { number }, __type__: { object, boolean } },
-      from: { enabled: { boolean }, scaleFactor: { number }, __type__: { object, boolean } },
+      to: { enabled: { boolean }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean } },
+      middle: { enabled: { boolean }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean } },
+      from: { enabled: { boolean }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean } },
       __type__: { string: ['from', 'to', 'middle'], object }
     },
     arrowStrikethrough: { boolean },
@@ -371,9 +371,9 @@ let configureOptions = {
   },
   edges: {
     arrows: {
-      to: { enabled: false, scaleFactor: [1, 0, 3, 0.05] }, // boolean / {arrowScaleFactor:1} / {enabled: false, arrowScaleFactor:1}
-      middle: { enabled: false, scaleFactor: [1, 0, 3, 0.05] },
-      from: { enabled: false, scaleFactor: [1, 0, 3, 0.05] }
+      to: { enabled: false, scaleFactor: [1, 0, 3, 0.05], type: 'arrow' },
+      middle: { enabled: false, scaleFactor: [1, 0, 3, 0.05], type: 'arrow' },
+      from: { enabled: false, scaleFactor: [1, 0, 3, 0.05], type: 'arrow' }
     },
     arrowStrikethrough: true,
     color: {

--- a/lib/network/shapes.js
+++ b/lib/network/shapes.js
@@ -206,9 +206,9 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
 
 
   /**
-   * Draw an arrow point (no line)
+   * Draw an arrow an the end of an line with the given angle.
    */
-  CanvasRenderingContext2D.prototype.arrow = function (x, y, angle, length) {
+  CanvasRenderingContext2D.prototype.arrowEndpoint = function (x, y, angle, length) {
     // tail
     var xt = x - length * Math.cos(angle);
     var yt = y - length * Math.sin(angle);
@@ -231,6 +231,16 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
     this.lineTo(xi, yi);
     this.lineTo(xr, yr);
     this.closePath();
+  };
+
+  /**
+   * Draw an circle an the end of an line with the given angle.
+   */
+  CanvasRenderingContext2D.prototype.circleEndpoint = function (x, y, angle, length) {
+    var radius = length * 0.4;
+    var xc = x - radius * Math.cos(angle);
+    var yc = y - radius * Math.sin(angle);
+    this.circle(xc, yc, radius);
   };
 
   /**

--- a/lib/network/shapes.js
+++ b/lib/network/shapes.js
@@ -206,7 +206,7 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
 
 
   /**
-   * Draw an arrow an the end of an line with the given angle.
+   * Draw an arrow at the end of a line with the given angle.
    */
   CanvasRenderingContext2D.prototype.arrowEndpoint = function (x, y, angle, length) {
     // tail


### PR DESCRIPTION
Make it possible to also define an `type` of edge-endpoint (`arrow` or `circle`):

![image](https://cloud.githubusercontent.com/assets/600565/18230987/e2a0c344-72ab-11e6-8c9e-fade273342af.png)

implements #1993