### PR TITLE
generate details source maps of webpack modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,7 +72,11 @@ var webpackConfig = {
   },
   module: webpackModule,
   plugins: [ bannerPlugin ],
-  cache: true
+  cache: true,
+
+  // generate details sourcempas of webpack modules
+  devtool: 'source-map'
+
   //debug: true,
   //bail: true
 };


### PR DESCRIPTION
This sourcemaps really help during development. Here a screenshot how it looks in the chrome dev-tools:

![image](https://cloud.githubusercontent.com/assets/600565/19832527/d64382d0-9e25-11e6-8e9b-6060bb916d8d.png)

But we should talk about if we want to remove the big map file from the distribution ZIP when building a release. What do you think?