### PR TITLE
Timeline: updated group.content description to show that it can be an element

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -399,9 +399,9 @@ var groups = [
     </tr>
     <tr>
       <td>content</td>
-      <td>String</td>
+      <td>String or Element</td>
       <td>yes</td>
-      <td>The contents of the group. This can be plain text or html code.</td>
+      <td>The contents of the group. This can be plain text, html code or an html element.</td>
     </tr>
     <tr>
       <td>id</td>


### PR DESCRIPTION
I have been working around this incorrect documentation for a while now. I have wanted an option to create a group with the content set to an element pre-configured with event handlers for user interaction.  I never thought to look at the code to see it could already handle this until now. This PR is to help prevent others from going down the wrong path like I did.