### PR TITLE
Moved recurring code for StepNumber to start() method

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1118,10 +1118,8 @@ Graph3d.prototype._redrawLegend = function() {
   var legendMin = isValueLegend ? this.valueMin :  this.zMin; 
   var legendMax = isValueLegend ? this.valueMax :  this.zMax;
   var step = new StepNumber(legendMin, legendMax, (legendMax-legendMin)/5, true);
-  step.start();
-  if (step.getCurrent() < legendMin) {
-    step.next();
-  }
+  step.start(true);
+
   var y;
   while (!step.end()) {
     y = bottom - (step.getCurrent() - legendMin) / (legendMax - legendMin) * height;
@@ -1254,10 +1252,8 @@ Graph3d.prototype._redrawAxis = function() {
   ctx.lineWidth = 1;
   prettyStep = (this.defaultXStep === undefined);
   step = new StepNumber(this.xMin, this.xMax, this.xStep, prettyStep);
-  step.start();
-  if (step.getCurrent() < this.xMin) {
-    step.next();
-  }
+  step.start(true);
+
   while (!step.end()) {
     var x = step.getCurrent();
 
@@ -1301,10 +1297,8 @@ Graph3d.prototype._redrawAxis = function() {
   ctx.lineWidth = 1;
   prettyStep = (this.defaultYStep === undefined);
   step = new StepNumber(this.yMin, this.yMax, this.yStep, prettyStep);
-  step.start();
-  if (step.getCurrent() < this.yMin) {
-    step.next();
-  }
+  step.start(true);
+
   while (!step.end()) {
     if (this.showGrid) {
       from = this._convert3Dto2D(new Point3d(this.xMin, step.getCurrent(), this.zMin));
@@ -1346,10 +1340,8 @@ Graph3d.prototype._redrawAxis = function() {
   ctx.lineWidth = 1;
   prettyStep = (this.defaultZStep === undefined);
   step = new StepNumber(this.zMin, this.zMax, this.zStep, prettyStep);
-  step.start();
-  if (step.getCurrent() < this.zMin) {
-    step.next();
-  }
+  step.start(true);
+
   xText = (Math.cos(armAngle ) > 0) ? this.xMin : this.xMax;
   yText = (Math.sin(armAngle ) < 0) ? this.yMin : this.yMax;
   while (!step.end()) {

--- a/lib/graph3d/StepNumber.js
+++ b/lib/graph3d/StepNumber.js
@@ -115,12 +115,28 @@ StepNumber.prototype.getStep = function () {
 };
 
 /**
- * Set the current value to the largest value smaller than start, which
- * is a multiple of the step size
+ * Set the current to its starting value.
+ *
+ * By default, this will be the largest value smaller than start, which
+ * is a multiple of the step size.
+ *
+ * Parameters checkFirst is optional, default false.
+ * If set to true, move the current value one step if smaller than start.
  */
-StepNumber.prototype.start = function() {
+StepNumber.prototype.start = function(checkFirst) {
+  if (checkFirst === undefined) {
+    checkFirst = false;
+  }
+
   this._current = this._start - this._start % this._step;
+
+  if (checkFirst) {
+    if (this.getCurrent() < this._start) {
+      this.next();
+    }
+  }
 };
+
 
 /**
  * Do a step, add the step size to the current value


### PR DESCRIPTION
The following code fragment:

```js
step.start();
  if (step.getCurrent() < this.valueMin) {
    step.next();
}
```

Occurs every single time a `StepNumber` instance is used. This leads me to conclude that it should be part of the `start()` method. I've made its running optional, default is the original working.