### PR TITLE
This was a necessity I had when I started using dot-color of graph3d module, if you think it will be useful for someone else, you could accept this change.

### DIFF
--- a/dist/vis.js
+++ b/dist/vis.js
@@ -7913,7 +7913,8 @@ return /******/ (function(modules) { // webpackBootstrap
     yStep: autoByDefault,
     zMin: autoByDefault,
     zMax: autoByDefault,
-    zStep: autoByDefault
+    zStep: autoByDefault,
+    customPointColor: false
   };
 
   // -----------------------------------------------------------------------------
@@ -9474,7 +9475,19 @@ return /******/ (function(modules) { // webpackBootstrap
    * Draw single datapoint for graph style 'dot-color'.
    */
   Graph3d.prototype._redrawDotColorGraphPoint = function (ctx, point) {
-    var colors = this._getColorsColor(point);
+	 var colors = {
+      fill: this.dataColor.fill,
+      border: this.dataColor.stroke
+    };
+	
+    if(this.customPointColor != true)
+	  {
+	    colors = this._getColorsColor(point);     
+    } else
+    {
+      colors.fill = point.point.data.fill_color;
+      colors.border = point.point.data.border_color;
+    }
 
     this._drawCircle(ctx, point, colors.fill, colors.border);
   };
@@ -11380,7 +11393,7 @@ return /******/ (function(modules) { // webpackBootstrap
    * Specifically, these are the fields which require no special handling,
    * and can be directly copied over.
    */
-  var OPTIONKEYS = ['width', 'height', 'filterLabel', 'legendLabel', 'xLabel', 'yLabel', 'zLabel', 'xValueLabel', 'yValueLabel', 'zValueLabel', 'showGrid', 'showPerspective', 'showShadow', 'keepAspectRatio', 'verticalRatio', 'dotSizeRatio', 'showAnimationControls', 'animationInterval', 'animationPreload', 'animationAutoStart', 'axisColor', 'gridColor', 'xCenter', 'yCenter'];
+  var OPTIONKEYS = ['width', 'height', 'filterLabel', 'legendLabel', 'xLabel', 'yLabel', 'zLabel', 'xValueLabel', 'yValueLabel', 'zValueLabel', 'showGrid', 'showPerspective', 'showShadow', 'keepAspectRatio', 'verticalRatio', 'dotSizeRatio', 'showAnimationControls', 'animationInterval', 'animationPreload', 'animationAutoStart', 'axisColor', 'gridColor', 'xCenter', 'yCenter', 'customPointColor'];
 
   /**
    * Field names in the options hash which are of relevance to the user.


### PR DESCRIPTION
In graph3d, 'dot-color' graph style:

- Created the 'customPointColor' (default = false) option to allow the developer to define point color (fill and border) in 'dot-color' graphics;

- To use, you must change the 'customPointColor' option to true,
  e.g. "...keepAspectRatio: false,
           verticalRatio: 0.5,
           customPointColor : true
           };";
  and pass 'fill_color' and 'border_color' as 'data' object fields in 'data.add' function call,
  e.g. "var z = 0;
        var x = 0;
        var y = 4;
        var value = 20;
        var fillColor = 'red';
        var borderColor = 'rgb(255,255,255)';
        data.add({ z: z, x: x, y: y, style: value, extra: extra_content, fill_color: fillColor, border_color: borderColor });";

- When changing the 'customPointColor' option to true, it is good to change the 'showLegend' option to false so as not to make it strange in the graph view;

- I hope I can make an improvement in the legend soon;