### PR TITLE
Fix axis not displayed after daylight saving

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -216,7 +216,17 @@ TimeStep.prototype.next = function() {
       case 'millisecond':  this.current.add(this.step, 'millisecond'); break;
       case 'second':       this.current.add(this.step, 'second'); break;
       case 'minute':       this.current.add(this.step, 'minute'); break;
-      case 'hour':         this.current.add(this.step, 'hour'); break;
+      case 'hour':
+        this.current.add(this.moment.duration(this.step, 'hour'));
+
+        // correct for daylight saving
+        // FIXME: use this.current.add(moment.duration(this.step, 'hour'))
+        // see http://momentjs.com/docs/#special-considerations-for-months-and-years
+        if (this.current.hours() % this.step !== 0) {
+          this.current.add(this.step - this.current.hours() % this.step, 'hour');
+        }
+
+        break;
       case 'weekday':      // intentional fall through
       case 'day':          this.current.add(this.step, 'day'); break;
       case 'month':        this.current.add(this.step, 'month'); break;
@@ -228,10 +238,10 @@ TimeStep.prototype.next = function() {
   if (this.step != 1) {
     // round down to the correct major value
     switch (this.scale) {
-      case 'millisecond':  if(this.current.milliseconds() < this.step) this.current.milliseconds(0);  break;
-      case 'second':       if(this.current.seconds() < this.step) this.current.seconds(0);  break;
-      case 'minute':       if(this.current.minutes() < this.step) this.current.minutes(0);  break;
-      case 'hour':         if(this.current.hours() < this.step) this.current.hours(0);  break;
+      case 'millisecond':  if(this.current.milliseconds() > 0 && this.current.milliseconds() < this.step) this.current.milliseconds(0);  break;
+      case 'second':       if(this.current.seconds() > 0 && this.current.seconds() < this.step) this.current.seconds(0);  break;
+      case 'minute':       if(this.current.minutes() > 0 && this.current.minutes() < this.step) this.current.minutes(0); break;
+      case 'hour':         if(this.current.hours() > 0 && this.current.hours() < this.step) this.current.hours(0);  break;
       case 'weekday':      // intentional fall through
       case 'day':          if(this.current.date() < this.step+1) this.current.date(1); break;
       case 'month':        if(this.current.month() < this.step) this.current.month(0);  break;


### PR DESCRIPTION
@mojoaxel can you have a look at this PR?

It fixes #2251. 

It's a bit of a workaround, it should be able to solve this by using moment.duration (see moment.js docs: http://momentjs.com/docs/#special-considerations-for-months-and-years), but I couldn't get that working so far.

With this fix, the axis will be displayed again after daylight saving switch:

![image](https://cloud.githubusercontent.com/assets/568626/20142452/14718706-a695-11e6-9698-d9a45387af87.png)

What's not yet very nice is that the hour 2 o clock is displayed twice (empty space would be more neat I think):

![image](https://cloud.githubusercontent.com/assets/568626/20142503/4845888e-a695-11e6-938b-90ac81145a40.png)


