### PR TITLE
Replaced sin/cos usage in drawAxis() with unit vector

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1360,10 +1360,11 @@ Graph3d.prototype._redrawAxis = function() {
   ctx.font = 24 / this.camera.getArmLength() + 'px arial';
 
   // calculate the length for the short grid lines
-  var gridLenX = 0.025 / this.scale.x;
-  var gridLenY = 0.025 / this.scale.y;
+  var gridLenX   = 0.025 / this.scale.x;
+  var gridLenY   = 0.025 / this.scale.y;
   var textMargin = 5 / this.camera.getArmLength(); // px
-  var armAngle = this.camera.getArmRotation().horizontal;
+  var armAngle   = this.camera.getArmRotation().horizontal;
+  var armVector  = new Point2d(Math.cos(armAngle), Math.sin(armAngle));
 
   // draw x-grid lines
   ctx.lineWidth = 1;
@@ -1389,7 +1390,7 @@ Graph3d.prototype._redrawAxis = function() {
       this._line3d(ctx, from, to, this.axisColor);
     }
 
-    yText       = (Math.cos(armAngle) > 0) ? this.yMin : this.yMax;
+    yText       = (armVector.x > 0) ? this.yMin : this.yMax;
     var point3d = new Point3d(x, yText, this.zMin);
     var msg     = '  ' + this.xValueLabel(x) + '  ';
     this.drawAxisLabelX(ctx, point3d, msg, armAngle, textMargin);
@@ -1421,7 +1422,7 @@ Graph3d.prototype._redrawAxis = function() {
       this._line3d(ctx, from, to, this.axisColor);
     }
 
-    xText   = (Math.sin(armAngle ) > 0) ? this.xMin : this.xMax;
+    xText   = (armVector.y > 0) ? this.xMin : this.xMax;
     point3d = new Point3d(xText, y, this.zMin);
     var msg = '  ' + this.yValueLabel(y) + '  ';    
     this.drawAxisLabelY(ctx, point3d, msg, armAngle, textMargin);
@@ -1435,8 +1436,8 @@ Graph3d.prototype._redrawAxis = function() {
   step = new StepNumber(this.zMin, this.zMax, this.zStep, prettyStep);
   step.start(true);
 
-  xText = (Math.cos(armAngle ) > 0) ? this.xMin : this.xMax;
-  yText = (Math.sin(armAngle ) < 0) ? this.yMin : this.yMax;
+  xText = (armVector.x > 0) ? this.xMin : this.xMax;
+  yText = (armVector.y < 0) ? this.yMin : this.yMax;
 
   while (!step.end()) {
     var z = step.getCurrent();
@@ -1485,7 +1486,7 @@ Graph3d.prototype._redrawAxis = function() {
   if (xLabel.length > 0) {
     yOffset = 0.1 / this.scale.y;
     xText   = (this.xMin + this.xMax) / 2;
-    yText   = (Math.cos(armAngle) > 0) ? this.yMin - yOffset: this.yMax + yOffset;
+    yText   = (armVector.x > 0) ? this.yMin - yOffset: this.yMax + yOffset;
     text    = new Point3d(xText, yText, this.zMin);
     this.drawAxisLabelX(ctx, text, xLabel, armAngle);
   }
@@ -1494,7 +1495,7 @@ Graph3d.prototype._redrawAxis = function() {
   var yLabel = this.yLabel;
   if (yLabel.length > 0) {
     xOffset = 0.1 / this.scale.x;
-    xText   = (Math.sin(armAngle ) > 0) ? this.xMin - xOffset : this.xMax + xOffset;
+    xText   = (armVector.y > 0) ? this.xMin - xOffset : this.xMax + xOffset;
     yText   = (this.yMin + this.yMax) / 2;
     text    = new Point3d(xText, yText, this.zMin);
 
@@ -1505,8 +1506,8 @@ Graph3d.prototype._redrawAxis = function() {
   var zLabel = this.zLabel;
   if (zLabel.length > 0) {
     offset = 30;  // pixels.  // TODO: relate to the max width of the values on the z axis?
-    xText  = (Math.cos(armAngle ) > 0) ? this.xMin : this.xMax;
-    yText  = (Math.sin(armAngle ) < 0) ? this.yMin : this.yMax;
+    xText  = (armVector.x > 0) ? this.xMin : this.xMax;
+    yText  = (armVector.y < 0) ? this.yMin : this.yMax;
     zText  = (this.zMin + this.zMax) / 2;
     text   = new Point3d(xText, yText, zText);
 


### PR DESCRIPTION
This removes excessive calls to sin and cos in `drawAxis()`.

The following construct is used to retain the sin and cos values:
```js
  var armVector  = new Point2d(Math.cos(armAngle), Math.sin(armAngle));
```
This is a unit vector in the XY plane pointing into the direction of the camera arm.