### PR TITLE
Graph3d: make setting dotSizeRatio public

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -898,13 +898,18 @@ Graph3d.prototype._redrawClear = function() {
 };
 
 
+Graph3d.prototype._dotSize = function() {
+return this.frame.clientWidth * this.dotSizeRatio;
+};
+
+
 /**
  * Get legend width 
  */
 Graph3d.prototype._getLegendWidth = function() {
   var width; 
   if (this.style === Graph3d.STYLE.DOTSIZE) {
-    var dotSize = this.frame.clientWidth * this.dotSizeRatio;
+    var dotSize = this._dotSize();
     width =  dotSize / 2 + dotSize * 2; 
   } else if (this.style === Graph3d.STYLE.BARSIZE) {
     width = this.xBarWidth ;
@@ -973,7 +978,7 @@ Graph3d.prototype._redrawLegend = function() {
     // draw the size legend box 
     var  widthMin;
     if (this.style === Graph3d.STYLE.DOTSIZE) { 
-      var  dotSize = this.frame.clientWidth * this.dotSizeRatio;
+      var dotSize = this._dotSize();
       widthMin = dotSize / 2; // px
     } else if (this.style === Graph3d.STYLE.BARSIZE) { 
       //widthMin = this.xBarWidth * 0.2 this is wrong - barwidth measures in terms of xvalues 
@@ -1522,7 +1527,7 @@ Graph3d.prototype._redrawDataDot = function() {
   this._calcTranslations(this.dataPoints);
 
   // draw the datapoints as colored circles
-  var dotSize = this.frame.clientWidth * this.dotSizeRatio;  // px
+  var dotSize = this._dotSize();
   for (i = 0; i < this.dataPoints.length; i++) {
     var point = this.dataPoints[i];
 

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -899,7 +899,7 @@ Graph3d.prototype._redrawClear = function() {
 
 
 Graph3d.prototype._dotSize = function() {
-return this.frame.clientWidth * this.dotSizeRatio;
+  return this.frame.clientWidth * this.dotSizeRatio;
 };
 
 

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -50,6 +50,7 @@ var DEFAULTS = {
   showShadow       : false,
   keepAspectRatio  : true,
   verticalRatio    : 0.5,               // 0.1 to 1.0, where 1.0 results in a 'cube'
+  dotSizeRatio     : 0.02,              // size of the dots as a fraction of the graph width
 
   showAnimationControls: autoByDefault,
   animationInterval    : 1000,          // milliseconds

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -58,6 +58,7 @@ var OPTIONKEYS = [
   'showShadow',
   'keepAspectRatio',
   'verticalRatio',
+  'dotSizeRatio',
   'showAnimationControls',
   'animationInterval',
   'animationPreload',
@@ -220,7 +221,6 @@ function setDefaults(src, dst) {
   dst.margin = 10;                  // px
   dst.showGrayBottom = false;       // TODO: this does not work correctly
   dst.showTooltip = false;
-  dst.dotSizeRatio = 0.02;          // size of the dots as a fraction of the graph width
   dst.eye = new Point3d(0, 0, -1);  // TODO: set eye.z about 3/4 of the width of the window?
 }
 


### PR DESCRIPTION
Oversight. `dotSizeRatio` wasn't public in the code, but the documentation says it is.