### PR TITLE
Updates DataSet and DataView remove event payload

### DIFF
--- a/docs/data/dataset.html
+++ b/docs/data/dataset.html
@@ -598,9 +598,11 @@ function (event, properties, senderId) {
         <code>update</code>, and <code>remove</code>,
         <code>properties</code> is always an object containing a property
         <code>items</code>, which contains an array with the ids of the affected
-        items. The <code>update</code> event has an extra field <code>oldData</code>
-        containing the original data of the updated items, and a field <code>data</code>
-        containing the changes: the properties of the items that are being updated.
+        items. The <code>update</code> and <code>remove</code> events have an extra
+        field <code>oldData</code> containing the original data of the items in the
+        dataset before the items were updated or removed. The <code>update</code>
+        event also contains a field <code>data</code> containing the changes:
+        the properties of the items that are being updated. 
       </td>
     </tr>
     <tr>

--- a/lib/DataSet.js
+++ b/lib/DataSet.js
@@ -669,14 +669,14 @@ DataSet.prototype._sort = function (items, order) {
 DataSet.prototype.remove = function (id, senderId) {
   var removedIds = [],
       removedItems = [],
+      ids = [],
       i, len, itemId, item;
 
-  if (!Array.isArray(id)) { // force everything to be an array for simplicity
-    id = [id];
-  }
+  // force everything to be an array for simplicity
+  ids = Array.isArray(id) ? id : [id];
 
-  for (i = 0, len = id.length; i < len; i++) {
-    item = this._remove(id[i]);
+  for (i = 0, len = ids.length; i < len; i++) {
+    item = this._remove(ids[i]);
     if (item) {
       itemId = item[this._fieldId];
       if (itemId) {
@@ -685,7 +685,7 @@ DataSet.prototype.remove = function (id, senderId) {
       }
     }
   }
- 
+
   if (removedIds.length) {
     this._trigger('remove', {items: removedIds, oldData: removedItems}, senderId);
   }
@@ -713,8 +713,8 @@ DataSet.prototype._remove = function (id) {
 
   // do the remove if the item is found
   if (ident !== undefined && this._data[ident]) {
-    item = this._data[id];
-    delete this._data[id];
+    item = this._data[ident];
+    delete this._data[ident];
     this.length--;
     return item;
   }

--- a/lib/DataSet.js
+++ b/lib/DataSet.js
@@ -668,25 +668,26 @@ DataSet.prototype._sort = function (items, order) {
  */
 DataSet.prototype.remove = function (id, senderId) {
   var removedIds = [],
-      i, len, removedId;
+      removedItems = [],
+      i, len, itemId, item;
 
-  if (Array.isArray(id)) {
-    for (i = 0, len = id.length; i < len; i++) {
-      removedId = this._remove(id[i]);
-      if (removedId != null) {
-        removedIds.push(removedId);
+  if (!Array.isArray(id)) { // force everything to be an array for simplicity
+    id = [id];
+  }
+
+  for (i = 0, len = id.length; i < len; i++) {
+    item = this._remove(id[i]);
+    if (item) {
+      itemId = item[this._fieldId];
+      if (itemId) {
+        removedIds.push(itemId);
+        removedItems.push(item);
       }
     }
   }
-  else {
-    removedId = this._remove(id);
-    if (removedId != null) {
-      removedIds.push(removedId);
-    }
-  }
-
+ 
   if (removedIds.length) {
-    this._trigger('remove', {items: removedIds}, senderId);
+    this._trigger('remove', {items: removedIds, oldData: removedItems}, senderId);
   }
 
   return removedIds;
@@ -699,20 +700,23 @@ DataSet.prototype.remove = function (id, senderId) {
  * @private
  */
 DataSet.prototype._remove = function (id) {
+  var item,
+      ident;
+
+  // confirm the id to use based on the args type
   if (util.isNumber(id) || util.isString(id)) {
-    if (this._data[id]) {
-      delete this._data[id];
-      this.length--;
-      return id;
-    }
+    ident = id;
   }
   else if (id instanceof Object) {
-    var itemId = id[this._fieldId];
-    if (itemId !== undefined && this._data[itemId]) {
-      delete this._data[itemId];
-      this.length--;
-      return itemId;
-    }
+    ident = id[this._fieldId]; // look for the identifier field using _fieldId
+  }
+
+  // do the remove if the item is found
+  if (ident !== undefined && this._data[ident]) {
+    item = this._data[id];
+    delete this._data[id];
+    this.length--;
+    return item;
   }
   return null;
 };
@@ -723,12 +727,18 @@ DataSet.prototype._remove = function (id) {
  * @return {Array} removedIds    The ids of all removed items
  */
 DataSet.prototype.clear = function (senderId) {
+  var i, len;
   var ids = Object.keys(this._data);
+  var items = [];
+  
+  for (i = 0, len = ids.length; i < len; i++) {
+    items.push(this._data[ids[i]]);
+  }
 
   this._data = {};
   this.length = 0;
 
-  this._trigger('remove', {items: ids}, senderId);
+  this._trigger('remove', {items: ids, oldData: items}, senderId);
 
   return ids;
 };

--- a/lib/DataView.js
+++ b/lib/DataView.js
@@ -35,7 +35,7 @@ function DataView (data, options) {
  * @param {DataSet | DataView} data
  */
 DataView.prototype.setData = function (data) {
-  var ids, id, i, len;
+  var ids, id, i, len, items;
 
   if (this._data) {
     // unsubscribe from current dataset
@@ -44,10 +44,16 @@ DataView.prototype.setData = function (data) {
     }
 
     // trigger a remove of all items in memory
-    ids = Object.keys(this._ids);
+    ids = this._data.getIds({filter: this._options && this._options.filter});
+    items = [];
+
+    for (i = 0, len = ids.length; i < len; i++) {
+      items.push(this._data._data[ids[i]]);
+    }
+
     this._ids = {};
     this.length = 0;
-    this._trigger('remove', {items: ids});
+    this._trigger('remove', {items: ids, oldData: items});
   }
 
   this._data = data;
@@ -80,18 +86,19 @@ DataView.prototype.setData = function (data) {
  */
 DataView.prototype.refresh = function () {
   var id, i, len;
-  var ids = this._data.getIds({filter: this._options && this._options.filter});
-  var oldIds = Object.keys(this._ids);
-  var newIds = {};
-  var added = [];
-  var removed = [];
+  var ids = this._data.getIds({filter: this._options && this._options.filter}),
+      oldIds = Object.keys(this._ids),
+      newIds = {},
+      addedIds = [],
+      removedIds = [],
+      removedItems = [];
 
   // check for additions
   for (i = 0, len = ids.length; i < len; i++) {
     id = ids[i];
     newIds[id] = true;
     if (!this._ids[id]) {
-      added.push(id);
+      addedIds.push(id);
       this._ids[id] = true;
     }
   }
@@ -100,19 +107,20 @@ DataView.prototype.refresh = function () {
   for (i = 0, len = oldIds.length; i < len; i++) {
     id = oldIds[i];
     if (!newIds[id]) {
-      removed.push(id);
+      removedIds.push(id);
+      removedItems.push(this._data[id]);
       delete this._ids[id];
     }
   }
 
-  this.length += added.length - removed.length;
+  this.length += addedIds.length - removedIds.length;
 
   // trigger events
-  if (added.length) {
+  if (addedIds.length) {
     this._trigger('add', {items: added});
   }
-  if (removed.length) {
-    this._trigger('remove', {items: removed});
+  if (removedIds.length) {
+    this._trigger('remove', {items: removedIds, oldData: removedItems});
   }
 };
 
@@ -298,14 +306,14 @@ DataView.prototype.getDataSet = function () {
 DataView.prototype._onEvent = function (event, params, senderId) {
   var i, len, id, item;
   var ids = params && params.items;
-  var data = this._data;
-  var updatedData = [];
-  var oldData = [];
-  var added = [];
-  var updated = [];
-  var removed = [];
+  var addedIds = [],
+      updatedIds = [],
+      removedIds = [],
+      oldItems = [],
+      updatedItems = [],
+      removedItems = [];
 
-  if (ids && data) {
+  if (ids && this._data) {
     switch (event) {
       case 'add':
         // filter the ids of the added items
@@ -314,7 +322,7 @@ DataView.prototype._onEvent = function (event, params, senderId) {
           item = this.get(id);
           if (item) {
             this._ids[id] = true;
-            added.push(id);
+            addedIds.push(id);
           }
         }
 
@@ -329,19 +337,20 @@ DataView.prototype._onEvent = function (event, params, senderId) {
 
           if (item) {
             if (this._ids[id]) {
-              updated.push(id);
-              updatedData.push(params.data[i]);
-              oldData.push(params.oldData[i]);
+              updatedIds.push(id);
+              updatedItems.push(params.data[i]);
+              oldItems.push(params.oldData[i]);
             }
             else {
               this._ids[id] = true;
-              added.push(id);
+              addedIds.push(id);
             }
           }
           else {
             if (this._ids[id]) {
               delete this._ids[id];
-              removed.push(id);
+              removedIds.push(id);
+              removedItems.push(params.oldData[i]);
             }
             else {
               // nothing interesting for me :-(
@@ -357,23 +366,24 @@ DataView.prototype._onEvent = function (event, params, senderId) {
           id = ids[i];
           if (this._ids[id]) {
             delete this._ids[id];
-            removed.push(id);
+            removedIds.push(id);
+            removedItems.push(params.oldData[i]);
           }
         }
 
         break;
     }
 
-    this.length += added.length - removed.length;
+    this.length += addedIds.length - removedIds.length;
 
-    if (added.length) {
-      this._trigger('add', {items: added}, senderId);
+    if (addedIds.length) {
+      this._trigger('add', {items: addedIds}, senderId);
     }
-    if (updated.length) {
-      this._trigger('update', {items: updated, oldData: oldData, data: updatedData}, senderId);
+    if (updatedIds.length) {
+      this._trigger('update', {items: updatedIds, oldData: oldItems, data: updatedItems}, senderId);
     }
-    if (removed.length) {
-      this._trigger('remove', {items: removed}, senderId);
+    if (removedIds.length) {
+      this._trigger('remove', {items: removedIds, oldData: removedItems}, senderId);
     }
   }
 };


### PR DESCRIPTION
The `remove` event that is triggered in DataView and DataSet only includes the ids of the items that were removed, and since the items are no longer available, it is hard to tell what items were removed.

This pr would add an `oldItems` property to the object that is sent with the `remove` event. This is supplementary to the `items` containing the ids to maintain reverse compatibility.

This effects
- Items getting removed from DataSets
- Items getting removed from DataViews
- Clearing a DataSet using `ds.clear()`
- Setting the data for a DataView using `dv.setData()` or when the DataView is created

Also updates the documentation for `dataset` Callback section.