### PR TITLE
jump back to overview if directory is viewed

### DIFF
--- a/examples/graph2d/index.html
+++ b/examples/graph2d/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../graph3d_examples.html">
+</head>
+<body>
+  <a href="../../graph3d_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/graph3d/index.html
+++ b/examples/graph3d/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../graph3d_examples.html">
+</head>
+<body>
+  <a href="../../graph3d_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../#modules">
+</head>
+<body>
+  <a href="../#modules">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/data/index.html
+++ b/examples/network/data/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/datasources/index.html
+++ b/examples/network/datasources/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/edgeStyles/index.html
+++ b/examples/network/edgeStyles/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/events/index.html
+++ b/examples/network/events/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/exampleApplications/index.html
+++ b/examples/network/exampleApplications/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/img/index.html
+++ b/examples/network/img/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/index.html
+++ b/examples/network/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../network_examples.html">
+</head>
+<body>
+  <a href="../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/labels/index.html
+++ b/examples/network/labels/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/layout/index.html
+++ b/examples/network/layout/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/nodeStyles/index.html
+++ b/examples/network/nodeStyles/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/other/index.html
+++ b/examples/network/other/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/network/physics/index.html
+++ b/examples/network/physics/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../network_examples.html">
+</head>
+<body>
+  <a href="../../../network_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/dataHandling/index.html
+++ b/examples/timeline/dataHandling/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/editing/index.html
+++ b/examples/timeline/editing/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/groups/index.html
+++ b/examples/timeline/groups/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/index.html
+++ b/examples/timeline/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/interaction/index.html
+++ b/examples/timeline/interaction/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/items/index.html
+++ b/examples/timeline/items/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/other/index.html
+++ b/examples/timeline/other/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/resources/index.html
+++ b/examples/timeline/resources/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>

--- a/examples/timeline/styling/index.html
+++ b/examples/timeline/styling/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=../../../timeline_examples.html">
+</head>
+<body>
+  <a href="../../../timeline_examples.html">Back to overview...</a></p>
+</body>
+</html>


### PR DESCRIPTION
If you try to access a directory e.g. http://visjs.org/examples/ a 404 error appears. With this PR requests are being redirected to the fitting Overview-Page. 

Because gh-pages does not support `.htaccess` files, I've created hard-coded redirects.
In the future this is better done using [Jekylls Redirect plugin](https://help.github.com/articles/redirects-on-github-pages/).