### PR TITLE
fixed label disappearing bug for large axis values in graph3d

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1394,7 +1394,7 @@ Graph3d.prototype._redrawAxis = function() {
   var xLabel = this.xLabel;
   if (xLabel.length > 0) {
     yOffset = 0.1 / this.scale.y;
-    xText   = xRange.min + (xRange.max - xRange.min)/2;
+    xText   = (xRange.max + 2*xRange.min)/3;
     yText   = (armVector.x > 0) ? yRange.min - yOffset: yRange.max + yOffset;
     text    = new Point3d(xText, yText, zRange.min);
     this.drawAxisLabelX(ctx, text, xLabel, armAngle);
@@ -1405,7 +1405,7 @@ Graph3d.prototype._redrawAxis = function() {
   if (yLabel.length > 0) {
     xOffset = 0.1 / this.scale.x;
     xText   = (armVector.y > 0) ? xRange.min - xOffset : xRange.max + xOffset;
-    yText   = yRange.min + (yRange.max - yRange.min)/2;
+    yText   = (yRange.max + 2*yRange.min)/3;
     text    = new Point3d(xText, yText, zRange.min);
 
     this.drawAxisLabelY(ctx, text, yLabel, armAngle);
@@ -1417,7 +1417,7 @@ Graph3d.prototype._redrawAxis = function() {
     offset = 30;  // pixels.  // TODO: relate to the max width of the values on the z axis?
     xText  = (armVector.x > 0) ? xRange.min : xRange.max;
     yText  = (armVector.y < 0) ? yRange.min : yRange.max;
-    zText  = zRange.max;
+    zText  = (zRange.max + 2*zRange.min)/3;
     text   = new Point3d(xText, yText, zText);
 
     this.drawAxisLabelZ(ctx, text, zLabel, offset);

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1394,7 +1394,7 @@ Graph3d.prototype._redrawAxis = function() {
   var xLabel = this.xLabel;
   if (xLabel.length > 0) {
     yOffset = 0.1 / this.scale.y;
-    xText   = xRange.center() / 2;
+    xText   = xRange.min + (xRange.max - xRange.min)/2;
     yText   = (armVector.x > 0) ? yRange.min - yOffset: yRange.max + yOffset;
     text    = new Point3d(xText, yText, zRange.min);
     this.drawAxisLabelX(ctx, text, xLabel, armAngle);
@@ -1405,7 +1405,7 @@ Graph3d.prototype._redrawAxis = function() {
   if (yLabel.length > 0) {
     xOffset = 0.1 / this.scale.x;
     xText   = (armVector.y > 0) ? xRange.min - xOffset : xRange.max + xOffset;
-    yText   = yRange.center() / 2;
+    yText   = yRange.min + (yRange.max - yRange.min)/2;
     text    = new Point3d(xText, yText, zRange.min);
 
     this.drawAxisLabelY(ctx, text, yLabel, armAngle);
@@ -1417,7 +1417,7 @@ Graph3d.prototype._redrawAxis = function() {
     offset = 30;  // pixels.  // TODO: relate to the max width of the values on the z axis?
     xText  = (armVector.x > 0) ? xRange.min : xRange.max;
     yText  = (armVector.y < 0) ? yRange.min : yRange.max;
-    zText  = zRange.center() / 2;
+    zText  = zRange.max;
     text   = new Point3d(xText, yText, zText);
 
     this.drawAxisLabelZ(ctx, text, zLabel, offset);

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1394,7 +1394,7 @@ Graph3d.prototype._redrawAxis = function() {
   var xLabel = this.xLabel;
   if (xLabel.length > 0) {
     yOffset = 0.1 / this.scale.y;
-    xText   = (xRange.max + 2*xRange.min)/3;
+    xText   = (xRange.max + 3*xRange.min)/4;
     yText   = (armVector.x > 0) ? yRange.min - yOffset: yRange.max + yOffset;
     text    = new Point3d(xText, yText, zRange.min);
     this.drawAxisLabelX(ctx, text, xLabel, armAngle);
@@ -1405,7 +1405,7 @@ Graph3d.prototype._redrawAxis = function() {
   if (yLabel.length > 0) {
     xOffset = 0.1 / this.scale.x;
     xText   = (armVector.y > 0) ? xRange.min - xOffset : xRange.max + xOffset;
-    yText   = (yRange.max + 2*yRange.min)/3;
+    yText   = (yRange.max + 3*yRange.min)/4;
     text    = new Point3d(xText, yText, zRange.min);
 
     this.drawAxisLabelY(ctx, text, yLabel, armAngle);
@@ -1417,7 +1417,7 @@ Graph3d.prototype._redrawAxis = function() {
     offset = 30;  // pixels.  // TODO: relate to the max width of the values on the z axis?
     xText  = (armVector.x > 0) ? xRange.min : xRange.max;
     yText  = (armVector.y < 0) ? yRange.min : yRange.max;
-    zText  = (zRange.max + 2*zRange.min)/3;
+    zText  = (zRange.max + 3*zRange.min)/4;
     text   = new Point3d(xText, yText, zText);
 
     this.drawAxisLabelZ(ctx, text, zLabel, offset);


### PR DESCRIPTION
Axis labels of graph3d is positioned on the middle point of between the origin and the center of each range. e.g.,

```javascript
xText   = xRange.center() / 2;
````

For example, for xRange = [100, 200], the center of range is (100+200)/2 = 150 and the middle point is (0+150)/2 = 75 then the middle point is positioned out of range. So axis labels disappear. This patch uses points divide each range in the ratio 1:3 as axis label positions 

I've setup preview https://fiddle.jshell.net/gotoken/5sk9ka72/3/show/ . Please try to reproduce by pasting this CSV into http://visjs.org/examples/graph3d/playground/index.html then click "Draw graph". 