### PR TITLE
Added option 'selectEvent' for Timeline.prototype.setSelection

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1322,7 +1322,7 @@ document.getElementById('myTimeline').onclick = function (event) {
           <li><code>focus: boolean</code><br>If true, focus will be set to the selected item(s)</li>
           <li><code>animation: boolean or {duration: number, easingFunction: string}</code><br>If true (default) or an Object, the range is animated smoothly to the new window. An object can be provided to specify duration and easing function. Default duration is 500 ms, and default easing function is <code>'easeInOutQuad'</code>. Only applicable when option focus is true. Available easing functions: <code>"linear"</code>, <code>"easeInQuad"</code>, <code>"easeOutQuad"</code>, <code>"easeInOutQuad"</code>, <code>"easeInCubic"</code>, <code>"easeOutCubic"</code>, <code>"easeInOutCubic"</code>, <code>"easeInQuart"</code>, <code>"easeOutQuart"</code>, <code>"easeInOutQuart"</code>, <code>"easeInQuint"</code>, <code>"easeOutQuint"</code>, <code>"easeInOutQuint"</code>.</li>
           <li><code>emitSelectEvent: Event</code><br>Call the select event manually to make sure the selected items will be highlighted in the timeline</li>
-		</ul>
+        </ul>
       </td>
     </tr>
 

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1321,7 +1321,8 @@ document.getElementById('myTimeline').onclick = function (event) {
         <ul>
           <li><code>focus: boolean</code><br>If true, focus will be set to the selected item(s)</li>
           <li><code>animation: boolean or {duration: number, easingFunction: string}</code><br>If true (default) or an Object, the range is animated smoothly to the new window. An object can be provided to specify duration and easing function. Default duration is 500 ms, and default easing function is <code>'easeInOutQuad'</code>. Only applicable when option focus is true. Available easing functions: <code>"linear"</code>, <code>"easeInQuad"</code>, <code>"easeOutQuad"</code>, <code>"easeInOutQuad"</code>, <code>"easeInCubic"</code>, <code>"easeOutCubic"</code>, <code>"easeInOutCubic"</code>, <code>"easeInQuart"</code>, <code>"easeOutQuart"</code>, <code>"easeInOutQuart"</code>, <code>"easeInQuint"</code>, <code>"easeOutQuint"</code>, <code>"easeInOutQuint"</code>.</li>
-        </ul>
+		  <li><code>emitSelectEvent: Event</code><br>Call the select event manually to make sure the selected items will be highlighted in the timeline</li>
+		</ul>
       </td>
     </tr>
 

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1321,7 +1321,7 @@ document.getElementById('myTimeline').onclick = function (event) {
         <ul>
           <li><code>focus: boolean</code><br>If true, focus will be set to the selected item(s)</li>
           <li><code>animation: boolean or {duration: number, easingFunction: string}</code><br>If true (default) or an Object, the range is animated smoothly to the new window. An object can be provided to specify duration and easing function. Default duration is 500 ms, and default easing function is <code>'easeInOutQuad'</code>. Only applicable when option focus is true. Available easing functions: <code>"linear"</code>, <code>"easeInQuad"</code>, <code>"easeOutQuad"</code>, <code>"easeInOutQuad"</code>, <code>"easeInCubic"</code>, <code>"easeOutCubic"</code>, <code>"easeInOutCubic"</code>, <code>"easeInQuart"</code>, <code>"easeOutQuart"</code>, <code>"easeInOutQuart"</code>, <code>"easeInQuint"</code>, <code>"easeOutQuint"</code>, <code>"easeInOutQuint"</code>.</li>
-		  <li><code>emitSelectEvent: Event</code><br>Call the select event manually to make sure the selected items will be highlighted in the timeline</li>
+          <li><code>emitSelectEvent: Event</code><br>Call the select event manually to make sure the selected items will be highlighted in the timeline</li>
 		</ul>
       </td>
     </tr>

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -313,7 +313,7 @@ Timeline.prototype.setSelection = function(ids, options) {
     this.focus(ids, options);
   } else if (options && options.emitSelectEvent) {
     var newSelection = this.itemSet.getSelection();
-	// either the new selection has items or the old one has
+    // either the new selection has items or the old one has
     if (newSelection.length > 0 || oldSelection.length > 0) {
       // emit select event
       this.body.emitter.emit('select', {

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -318,7 +318,7 @@ Timeline.prototype.setSelection = function(ids, options) {
       // emit select event
       this.body.emitter.emit('select', {
         items: newSelection,
-        event: emitSelectEvent
+        event: options.emitSelectEvent
       });
     }
   }

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -301,10 +301,10 @@ Timeline.prototype.setData = function (data) {
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
  *                                    Only applicable when option focus is true.
- *								  `selectEvent: Event`
- *									  Call the select event manually to make sure the selected items
- *									  will be highlighted in the timeline. Specific use for JQuery-
- *									  drag&drop of timelime items when using IE11.
+ *                                `selectEvent: Event`
+ *                                    Call the select event manually to make sure the selected items
+ *                                    will be highlighted in the timeline. Specific use for JQuery-
+ *                                    drag&drop of timelime items when using IE11.
  */
 Timeline.prototype.setSelection = function(ids, options) {
   var oldSelection = [];

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -301,10 +301,9 @@ Timeline.prototype.setData = function (data) {
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
  *                                    Only applicable when option focus is true.
- *                                `selectEvent: Event`
+ *                                `emitSelectEvent: Event`
  *                                    Call the select event manually to make sure the selected items
- *                                    will be highlighted in the timeline. Specific use for JQuery-
- *                                    drag&drop of timelime items when using IE11.
+ *                                    will be highlighted in the timeline.
  */
 Timeline.prototype.setSelection = function(ids, options) {
   var oldSelection = [];
@@ -312,14 +311,14 @@ Timeline.prototype.setSelection = function(ids, options) {
 
   if (options && options.focus) {
     this.focus(ids, options);
-  } else if (options && options.selectEvent) {
+  } else if (options && options.emitSelectEvent) {
     var newSelection = this.itemSet.getSelection();
 	// either the new selection has items or the old one has
     if (newSelection.length > 0 || oldSelection.length > 0) {
       // emit select event
       this.body.emitter.emit('select', {
         items: newSelection,
-        event: event
+        event: emitSelectEvent
       });
     }
   }

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -301,12 +301,27 @@ Timeline.prototype.setData = function (data) {
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
  *                                    Only applicable when option focus is true.
+ *								  `selectEvent: Event`
+ *									  Call the select event manually to make sure the selected items
+ *									  will be highlighted in the timeline. Specific use for JQuery-
+ *									  drag&drop of timelime items when using IE11.
  */
 Timeline.prototype.setSelection = function(ids, options) {
-  this.itemSet && this.itemSet.setSelection(ids);
+  var oldSelection = [];
+  this.itemSet && (oldSelection = this.itemSet.getSelection()) && this.itemSet.setSelection(ids);
 
   if (options && options.focus) {
     this.focus(ids, options);
+  } else if (options && options.selectEvent) {
+    var newSelection = this.itemSet.getSelection();
+	// either the new selection has items or the old one has
+    if (newSelection.length > 0 || oldSelection.length > 0) {
+      // emit select event
+      this.body.emitter.emit('select', {
+        items: newSelection,
+        event: event
+      });
+    }
   }
 };
 


### PR DESCRIPTION
When using multiple timelines with JQuery drag&drop in IE11 there occurs a problem that prevents the drag&drop events to be fired. To make JQuery drag&drop work, the 'pointerdown' event must be stopped for each item in the timeline. When calling 'event.stopPropagation()' JQuery drag&drop works, but the selection of items does not work any more. 
This PR adds an option to the setSelection-function of the Timeline-prototype that allows to call the select-event manually when the pointerdown-event-propagation was stopped.

The following code shows how to 'disable' the pointerdown-event and use the setSelection-function with the added option.

```javascript
for (var prop in myTimeline.itemSet.items) {
  if (myTimeline.itemSet.items[prop].dom &&
    myTimeline.itemSet.items[prop].dom.box) {
      var item = $(myTimeline.itemSet.items[prop].dom.box);
      var itemData = myTimeline.itemSet.items[prop].data;
      //  IE11-fix: prevent the timeline from canceling the event
      if (IsMicrosoftInternetExplorer) {
        item.on("pointerdown", function (event) {
          event.stopPropagation();
        });
        //  this re-enables selecting items
        item.on("click", function (event) {
          var clicked = $(event.currentTarget);
          var id = clicked.data("id");
          myTimeline.setSelection([id], { selectEvent: event });
        });
      }
      //  enable drag for items
      if (item.is("your selector here")) {
        item.draggable({
          axis: "y",
          revert: "invalid",
          revertDuration: 150,
          scroll: false,
          helper: "clone",
          appendTo: "body",
          drag: function (event, ui) {
            event.stopImmediatePropagation();
          },
          stop: function (event, ui) {
            event.stopImmediatePropagation();
          }
        });
      }
    }
}
//  create dropzone for another timeline
$(myTimeline2.body.dom.centerContainer).droppable({
  tolerance: "pointer",
  accept: "your selector here",
  hoverClass: "...",
  greedy: true,
  drop: function (event, ui) {
    //  your drop function
  }
});
```

Please note this is a very specific solution for a very specific problem. It does not solve the problem of dragging items of one timeline onto another but only fixes a side-effect that occurs when using JQuery drag&drop with the timeline.