### PR TITLE
Uniform handling of common user options

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -8,6 +8,65 @@ var Filter = require('./Filter');
 var Slider = require('./Slider');
 var StepNumber = require('./StepNumber');
 
+// -----------------------------------------------------------------------------
+// Definitions private to module
+// -----------------------------------------------------------------------------
+
+/**
+ * Field names in the options hash which are of relevance to the user.
+ *
+ * Specifically, these are the fields which require no special handling,
+ * and can be directly copied over.
+ */
+var OPTIONKEYS = [
+  'width',
+  'height',
+  'filterLabel',
+  'legendLabel',
+  'xLabel',
+  'yLabel',
+  'zLabel',
+  'xValueLabel',
+  'yValueLabel',
+  'zValueLabel',
+  'showGrid',
+  'showPerspective',
+  'showShadow',
+  'showAnimationControls',
+  'keepAspectRatio',
+  'verticalRatio',
+  'animationInterval',
+  'animationPreload',
+  'animationAutoStart',
+  'axisColor',
+  'gridColor'
+];
+
+
+/**
+ * Copy fields from src to dst in a controlled manner.
+ *
+ * Only the fields mentioned in array 'fields' will be copied over,
+ * and only if these are actually defined.
+ *
+ * @param fields  array with names of fields to copy
+ */
+function safeCopy(src, dst, fields) {
+  for (var i in fields) {
+    var field = fields[i];
+
+    if (src[field] !== undefined) {
+      dst[field] = src[field];
+    }
+  }
+}
+
+
+
+// -----------------------------------------------------------------------------
+// Class Graph3d
+// -----------------------------------------------------------------------------
+
 /**
  * @constructor Graph3d
  * Graph3d displays data in 3d.
@@ -867,24 +926,14 @@ Graph3d.prototype.setOptions = function (options) {
 
   if (options !== undefined) {
     // retrieve parameter values
-    if (options.width !== undefined)            this.width = options.width;
-    if (options.height !== undefined)           this.height = options.height;
 
+    // Handle the parameters which can be simply copied over
+    safeCopy(options, this, OPTIONKEYS);
+
+    // Handle the rest of the parameters
     if (options.xCenter !== undefined)          this.defaultXCenter = options.xCenter;
     if (options.yCenter !== undefined)          this.defaultYCenter = options.yCenter;
-
-    if (options.filterLabel !== undefined)      this.filterLabel = options.filterLabel;
-    if (options.legendLabel !== undefined)      this.legendLabel = options.legendLabel;
     if (options.showLegend  !== undefined)      this.defaultShowLegend = options.showLegend; 
-    if (options.xLabel !== undefined)           this.xLabel = options.xLabel;
-    if (options.yLabel !== undefined)           this.yLabel = options.yLabel;
-    if (options.zLabel !== undefined)           this.zLabel = options.zLabel;
-
-    if (options.xValueLabel !== undefined)      this.xValueLabel = options.xValueLabel;
-    if (options.yValueLabel !== undefined)      this.yValueLabel = options.yValueLabel;
-    if (options.zValueLabel !== undefined)      this.zValueLabel = options.zValueLabel;
-
-    if (options.dotSizeRatio !== undefined)     this.dotSizeRatio = options.dotSizeRatio;
 
     if (options.style !== undefined) {
       var styleNumber = this._getStyleNumber(options.style);
@@ -892,21 +941,10 @@ Graph3d.prototype.setOptions = function (options) {
         this.style = styleNumber;
       }
     }
-    if (options.showGrid !== undefined)      this.showGrid = options.showGrid;
-    if (options.showPerspective !== undefined)   this.showPerspective = options.showPerspective;
-    if (options.showShadow !== undefined)    this.showShadow = options.showShadow;
-    if (options.tooltip !== undefined)       this.showTooltip = options.tooltip;
-    if (options.showAnimationControls !== undefined) this.showAnimationControls = options.showAnimationControls;
-    if (options.keepAspectRatio !== undefined)   this.keepAspectRatio = options.keepAspectRatio;
-    if (options.verticalRatio !== undefined)   this.verticalRatio = options.verticalRatio;
-
-    if (options.animationInterval !== undefined) this.animationInterval = options.animationInterval;
-    if (options.animationPreload !== undefined)  this.animationPreload = options.animationPreload;
-    if (options.animationAutoStart !== undefined)this.animationAutoStart = options.animationAutoStart;
+    if (options.tooltip !== undefined) this.showTooltip = options.tooltip;
 
     if (options.xBarWidth !== undefined) this.defaultXBarWidth = options.xBarWidth;
     if (options.yBarWidth !== undefined) this.defaultYBarWidth = options.yBarWidth;
-
     if (options.xMin !== undefined) this.defaultXMin = options.xMin;
     if (options.xStep !== undefined) this.defaultXStep = options.xStep;
     if (options.xMax !== undefined) this.defaultXMax = options.xMax;
@@ -928,8 +966,6 @@ Graph3d.prototype.setOptions = function (options) {
     }
 
     // colors
-    if (options.axisColor !== undefined)        this.axisColor = options.axisColor;
-    if (options.gridColor !== undefined)        this.gridColor = options.gridColor;
     if (options.dataColor) {
       if (typeof options.dataColor === 'string') {
         this.dataColor.fill = options.dataColor;


### PR DESCRIPTION
This change removes many of the recurring lines in `setOptions()` of the form:

```js
    if (options.width !== undefined)            this.width = options.width;
```
I hereby note that many of the rest of the lines are similar but with a prefix `default`, e.g.:
```js
    if (options.xCenter !== undefined)          this.defaultXCenter = options.xCenter;
```
The prefix `default` is ultimately not required and I can remove its need in due time, which enables uniform handling also for these fields.

There are longer term reasons for this change:

**First:** Currently, there are two sets of options present, namely:
- the user options, as set in `setOptions()`
- the defaults, as set in the constructor of `Graph3d` 

I believe it's for the better if these can be handled uniformly. Uniform handling of default settings is something I intend to add in the future (most likely immediately after if/when you accept this PR).

**Second:** I hereby remind you that my ultimate goal is to enable multiple graphs in a single view. This will add a _third_ set of options, namely options specific to each graph present. I strongly prefer to have a uniform handling of these options as well.

What I ultimately want is for _all_ options to be handled in the same consistent manner. This change is a first step to achieve that.

I hope you have an appreciation for this. 
