### PR TITLE
Update index.html of Graph3D documentation

### DIFF
--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -364,13 +364,13 @@ var options = {
       <td>dataColor.fill</td>
       <td>string</td>
       <td>'#7DC1FF'</td>
-      <td>The border color of the dots or bars. Applicable when using styles <code>dot-size</code> or <code>bar-size</code>.</td>
+      <td>The fill color of the dots or bars. Applicable when using styles <code>dot-size</code>, <code>bar-size</code>, or <code>line</code>.</td>   
     </tr>
     <tr>
       <td>dataColor.stroke</td>
       <td>string</td>
       <td>'#3267D2'</td>
-      <td>The fill color of the dots or bars. Applicable when using styles <code>dot-size</code>, <code>bar-size</code>, or <code>line</code>.</td>
+      <td>The border color of the dots or bars. Applicable when using styles <code>dot-size</code> or <code>bar-size</code>.</td>
     </tr>
     <tr>
       <td>dataColor.strokeWidth</td>


### PR DESCRIPTION
There was a small mistake - dataColor.fill and dataColor.stroke had wrong descriptions.