### PR TITLE
Timeline: options.editable to override item.editable

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1199,8 +1199,7 @@ ItemSet.prototype._onDragStart = function (event) {
   if (item && (item.selected || this.options.itemsAlwaysDraggable)) {
 
     if (!this.options.editable.updateTime &&
-        !this.options.editable.updateGroup &&
-        !item.editable) {
+        !this.options.editable.updateGroup) {
       return;
     }
 

--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -146,8 +146,7 @@ Item.prototype.repositionY = function() {
  * @protected
  */
 Item.prototype._repaintDeleteButton = function (anchor) {
-  var editable = (this.options.editable.remove || 
-                  this.data.editable === true) &&
+  var editable = this.options.editable.remove &&
                  this.data.editable !== false;
 
   if (this.selected && editable && !this.dom.deleteButton) {


### PR DESCRIPTION
Removed redundant checks for item.editable. These checks cause the editable attribute of each item to override the timeline editable options. Applications that use timeline editable options to toggle between view and edit "modes" while maintaining partial edibility determined by item.editable need the converse to be true.