### PR TITLE
Prevent moment deprecation warning

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -415,7 +415,7 @@ exports.convert = function (object, type) {
           return new Date(Number(match[1])); // parse number
         }
         else {
-          return moment(object).toDate(); // parse string
+          return moment(new Date(object)).toDate(); // parse string
         }
       }
       else {


### PR DESCRIPTION
Replaced `return moment(object).toDate();` with `return moment(new Date(object)).toDate();` in order to prevent the deprecation warning from moment. See more about the deprecation [here](https://github.com/moment/moment/issues/1407).