### PR TITLE
Adds oldData to the update event payload in dataview to match dataset.

### DIFF
--- a/lib/DataView.js
+++ b/lib/DataView.js
@@ -370,7 +370,7 @@ DataView.prototype._onEvent = function (event, params, senderId) {
       this._trigger('add', {items: added}, senderId);
     }
     if (updated.length) {
-      this._trigger('update', {items: updated, data: updatedData, oldData: oldData}, senderId);
+      this._trigger('update', {items: updated, oldData: oldData, data: updatedData}, senderId);
     }
     if (removed.length) {
       this._trigger('remove', {items: removed}, senderId);

--- a/lib/DataView.js
+++ b/lib/DataView.js
@@ -300,6 +300,7 @@ DataView.prototype._onEvent = function (event, params, senderId) {
   var ids = params && params.items;
   var data = this._data;
   var updatedData = [];
+  var oldData = [];
   var added = [];
   var updated = [];
   var removed = [];
@@ -330,6 +331,7 @@ DataView.prototype._onEvent = function (event, params, senderId) {
             if (this._ids[id]) {
               updated.push(id);
               updatedData.push(params.data[i]);
+              oldData.push(params.oldData[i]);
             }
             else {
               this._ids[id] = true;
@@ -368,7 +370,7 @@ DataView.prototype._onEvent = function (event, params, senderId) {
       this._trigger('add', {items: added}, senderId);
     }
     if (updated.length) {
-      this._trigger('update', {items: updated, data: updatedData}, senderId);
+      this._trigger('update', {items: updated, data: updatedData, oldData: oldData}, senderId);
     }
     if (removed.length) {
       this._trigger('remove', {items: removed}, senderId);


### PR DESCRIPTION
The DataSet update event payload includes an object with: `items`, `data` and `oldData`.
The DataView update event payload includes an object with `items` and `data`.

This pr will add `oldData` to the update event payload for DataView so it includes the same data that DataSet does.