### PR TITLE
Fix background items with no groups

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -502,8 +502,7 @@ Group.prototype.order = function() {
 Group.prototype._updateVisibleItems = function(orderedItems, oldVisibleItems, range) {
   var visibleItems = [];
   var visibleItemsLookup = {}; // we keep this to quickly look up if an item already exists in the list without using indexOf on visibleItems
-   
-  if (!this.isVisible) {
+  if (!this.isVisible && this.groupId != "__background__") {
     for (var i = 0; i < oldVisibleItems.length; i++) {
       var item = oldVisibleItems[i];
       if (item.displayed) item.hide();
@@ -556,7 +555,6 @@ Group.prototype._updateVisibleItems = function(orderedItems, oldVisibleItems, ra
       return (item.data.end < lowerBound || item.data.end > upperBound);
     });
   }
-
 
   // finally, we reposition all the visible items.
   for (var i = 0; i < visibleItems.length; i++) {


### PR DESCRIPTION
Backgrounds with no groups were not displayed because of a"group.isVisible" check so I had to fix to check that the visibility check is only applied to groups that are not `__background__` groups