### PR TITLE
Consolidated usage of getContext()

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -967,6 +967,17 @@ Graph3d.prototype.redraw = function() {
   this._redrawLegend();
 };
 
+
+/**
+ * Get drawing context without exposing canvas
+ */
+Graph3d.prototype._getContext = function() {
+  var canvas = this.frame.canvas;
+  var ctx = canvas.getContext('2d');
+  return ctx;
+};
+
+
 /**
  * Clear the canvas before redrawing
  */
@@ -1024,8 +1035,7 @@ Graph3d.prototype._redrawLegend = function() {
   var left   = right - width;
   var bottom = top + height;
 
-  var canvas = this.frame.canvas;
-  var ctx = canvas.getContext('2d');
+  var ctx = this._getContext();
   ctx.lineWidth = 1;
   ctx.font = '14px arial'; // TODO: put in options
 
@@ -1157,8 +1167,7 @@ Graph3d.prototype._redrawSlider = function() {
  */
 Graph3d.prototype._redrawInfo = function() {
   if (this.dataFilter) {
-    var canvas = this.frame.canvas;
-    var ctx = canvas.getContext('2d');
+    var ctx = this._getContext();
 
     ctx.font = '14px arial'; // TODO: put in options
     ctx.lineStyle = 'gray';
@@ -1177,8 +1186,7 @@ Graph3d.prototype._redrawInfo = function() {
  * Redraw the axis
  */
 Graph3d.prototype._redrawAxis = function() {
-  var canvas = this.frame.canvas,
-    ctx = canvas.getContext('2d'),
+  var ctx = this._getContext(),
     from, to, step, prettyStep,
     text, xText, yText, zText,
     offset, xOffset, yOffset,
@@ -1477,8 +1485,7 @@ Graph3d.prototype._hsv2rgb = function(H, S, V) {
  * This function can be used when the style is 'grid'
  */
 Graph3d.prototype._redrawDataGrid = function() {
-  var canvas = this.frame.canvas,
-    ctx = canvas.getContext('2d'),
+  var ctx = this._getContext(),
     point, right, top, cross,
     i,
     topSideVisible, fillStyle, strokeStyle, lineWidth,
@@ -1624,8 +1631,7 @@ Graph3d.prototype._getStrokeWidth = function(point) {
  * This function can be used when the style is 'dot' or 'dot-line'
  */
 Graph3d.prototype._redrawDataDot = function() {
-  var canvas = this.frame.canvas;
-  var ctx = canvas.getContext('2d');
+  var ctx = this._getContext();
   var i;
 
   if (this.dataPoints === undefined || this.dataPoints.length <= 0)
@@ -1720,8 +1726,7 @@ Graph3d.prototype._redrawDataDot = function() {
  * This function can be used when the style is 'bar', 'bar-color', or 'bar-size'
  */
 Graph3d.prototype._redrawDataBar = function() {
-  var canvas = this.frame.canvas;
-  var ctx = canvas.getContext('2d');
+  var ctx = this._getContext();
   var i, j, surface, corners;
 
   if (this.dataPoints === undefined || this.dataPoints.length <= 0)
@@ -1862,8 +1867,7 @@ Graph3d.prototype._redrawDataBar = function() {
  * This function can be used when the style is 'line'
  */
 Graph3d.prototype._redrawDataLine = function() {
-  var canvas = this.frame.canvas,
-    ctx = canvas.getContext('2d'),
+  var ctx = this._getContext(),
     point, i;
 
   if (this.dataPoints === undefined || this.dataPoints.length <= 0)


### PR DESCRIPTION
DRY'd the retrieval of a canvas context.