### PR TITLE
Small bugfix in ItemSet._onUpdate() which caused a nullpointer in Ite…

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -880,7 +880,7 @@ ItemSet.prototype._onUpdate = function(ids) {
   ids.forEach(function (id) {
     var itemData = me.itemsData.get(id, me.itemOptions);
     var item = me.items[id];
-    var type = me._getType(itemData);
+    var type = itemData ? me._getType(itemData) : null;
 
     var constructor = ItemSet.types[type];
     var selected;
@@ -898,7 +898,7 @@ ItemSet.prototype._onUpdate = function(ids) {
       }
     }
 
-    if (!item) {
+    if (!item && itemData) {
       // create item
       if (constructor) {
         item = new constructor(itemData, me.conversion, me.options);


### PR DESCRIPTION
…mSet._getType() if a newly delivered item got filtered out inside DataSet.get().

The DataSet allows to pass in a filter function which is called inside DataSet.get().
The item object is set to null if the filter applies.
This causes a Nullpointer exception inside ItemSet._getType() which expects the parameter itemData to be an object.
With the fix ItemSet._getType() is only called if itemData is not null.