### PR TITLE
timeline: add missing require for util module

### DIFF
--- a/lib/timeline/component/Component.js
+++ b/lib/timeline/component/Component.js
@@ -1,3 +1,5 @@
+var util = require('../../util');
+
 /**
  * Prototype for visual components
  * @param {{dom: Object, domProps: Object, emitter: Emitter, range: Range}} [body]


### PR DESCRIPTION
Added missing require for `util`, which is used in `Component.prototype.setOptions` but never declared.

Caught this while debugging some down-stream sanity checker failures.