### PR TITLE
Fix grammar/syntax in loading instructions

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -162,8 +162,8 @@
 
   <h2 id="Loading">Loading</h2>
   <p>
-    Install or download the <a href="http://visjs.org" target="_blank">vis.js</a> library.
-    in a subfolder of your project. Include the libraries script and css files in the
+    Install or download the <a href="http://visjs.org" target="_blank">vis.js</a> library
+    in a subfolder of your project. Include the library's script and css files in the
     head of your html code:
   </p>
 


### PR DESCRIPTION
Two small fixes to text of loading instructions in the timeline's docs. 