### PR TITLE
Added generic graph drawing loop; isolated point drawing of graph style 'Bar'

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -838,8 +838,12 @@ Graph3d.prototype.redraw = function() {
   else if (this.style === Graph3d.STYLE.LINE) {
     this._redrawDataLine();
   }
-  else if (this.style === Graph3d.STYLE.BAR ||
-    this.style === Graph3d.STYLE.BARCOLOR ||
+  else if (this.style === Graph3d.STYLE.BAR) {
+
+    // Pass a method reference here
+    this._redrawDataGraph(Graph3d.prototype._redrawBarGraphPoint);
+
+  } else if (this.style === Graph3d.STYLE.BARCOLOR ||
     this.style === Graph3d.STYLE.BARSIZE) {
     this._redrawDataBar();
   }
@@ -1565,125 +1569,131 @@ Graph3d.prototype._redrawDataDot = function() {
 
 
 /**
- * Draw all datapoints for currently selected graph style.
+ * Draw a bar element in the view with the given properties.
  */
-Graph3d.prototype._redrawDataBar = function() {
-  var ctx = this._getContext();
+Graph3d.prototype._redrawBar = function(ctx, point, xWidth, yWidth, color, borderColor) {
   var i, j, surface, corners;
+
+  // calculate all corner points
+  var me = this;
+  var point3d = point.point;
+  var top = [
+    {point: new Point3d(point3d.x - xWidth, point3d.y - yWidth, point3d.z)},
+    {point: new Point3d(point3d.x + xWidth, point3d.y - yWidth, point3d.z)},
+    {point: new Point3d(point3d.x + xWidth, point3d.y + yWidth, point3d.z)},
+    {point: new Point3d(point3d.x - xWidth, point3d.y + yWidth, point3d.z)}
+  ];
+  var bottom = [
+    {point: new Point3d(point3d.x - xWidth, point3d.y - yWidth, this.zMin)},
+    {point: new Point3d(point3d.x + xWidth, point3d.y - yWidth, this.zMin)},
+    {point: new Point3d(point3d.x + xWidth, point3d.y + yWidth, this.zMin)},
+    {point: new Point3d(point3d.x - xWidth, point3d.y + yWidth, this.zMin)}
+  ];
+
+  // calculate screen location of the points
+  top.forEach(function (obj) {
+    obj.screen = me._convert3Dto2D(obj.point);
+  });
+  bottom.forEach(function (obj) {
+    obj.screen = me._convert3Dto2D(obj.point);
+  });
+
+  // create five sides, calculate both corner points and center points
+  var surfaces = [
+    {corners: top, center: Point3d.avg(bottom[0].point, bottom[2].point)},
+    {corners: [top[0], top[1], bottom[1], bottom[0]], center: Point3d.avg(bottom[1].point, bottom[0].point)},
+    {corners: [top[1], top[2], bottom[2], bottom[1]], center: Point3d.avg(bottom[2].point, bottom[1].point)},
+    {corners: [top[2], top[3], bottom[3], bottom[2]], center: Point3d.avg(bottom[3].point, bottom[2].point)},
+    {corners: [top[3], top[0], bottom[0], bottom[3]], center: Point3d.avg(bottom[0].point, bottom[3].point)}
+  ];
+  point.surfaces = surfaces;
+
+  // calculate the distance of each of the surface centers to the camera
+  for (j = 0; j < surfaces.length; j++) {
+    surface = surfaces[j];
+    var transCenter = this._convertPointToTranslation(surface.center);
+    surface.dist = this.showPerspective ? transCenter.length() : -transCenter.z;
+    // TODO: this dept calculation doesn't work 100% of the cases due to perspective,
+    //     but the current solution is fast/simple and works in 99.9% of all cases
+    //     the issue is visible in example 14, with graph.setCameraPosition({horizontal: 2.97, vertical: 0.5, distance: 0.9})
+  }
+
+  // order the surfaces by their (translated) depth
+  surfaces.sort(function (a, b) {
+    var diff = b.dist - a.dist;
+    if (diff) return diff;
+
+    // if equal depth, sort the top surface last
+    if (a.corners === top) return 1;
+    if (b.corners === top) return -1;
+
+    // both are equal
+    return 0;
+  });
+
+  // draw the ordered surfaces
+  ctx.lineWidth = this._getStrokeWidth(point);
+  ctx.strokeStyle = borderColor;
+  ctx.fillStyle = color;
+  // NOTE: we start at j=2 instead of j=0 as we don't need to draw the two surfaces at the backside
+  for (j = 2; j < surfaces.length; j++) {
+    surface = surfaces[j];
+    corners = surface.corners;
+    ctx.beginPath();
+    ctx.moveTo(corners[3].screen.x, corners[3].screen.y);
+    ctx.lineTo(corners[0].screen.x, corners[0].screen.y);
+    ctx.lineTo(corners[1].screen.x, corners[1].screen.y);
+    ctx.lineTo(corners[2].screen.x, corners[2].screen.y);
+    ctx.lineTo(corners[3].screen.x, corners[3].screen.y);
+    ctx.fill();
+    ctx.stroke();
+  }
+};
+
+
+/**
+ * Draw single datapoint for graph style 'Bar'.
+ */
+Graph3d.prototype._redrawBarGraphPoint = function(ctx, point) {
+  var i, j, surface, corners;
+
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+
+  var xWidth = this.xBarWidth / 2;
+  var yWidth = this.yBarWidth / 2;
+
+
+  // determine color
+  var hue, color, borderColor;
+  // calculate Hue from the current value. At zMin the hue is 240, at zMax the hue is 0
+  hue = (1 - (point.point.z - this.zMin) * this.scale.z  / this.verticalRatio) * 240;
+  color = this._hsv2rgb(hue, 1, 1);
+  borderColor = this._hsv2rgb(hue, 1, 0.8);
+
+  this._redrawBar(ctx, point, xWidth, yWidth, color, borderColor);
+};
+
+
+/**
+ * Draw all datapoints for currently selected graph style.
+ *
+ * @param pointDrawMethod - method reference to draw a point in a specific graph style.
+ */
+Graph3d.prototype._redrawDataGraph = function(pointDrawMethod) {
+  var ctx = this._getContext();
+  var i;
 
   if (this.dataPoints === undefined || this.dataPoints.length <= 0)
     return;  // TODO: throw exception?
 
   this._calcTranslations(this.dataPoints);
 
-  ctx.lineJoin = 'round';
-  ctx.lineCap = 'round';
-
-  // draw the datapoints as bars
-  var xWidth = this.xBarWidth / 2;
-  var yWidth = this.yBarWidth / 2;
   for (i = 0; i < this.dataPoints.length; i++) {
     var point = this.dataPoints[i];
 
-    // determine color
-    var hue, color, borderColor;
-    if (this.style === Graph3d.STYLE.BARCOLOR ) {
-      // calculate the color based on the value
-      hue = (1 - (point.point.value - this.valueMin) * this.scale.value) * 240;
-      color = this._hsv2rgb(hue, 1, 1);
-      borderColor = this._hsv2rgb(hue, 1, 0.8);
-    }
-    else if (this.style === Graph3d.STYLE.BARSIZE) {
-      color = this.dataColor.fill;
-      borderColor = this.dataColor.stroke;
-    }
-    else {
-      // calculate Hue from the current value. At zMin the hue is 240, at zMax the hue is 0
-      hue = (1 - (point.point.z - this.zMin) * this.scale.z  / this.verticalRatio) * 240;
-      color = this._hsv2rgb(hue, 1, 1);
-      borderColor = this._hsv2rgb(hue, 1, 0.8);
-    }
-
-    // calculate size for the bar
-    if (this.style === Graph3d.STYLE.BARSIZE) {
-      xWidth = (this.xBarWidth / 2) * ((point.point.value - this.valueMin) / (this.valueMax - this.valueMin) * 0.8 + 0.2);
-      yWidth = (this.yBarWidth / 2) * ((point.point.value - this.valueMin) / (this.valueMax - this.valueMin) * 0.8 + 0.2);
-    }
-
-    // calculate all corner points
-    var me = this;
-    var point3d = point.point;
-    var top = [
-      {point: new Point3d(point3d.x - xWidth, point3d.y - yWidth, point3d.z)},
-      {point: new Point3d(point3d.x + xWidth, point3d.y - yWidth, point3d.z)},
-      {point: new Point3d(point3d.x + xWidth, point3d.y + yWidth, point3d.z)},
-      {point: new Point3d(point3d.x - xWidth, point3d.y + yWidth, point3d.z)}
-    ];
-    var bottom = [
-      {point: new Point3d(point3d.x - xWidth, point3d.y - yWidth, this.zMin)},
-      {point: new Point3d(point3d.x + xWidth, point3d.y - yWidth, this.zMin)},
-      {point: new Point3d(point3d.x + xWidth, point3d.y + yWidth, this.zMin)},
-      {point: new Point3d(point3d.x - xWidth, point3d.y + yWidth, this.zMin)}
-    ];
-
-    // calculate screen location of the points
-    top.forEach(function (obj) {
-      obj.screen = me._convert3Dto2D(obj.point);
-    });
-    bottom.forEach(function (obj) {
-      obj.screen = me._convert3Dto2D(obj.point);
-    });
-
-    // create five sides, calculate both corner points and center points
-    var surfaces = [
-      {corners: top, center: Point3d.avg(bottom[0].point, bottom[2].point)},
-      {corners: [top[0], top[1], bottom[1], bottom[0]], center: Point3d.avg(bottom[1].point, bottom[0].point)},
-      {corners: [top[1], top[2], bottom[2], bottom[1]], center: Point3d.avg(bottom[2].point, bottom[1].point)},
-      {corners: [top[2], top[3], bottom[3], bottom[2]], center: Point3d.avg(bottom[3].point, bottom[2].point)},
-      {corners: [top[3], top[0], bottom[0], bottom[3]], center: Point3d.avg(bottom[0].point, bottom[3].point)}
-    ];
-    point.surfaces = surfaces;
-
-    // calculate the distance of each of the surface centers to the camera
-    for (j = 0; j < surfaces.length; j++) {
-      surface = surfaces[j];
-      var transCenter = this._convertPointToTranslation(surface.center);
-      surface.dist = this.showPerspective ? transCenter.length() : -transCenter.z;
-      // TODO: this dept calculation doesn't work 100% of the cases due to perspective,
-      //     but the current solution is fast/simple and works in 99.9% of all cases
-      //     the issue is visible in example 14, with graph.setCameraPosition({horizontal: 2.97, vertical: 0.5, distance: 0.9})
-    }
-
-    // order the surfaces by their (translated) depth
-    surfaces.sort(function (a, b) {
-      var diff = b.dist - a.dist;
-      if (diff) return diff;
-
-      // if equal depth, sort the top surface last
-      if (a.corners === top) return 1;
-      if (b.corners === top) return -1;
-
-      // both are equal
-      return 0;
-    });
-
-    // draw the ordered surfaces
-    ctx.lineWidth = this._getStrokeWidth(point);
-    ctx.strokeStyle = borderColor;
-    ctx.fillStyle = color;
-    // NOTE: we start at j=2 instead of j=0 as we don't need to draw the two surfaces at the backside
-    for (j = 2; j < surfaces.length; j++) {
-      surface = surfaces[j];
-      corners = surface.corners;
-      ctx.beginPath();
-      ctx.moveTo(corners[3].screen.x, corners[3].screen.y);
-      ctx.lineTo(corners[0].screen.x, corners[0].screen.y);
-      ctx.lineTo(corners[1].screen.x, corners[1].screen.y);
-      ctx.lineTo(corners[2].screen.x, corners[2].screen.y);
-      ctx.lineTo(corners[3].screen.x, corners[3].screen.y);
-      ctx.fill();
-      ctx.stroke();
-    }
+    // Using call() ensures that the correct context is used
+    pointDrawMethod.call(this, ctx, point);
   }
 };
 
@@ -1709,6 +1719,8 @@ Graph3d.prototype._redrawDataBar = function() {
   var yWidth = this.yBarWidth / 2;
   for (i = 0; i < this.dataPoints.length; i++) {
     var point = this.dataPoints[i];
+
+    // TODO: Remove code for style `Bar` here - it has been refactored to separate routine
 
     // determine color
     var hue, color, borderColor;

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -831,25 +831,34 @@ Graph3d.prototype.redraw = function() {
   this._redrawClear();
   this._redrawAxis();
 
-  if (this.style === Graph3d.STYLE.GRID ||
-    this.style === Graph3d.STYLE.SURFACE) {
-    this._redrawDataGrid();
+  var pointDrawingMethod = undefined;
+  switch (this.style) {
+    case Graph3d.STYLE.BAR:
+      pointDrawingMethod = Graph3d.prototype._redrawBarGraphPoint;
+      break;
   }
-  else if (this.style === Graph3d.STYLE.LINE) {
-    this._redrawDataLine();
-  }
-  else if (this.style === Graph3d.STYLE.BAR) {
 
-    // Pass a method reference here
-    this._redrawDataGraph(Graph3d.prototype._redrawBarGraphPoint);
+  if (pointDrawingMethod !== undefined) {
+    // Use generic drawing loop
+    // Pass the method reference here
+    this._redrawDataGraph(pointDrawingMethod);
+  } else {
+    // Use the old style drawing methods
 
-  } else if (this.style === Graph3d.STYLE.BARCOLOR ||
-    this.style === Graph3d.STYLE.BARSIZE) {
-    this._redrawDataBar();
-  }
-  else {
-    // style is DOT, DOTLINE, DOTCOLOR, DOTSIZE
-    this._redrawDataDot();
+    if (this.style === Graph3d.STYLE.GRID ||
+      this.style === Graph3d.STYLE.SURFACE) {
+      this._redrawDataGrid();
+    }
+    else if (this.style === Graph3d.STYLE.LINE) {
+      this._redrawDataLine();
+    } else if (this.style === Graph3d.STYLE.BARCOLOR ||
+      this.style === Graph3d.STYLE.BARSIZE) {
+      this._redrawDataBar();
+    }
+    else {
+      // style is DOT, DOTLINE, DOTCOLOR, DOTSIZE
+      this._redrawDataDot();
+    }
   }
 
   this._redrawInfo();

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1588,6 +1588,131 @@ Graph3d.prototype._redrawDataDot = function() {
   }
 };
 
+
+/**
+ * Draw all datapoints for currently selected graph style.
+ */
+Graph3d.prototype._redrawDataBar = function() {
+  var ctx = this._getContext();
+  var i, j, surface, corners;
+
+  if (this.dataPoints === undefined || this.dataPoints.length <= 0)
+    return;  // TODO: throw exception?
+
+  this._calcTranslations(this.dataPoints);
+
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+
+  // draw the datapoints as bars
+  var xWidth = this.xBarWidth / 2;
+  var yWidth = this.yBarWidth / 2;
+  for (i = 0; i < this.dataPoints.length; i++) {
+    var point = this.dataPoints[i];
+
+    // determine color
+    var hue, color, borderColor;
+    if (this.style === Graph3d.STYLE.BARCOLOR ) {
+      // calculate the color based on the value
+      hue = (1 - (point.point.value - this.valueMin) * this.scale.value) * 240;
+      color = this._hsv2rgb(hue, 1, 1);
+      borderColor = this._hsv2rgb(hue, 1, 0.8);
+    }
+    else if (this.style === Graph3d.STYLE.BARSIZE) {
+      color = this.dataColor.fill;
+      borderColor = this.dataColor.stroke;
+    }
+    else {
+      // calculate Hue from the current value. At zMin the hue is 240, at zMax the hue is 0
+      hue = (1 - (point.point.z - this.zMin) * this.scale.z  / this.verticalRatio) * 240;
+      color = this._hsv2rgb(hue, 1, 1);
+      borderColor = this._hsv2rgb(hue, 1, 0.8);
+    }
+
+    // calculate size for the bar
+    if (this.style === Graph3d.STYLE.BARSIZE) {
+      xWidth = (this.xBarWidth / 2) * ((point.point.value - this.valueMin) / (this.valueMax - this.valueMin) * 0.8 + 0.2);
+      yWidth = (this.yBarWidth / 2) * ((point.point.value - this.valueMin) / (this.valueMax - this.valueMin) * 0.8 + 0.2);
+    }
+
+    // calculate all corner points
+    var me = this;
+    var point3d = point.point;
+    var top = [
+      {point: new Point3d(point3d.x - xWidth, point3d.y - yWidth, point3d.z)},
+      {point: new Point3d(point3d.x + xWidth, point3d.y - yWidth, point3d.z)},
+      {point: new Point3d(point3d.x + xWidth, point3d.y + yWidth, point3d.z)},
+      {point: new Point3d(point3d.x - xWidth, point3d.y + yWidth, point3d.z)}
+    ];
+    var bottom = [
+      {point: new Point3d(point3d.x - xWidth, point3d.y - yWidth, this.zMin)},
+      {point: new Point3d(point3d.x + xWidth, point3d.y - yWidth, this.zMin)},
+      {point: new Point3d(point3d.x + xWidth, point3d.y + yWidth, this.zMin)},
+      {point: new Point3d(point3d.x - xWidth, point3d.y + yWidth, this.zMin)}
+    ];
+
+    // calculate screen location of the points
+    top.forEach(function (obj) {
+      obj.screen = me._convert3Dto2D(obj.point);
+    });
+    bottom.forEach(function (obj) {
+      obj.screen = me._convert3Dto2D(obj.point);
+    });
+
+    // create five sides, calculate both corner points and center points
+    var surfaces = [
+      {corners: top, center: Point3d.avg(bottom[0].point, bottom[2].point)},
+      {corners: [top[0], top[1], bottom[1], bottom[0]], center: Point3d.avg(bottom[1].point, bottom[0].point)},
+      {corners: [top[1], top[2], bottom[2], bottom[1]], center: Point3d.avg(bottom[2].point, bottom[1].point)},
+      {corners: [top[2], top[3], bottom[3], bottom[2]], center: Point3d.avg(bottom[3].point, bottom[2].point)},
+      {corners: [top[3], top[0], bottom[0], bottom[3]], center: Point3d.avg(bottom[0].point, bottom[3].point)}
+    ];
+    point.surfaces = surfaces;
+
+    // calculate the distance of each of the surface centers to the camera
+    for (j = 0; j < surfaces.length; j++) {
+      surface = surfaces[j];
+      var transCenter = this._convertPointToTranslation(surface.center);
+      surface.dist = this.showPerspective ? transCenter.length() : -transCenter.z;
+      // TODO: this dept calculation doesn't work 100% of the cases due to perspective,
+      //     but the current solution is fast/simple and works in 99.9% of all cases
+      //     the issue is visible in example 14, with graph.setCameraPosition({horizontal: 2.97, vertical: 0.5, distance: 0.9})
+    }
+
+    // order the surfaces by their (translated) depth
+    surfaces.sort(function (a, b) {
+      var diff = b.dist - a.dist;
+      if (diff) return diff;
+
+      // if equal depth, sort the top surface last
+      if (a.corners === top) return 1;
+      if (b.corners === top) return -1;
+
+      // both are equal
+      return 0;
+    });
+
+    // draw the ordered surfaces
+    ctx.lineWidth = this._getStrokeWidth(point);
+    ctx.strokeStyle = borderColor;
+    ctx.fillStyle = color;
+    // NOTE: we start at j=2 instead of j=0 as we don't need to draw the two surfaces at the backside
+    for (j = 2; j < surfaces.length; j++) {
+      surface = surfaces[j];
+      corners = surface.corners;
+      ctx.beginPath();
+      ctx.moveTo(corners[3].screen.x, corners[3].screen.y);
+      ctx.lineTo(corners[0].screen.x, corners[0].screen.y);
+      ctx.lineTo(corners[1].screen.x, corners[1].screen.y);
+      ctx.lineTo(corners[2].screen.x, corners[2].screen.y);
+      ctx.lineTo(corners[3].screen.x, corners[3].screen.y);
+      ctx.fill();
+      ctx.stroke();
+    }
+  }
+};
+
+
 /**
  * Draw all datapoints as bars.
  * This function can be used when the style is 'bar', 'bar-color', or 'bar-size'


### PR DESCRIPTION
## Redo of PR #2205, which I messed up in a very bad way.
I hope this is good now.

All graph drawing routines follow the following structure:

```js
Graph3d.prototype._redrawGraph = function() {
  var ctx = this._getContext()

  if (this.dataPoints === undefined || this.dataPoints.length <= 0)
    return; // TODO: throw exception?

  this._calcTranslations(this.dataPoints);

  for (i = 0; i < this.dataPoints.length; i++) {
    point = this.dataPoints[i];

    // Draw data point here
  }
};

```

It is possible to consolidate this loop and move graph-style specific point drawing
to separate routines. This PR shows how that will look like; I've done only a single
graph style (`Bar`) to illustrate this.

Changes:

- made generic routine `_redrawDataGraph()`, usable for all graph styles.
- made specific routine `_redrawBarGraphPoint()`, which draws a single point for style `Bar`
- as an extra, isolated the bar drawing code in `_redrawBar()`, so it can be reused.
- in method `redraw()`, pass `_redrawBarGraphPoint` as a reference to `_redrawDataGraph()`

The idea is:

- to make the drawing loop generic for all graph styles
- isolate the drawing of points for specific graph style in separate methods.
- do this for *all* present graph styles.

# Notes

**1.** This is a **very important update** in regard to handling multiple graphs in a view.
The reason is that the elements of the multiple graphs will need to be drawn together at the same time, so that the overlap of the various elements are correct in the view.

**2.** I would much rather prefer to use *graph-style specific classes* here, instead of passing
a point-drawing method.
However, I fully appreciate that implementing that in one go will be a 'Big Bang' change
which is totally unoverseeable for reviewing. For this reason, I am offering the changes in smaller,
bite-size chunks. The classes will have to wait.
