### PR TITLE
Multifont node and edge labels

### DIFF
--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -135,7 +135,49 @@ var options = {
       background: 'none',
       strokeWidth: 2, // px
       strokeColor: '#ffffff',
-      align:'horizontal'
+      align: 'horizontal',
+      multi: false,
+      vadjust: 0,
+      bold: {
+        color: '#343434',
+        size: 14, // px
+        face: 'arial',
+        background: 'none',
+        strokeWidth: 2, // px
+        strokeColor: '#ffffff',
+        vadjust: 0,
+        mod: 'bold'
+      },
+      ital: {
+        color: '#343434',
+        size: 14, // px
+        face: 'arial',
+        background: 'none',
+        strokeWidth: 2, // px
+        strokeColor: '#ffffff',
+        vadjust: 0,
+        mod: 'italic',
+      },
+      boldital: {
+        color: '#343434',
+        size: 14, // px
+        face: 'arial',
+        background: 'none',
+        strokeWidth: 2, // px
+        strokeColor: '#ffffff',
+        vadjust: 0,
+        mod: 'bold italic'
+      },
+      mono: {
+        color: '#343434',
+        size: 15, // px
+        face: 'courier new',
+        background: 'none',
+        strokeWidth: 2, // px
+        strokeColor: '#ffffff',
+        vadjust: 2,
+        mod: ''
+      }
     },
     hidden: false,
     hoverWidth: 1.5,
@@ -389,6 +431,171 @@ network.setOptions(options);
                 regardless of the orientation of the edge. When an option other than <code>horizontal</code> is chosen,
                 the label will align itself according to the edge.
             </td>
+        </tr>
+        <tr parent="font" class="hidden">
+            <td class="indent">font.vadjust</td>
+            <td>String</td>
+            <td><code>0</code></td>
+            <td>A font-specific correction to the vertical positioning of the base font in the label text. (Positive is down.)</td>
+        </tr>
+        <tr parent="font" class="hidden">
+            <td class="indent">font.multi</td>
+            <td>Boolean or String</td>
+            <td><code>false</code></td>
+            <td>If <code>false</code>, the label is treated as pure text drawn with the base font. If <code>true</code> or <code>'html'</code> the label may be multifonted, with bold, italic and code markup, interpreted as html. If the value is <code>'markdown'</code> or <code>'md'</code> the label may be multifonted, with bold, italic and code markup, interpreted as markdown.
+              The bold, italic, bold-italic and monospaced fonts may be set up under in the font.bold, font.ital, font.boldital and font.mono properties, respectively.</td>
+        </tr>
+        <tr parent="font" class='hidden toggle collapsible' onclick="toggleTable('optionTable','bold', this);">
+            <td><span parent="bold" class="right-caret"></span> font.bold</td>
+            <td>Object or String</td>
+            <td><code>false</code></td>
+            <td>This object defines the details of the bold font in the label. A shorthand is also supported in the form <code>'size face
+                color'</code> for example: <code>'14px arial red'</code>.
+            </td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.color</td>
+            <td>String</td>
+            <td><code>'#343434'</code></td>
+            <td>Color of the bold font in the label text. Defaults to the base font's color.</td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.size</td>
+            <td>Number</td>
+            <td><code>14</code></td>
+            <td>Size of the bold font in the label text. Defaults to the base font's size.</td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.face</td>
+            <td>String</td>
+            <td><code>'arial'</code></td>
+            <td>Font face (or font family) of the bold font in the label text. Defaults to the base font's face.</td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.mod</td>
+            <td>String</td>
+            <td><code>'bold'</code></td>
+            <td>A string added to the face and size when determining the bold font in the label text.</td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.vadjust</td>
+            <td>String</td>
+            <td><code>0</code></td>
+            <td>A font-specific correction to the vertical positioning of the bold italic font in the label text. (Positive is down.) Defaults to the base font's valign.</td>
+        </tr>
+        <tr parent="font" class='hidden toggle collapsible' onclick="toggleTable('optionTable','ital', this);">
+            <td><span parent="ital" class="right-caret"></span> font.ital</td>
+            <td>Object or String</td>
+            <td><code>false</code></td>
+            <td>This object defines the details of the italic font in the label. A shorthand is also supported in the form <code>'size face
+                color'</code> for example: <code>'14px arial red'</code>.
+            </td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.color</td>
+            <td>String</td>
+            <td><code>'#343434'</code></td>
+            <td>Color of the italic font in the label text. Defaults to the base font's color.</td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.size</td>
+            <td>Number</td>
+            <td><code>14</code></td>
+            <td>Size of the italic font in the label text. Defaults to the base font's size.</td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.face</td>
+            <td>String</td>
+            <td><code>'arial'</code></td>
+            <td>Font face (or font family) of the italic font in the label text. Defaults to the base font's face.</td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.mod</td>
+            <td>String</td>
+            <td><code>'italic'</code></td>
+            <td>A string added to the face and size when determining the italic font in the label text.</td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.vadjust</td>
+            <td>String</td>
+            <td><code>0</code></td>
+            <td>A font-specific correction to the vertical positioning of the italic font in the label text. (Positive is down.) Defaults to the base font's valign.</td>
+        </tr>
+        <tr parent="font" class='hidden toggle collapsible' onclick="toggleTable('optionTable','boldital', this);">
+            <td><span parent="boldital" class="right-caret"></span> font.boldital</td>
+            <td>Object or String</td>
+            <td><code>false</code></td>
+            <td>This object defines the details of the bold italic font in the label. A shorthand is also supported in the form <code>'size face
+                color'</code> for example: <code>'14px arial red'</code>.
+            </td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.color</td>
+            <td>String</td>
+            <td><code>'#343434'</code></td>
+            <td>Color of the bold italic font in the label text. Defaults to the base font's color.</td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.size</td>
+            <td>Number</td>
+            <td><code>14</code></td>
+            <td>Size of the bold italic font in the label text. Defaults to the base font's size.</td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.face</td>
+            <td>String</td>
+            <td><code>'arial'</code></td>
+            <td>Font face (or font family) of the bold italic font in the label text. Defaults to the base font's face.</td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.mod</td>
+            <td>String</td>
+            <td><code>'bold'</code></td>
+            <td>A string added to the face and size when determining the bold italic font in the label text.</td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.vadjust</td>
+            <td>String</td>
+            <td><code>0</code></td>
+            <td>A font-specific correction to the vertical positioning of the bold italic font in the label text. (Positive is down.) Defaults to the base font's valign.</td>
+        </tr>
+        <tr parent="font" class='hidden toggle collapsible' onclick="toggleTable('optionTable','mono', this);">
+            <td><span parent="mono" class="right-caret"></span> font.mono</td>
+            <td>Object or String</td>
+            <td><code>false</code></td>
+            <td>This object defines the details of the monospaced font in the label. A shorthand is also supported in the form <code>'size face
+                color'</code> for example: <code>'15px courier red'</code>.
+            </td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.color</td>
+            <td>String</td>
+            <td><code>'#343434'</code></td>
+            <td>Color of the monospaced font in the label text. Defaults to the base font's color.</td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.size</td>
+            <td>Number</td>
+            <td><code>15</code></td>
+            <td>Size of the monospaced font in the label text. Defaults to the base font's size.</td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.face</td>
+            <td>String</td>
+            <td><code>'courier new'</code></td>
+            <td>Font face (or font family) of the monospaced font in the label text.</td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.mod</td>
+            <td>String</td>
+            <td><code>''</code></td>
+            <td>A string added to the face and size when determining the monospaced font in the label text.</td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.vadjust</td>
+            <td>String</td>
+            <td><code>2</code></td>
+            <td>A font-specific correction to the vertical positioning of the monospaced font in the label text. (Positive is down.) Defaults to the base font's valign.</td>
         </tr>
         <tr>
             <td>from</td>

--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -142,9 +142,6 @@ var options = {
         color: '#343434',
         size: 14, // px
         face: 'arial',
-        background: 'none',
-        strokeWidth: 2, // px
-        strokeColor: '#ffffff',
         vadjust: 0,
         mod: 'bold'
       },
@@ -152,9 +149,6 @@ var options = {
         color: '#343434',
         size: 14, // px
         face: 'arial',
-        background: 'none',
-        strokeWidth: 2, // px
-        strokeColor: '#ffffff',
         vadjust: 0,
         mod: 'italic',
       },
@@ -162,9 +156,6 @@ var options = {
         color: '#343434',
         size: 14, // px
         face: 'arial',
-        background: 'none',
-        strokeWidth: 2, // px
-        strokeColor: '#ffffff',
         vadjust: 0,
         mod: 'bold italic'
       },
@@ -172,9 +163,6 @@ var options = {
         color: '#343434',
         size: 15, // px
         face: 'courier new',
-        background: 'none',
-        strokeWidth: 2, // px
-        strokeColor: '#ffffff',
         vadjust: 2,
         mod: ''
       }

--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -140,9 +140,6 @@ var options = {
         color: '#343434',
         size: 14, // px
         face: 'arial',
-        background: 'none',
-        strokeWidth: 2, // px
-        strokeColor: '#ffffff',
         vadjust: 0,
         mod: 'bold'
       },
@@ -150,9 +147,6 @@ var options = {
         color: '#343434',
         size: 14, // px
         face: 'arial',
-        background: 'none',
-        strokeWidth: 2, // px
-        strokeColor: '#ffffff',
         vadjust: 0,
         mod: 'italic',
       },
@@ -160,9 +154,6 @@ var options = {
         color: '#343434',
         size: 14, // px
         face: 'arial',
-        background: 'none',
-        strokeWidth: 2, // px
-        strokeColor: '#ffffff',
         vadjust: 0,
         mod: 'bold italic'
       },
@@ -170,9 +161,6 @@ var options = {
         color: '#343434',
         size: 15, // px
         face: 'courier new',
-        background: 'none',
-        strokeWidth: 2, // px
-        strokeColor: '#ffffff',
         vadjust: 2,
         mod: ''
       }

--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -133,7 +133,49 @@ var options = {
       background: 'none',
       strokeWidth: 0, // px
       strokeColor: '#ffffff',
-      align: 'center'
+      align: 'center',
+      multi: false,
+      vadjust: 0,
+      bold: {
+        color: '#343434',
+        size: 14, // px
+        face: 'arial',
+        background: 'none',
+        strokeWidth: 2, // px
+        strokeColor: '#ffffff',
+        vadjust: 0,
+        mod: 'bold'
+      },
+      ital: {
+        color: '#343434',
+        size: 14, // px
+        face: 'arial',
+        background: 'none',
+        strokeWidth: 2, // px
+        strokeColor: '#ffffff',
+        vadjust: 0,
+        mod: 'italic',
+      },
+      boldital: {
+        color: '#343434',
+        size: 14, // px
+        face: 'arial',
+        background: 'none',
+        strokeWidth: 2, // px
+        strokeColor: '#ffffff',
+        vadjust: 0,
+        mod: 'bold italic'
+      },
+      mono: {
+        color: '#343434',
+        size: 15, // px
+        face: 'courier new',
+        background: 'none',
+        strokeWidth: 2, // px
+        strokeColor: '#ffffff',
+        vadjust: 2,
+        mod: ''
+      }
     },
     group: undefined,
     hidden: false,
@@ -381,12 +423,177 @@ network.setOptions(options);
             <td>This can be set to 'left' to make the label left-aligned. Otherwise,
                 defaults to 'center'.</td>
         </tr>
+        <tr parent="font" class="hidden">
+            <td class="indent">font.vadjust</td>
+            <td>String</td>
+            <td><code>0</code></td>
+            <td>A font-specific correction to the vertical positioning of the base font in the label text. (Positive is down.)</td>
+        </tr>
+        <tr parent="font" class="hidden">
+            <td class="indent">font.multi</td>
+            <td>Boolean or String</td>
+            <td><code>false</code></td>
+            <td>If <code>false</code>, the label is treated as pure text drawn with the base font. If <code>true</code> or <code>'html'</code> the label may be multifonted, with bold, italic and code markup, interpreted as html. If the value is <code>'markdown'</code> or <code>'md'</code> the label may be multifonted, with bold, italic and code markup, interpreted as markdown.
+              The bold, italic, bold-italic and monospaced fonts may be set up under in the font.bold, font.ital, font.boldital and font.mono properties, respectively.</td>
+        </tr>
+        <tr parent="font" class='hidden toggle collapsible' onclick="toggleTable('optionTable','bold', this);">
+            <td><span parent="bold" class="right-caret"></span> font.bold</td>
+            <td>Object or String</td>
+            <td><code>false</code></td>
+            <td>This object defines the details of the bold font in the label. A shorthand is also supported in the form <code>'size face
+                color'</code> for example: <code>'14px arial red'</code>.
+            </td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.color</td>
+            <td>String</td>
+            <td><code>'#343434'</code></td>
+            <td>Color of the bold font in the label text. Defaults to the base font's color.</td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.size</td>
+            <td>Number</td>
+            <td><code>14</code></td>
+            <td>Size of the bold font in the label text. Defaults to the base font's size.</td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.face</td>
+            <td>String</td>
+            <td><code>'arial'</code></td>
+            <td>Font face (or font family) of the bold font in the label text. Defaults to the base font's face.</td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.mod</td>
+            <td>String</td>
+            <td><code>'bold'</code></td>
+            <td>A string added to the face and size when determining the bold font in the label text.</td>
+        </tr>
+        <tr parent="bold" class="hidden">
+            <td class="indent">font.bold.vadjust</td>
+            <td>String</td>
+            <td><code>0</code></td>
+            <td>A font-specific correction to the vertical positioning of the bold italic font in the label text. (Positive is down.) Defaults to the base font's valign.</td>
+        </tr>
+        <tr parent="font" class='hidden toggle collapsible' onclick="toggleTable('optionTable','ital', this);">
+            <td><span parent="ital" class="right-caret"></span> font.ital</td>
+            <td>Object or String</td>
+            <td><code>false</code></td>
+            <td>This object defines the details of the italic font in the label. A shorthand is also supported in the form <code>'size face
+                color'</code> for example: <code>'14px arial red'</code>.
+            </td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.color</td>
+            <td>String</td>
+            <td><code>'#343434'</code></td>
+            <td>Color of the italic font in the label text. Defaults to the base font's color.</td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.size</td>
+            <td>Number</td>
+            <td><code>14</code></td>
+            <td>Size of the italic font in the label text. Defaults to the base font's size.</td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.face</td>
+            <td>String</td>
+            <td><code>'arial'</code></td>
+            <td>Font face (or font family) of the italic font in the label text. Defaults to the base font's face.</td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.mod</td>
+            <td>String</td>
+            <td><code>'italic'</code></td>
+            <td>A string added to the face and size when determining the italic font in the label text.</td>
+        </tr>
+        <tr parent="ital" class="hidden">
+            <td class="indent">font.ital.vadjust</td>
+            <td>String</td>
+            <td><code>0</code></td>
+            <td>A font-specific correction to the vertical positioning of the italic font in the label text. (Positive is down.) Defaults to the base font's valign.</td>
+        </tr>
+        <tr parent="font" class='hidden toggle collapsible' onclick="toggleTable('optionTable','boldital', this);">
+            <td><span parent="boldital" class="right-caret"></span> font.boldital</td>
+            <td>Object or String</td>
+            <td><code>false</code></td>
+            <td>This object defines the details of the bold italic font in the label. A shorthand is also supported in the form <code>'size face
+                color'</code> for example: <code>'14px arial red'</code>.
+            </td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.color</td>
+            <td>String</td>
+            <td><code>'#343434'</code></td>
+            <td>Color of the bold italic font in the label text. Defaults to the base font's color.</td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.size</td>
+            <td>Number</td>
+            <td><code>14</code></td>
+            <td>Size of the bold italic font in the label text. Defaults to the base font's size.</td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.face</td>
+            <td>String</td>
+            <td><code>'arial'</code></td>
+            <td>Font face (or font family) of the bold italic font in the label text. Defaults to the base font's face.</td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.mod</td>
+            <td>String</td>
+            <td><code>'bold'</code></td>
+            <td>A string added to the face and size when determining the bold italic font in the label text.</td>
+        </tr>
+        <tr parent="boldital" class="hidden">
+            <td class="indent">font.boldital.vadjust</td>
+            <td>String</td>
+            <td><code>0</code></td>
+            <td>A font-specific correction to the vertical positioning of the bold italic font in the label text. (Positive is down.) Defaults to the base font's valign.</td>
+        </tr>
+        <tr parent="font" class='hidden toggle collapsible' onclick="toggleTable('optionTable','mono', this);">
+            <td><span parent="mono" class="right-caret"></span> font.mono</td>
+            <td>Object or String</td>
+            <td><code>false</code></td>
+            <td>This object defines the details of the monospaced font in the label. A shorthand is also supported in the form <code>'size face
+                color'</code> for example: <code>'15px courier red'</code>.
+            </td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.color</td>
+            <td>String</td>
+            <td><code>'#343434'</code></td>
+            <td>Color of the monospaced font in the label text. Defaults to the base font's color.</td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.size</td>
+            <td>Number</td>
+            <td><code>15</code></td>
+            <td>Size of the monospaced font in the label text. Defaults to the base font's size.</td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.face</td>
+            <td>String</td>
+            <td><code>'courier new'</code></td>
+            <td>Font face (or font family) of the monospaced font in the label text.</td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.mod</td>
+            <td>String</td>
+            <td><code>''</code></td>
+            <td>A string added to the face and size when determining the monospaced font in the label text.</td>
+        </tr>
+        <tr parent="mono" class="hidden">
+            <td class="indent">font.mono.vadjust</td>
+            <td>String</td>
+            <td><code>2</code></td>
+            <td>A font-specific correction to the vertical positioning of the monospaced font in the label text. (Positive is down.) Defaults to the base font's valign.</td>
+        </tr>
         <tr>
             <td>group</td>
             <td>String</td>
             <td><code>undefined</code></td>
             <td>When not <code>undefined</code>, the node will belong to the defined group. Styling information of
-                that group will apply to this node. Node specific styling overrides group styling. 
+                that group will apply to this node. Node specific styling overrides group styling.
             </td>
         </tr>
         <tr>

--- a/examples/network/labels/labelMultifont.html
+++ b/examples/network/labels/labelMultifont.html
@@ -75,7 +75,7 @@ Node and edge label fonts are separate.</p>
   var nodes = [
     { id: 1, label: 'This is a\nsingle-font label', x: -120, y: -120 },
     { id: 2, font: { multi: true }, label: '<b>This</b> is a\n<i>default</i> <b><i>multi-</i>font</b> <code>label</code>', x: -40, y: -40 },
-    { id: 3, font: { multi: 'html' }, label: '<b>This</b> is an\n<i>html</i> <b><i>multi-</i>font</b> <code>label</code>', x: 40, y: 40 },
+    { id: 3, font: { multi: 'html', size: 20 }, label: '<b>This</b> is an\n<i>html</i> <b><i>multi-</i>font</b> <code>label</code>', x: 40, y: 40 },
     { id: 4, font: { multi: 'md', face: 'georgia' }, label: '*This* is a\n_markdown_ *_multi-_ font* `label`', x: 120, y: 120},
   ];
 

--- a/examples/network/labels/labelMultifont.html
+++ b/examples/network/labels/labelMultifont.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html>
+<head>
+  <title>Network | Multifont Labels</title>
+
+  <script type="text/javascript" src="../../../dist/vis.js"></script>
+  <link href="../../../dist/vis-network.min.css" rel="stylesheet" type="text/css" />
+
+  <style type="text/css">
+    #mynetwork {
+      width: 600px;
+      height: 400px;
+      border: 1px solid lightgray;
+    }
+    code {
+      font-size: 15px;
+    }
+    p {
+      max-width: 600px;
+    }
+    .indented {
+      margin-left: 30px;
+    }
+    table {
+      border-collapse: collapse;
+      font-family: sans-serif;
+    }
+    table code {
+      background: #dddddd;
+    }
+    th, td {
+      border: 1px solid #aaaaaa;
+      text-align: center;
+      padding: 5px;
+      font-weight: normal;
+    }
+  </style>
+  <script src="../../googleAnalytics.js"></script>
+</head>
+
+<body>
+
+<p>Node and edge labels may be marked up to be drawn with multiple fonts.</p>
+
+<div id="mynetwork"></div>
+
+<p>The value of the <code>font.multi</code> property may be set to <code>'html'</code>, <code>'markdown'</code> or a boolean.</p>
+<table class="indented">
+  <tr><th colspan='4'>Embedded Font Markup</th></tr>
+  <tr><th rowspan=2>font mod</th><th colspan=3><code>font.multi</code> setting</th></tr>
+  <tr><th><code>'html'</code> or <code>true</code></th><th><code>'markdown'</code> or <code>'md'</code></th><th><code>false<code></th></tr>
+  <tr><th>bold</th><td><code>&lt;b&gt;</code> ... <code>&lt;/b></code></td><td><code>&nbsp;*</code> ... <code>*&nbsp;</code></td><td>n/a</td></tr>
+  <tr><th>italic</th><td><code>&lt;i&gt;</code> ... <code>&lt;/i></code></td><td><code>&nbsp;_</code> ... <code>_&nbsp;</code></td><td>n/a</td></tr>
+  <tr><th>mono-spaced</th><td><code>&lt;code&gt;</code> ... <code>&lt;/code&gt;</code></td><td><code>&nbsp;`</code> ... <code>`&nbsp;</code></td><td>n/a</td></tr>
+</table>
+
+<p>
+The <code>html</code> and <code>markdown</code> rendering is limited: bolds may be embedded in italics, italics may be embedded in bolds, and mono-spaced may be embedded in bold or italic, but will not be altered by those font mods, nor will embedded bolds or italics be handled.
+The only entities that will be observed in html are <code>&amp;lt;</code> and <code>&amp;amp;</code> and in <code>markdown</code> a backslash will escape the following character (including a backslash) from special processing.
+Any font mod that is started in a label line will be implicitly terminated at the end of that line.
+While this interpretation may not exactly match <i>official</i> rendering standards, it is a consistent compromise for drawing multifont strings in the non-multifont html canvas element underlying vis.
+</p>
+
+<p>This implies that four additional sets of font properties will be recognized in label processing.</p>
+<p class="indented"><code>font.bold</code> designates the font used for rendering bold font mods.
+<br/><code>font.ital</code> designates the font used for rendering italic font mods.
+<br/><code>font.boldital</code> designates the font used for rendering bold-<b><i>and</i></b>-italic font mods.
+<br/><code>font.mono</code> designates the font used for rendering monospaced font mods.</p>
+<p>Any font mod without a matching font will be rendered using the normal <code>font</code> (or default) value.</p>
+
+<p>The <code>font.multi</code> and extended font settings may be set in the network's <code>nodes</code> or <code>edges</code> properties, or on individual nodes and edges.
+Node and edge label fonts are separate.</p>
+
+<script type="text/javascript">
+  var nodes = [
+    { id: 1, label: 'This is a\nsingle-font label', x: -120, y: -120 },
+    { id: 2, font: { multi: true }, label: '<b>This</b> is a\n<i>default</i> <b><i>multi-</i>font</b> <code>label</code>', x: -40, y: -40 },
+    { id: 3, font: { multi: 'html' }, label: '<b>This</b> is an\n<i>html</i> <b><i>multi-</i>font</b> <code>label</code>', x: 40, y: 40 },
+    { id: 4, font: { multi: 'md', face: 'georgia' }, label: '*This* is a\n_markdown_ *_multi-_ font* `label`', x: 120, y: 120},
+  ];
+
+  var edges = [
+    {from: 1, to: 2, label: "single to default"},
+    {from: 2, to: 3, font: { multi: true }, label: "default to <b>html</b>" },
+    {from: 3, to: 4, font: { multi: "md" }, label: "*html* to _md_" }
+  ];
+
+  var container = document.getElementById('mynetwork');
+  var data = {
+    nodes: nodes,
+    edges: edges
+  };
+  var options = {
+    edges: {
+      font: {
+        size: 12
+      }
+    },
+    nodes: {
+      shape: 'box',
+      font: {
+        bold: {
+          color: '#0077aa'
+        }
+      }
+    },
+    physics: {
+      enabled: false
+    }
+  };
+  var network = new vis.Network(container, data, options);
+</script>
+
+</body>
+</html>

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -172,6 +172,7 @@ class EdgesHandler {
   }
 
   setOptions(options) {
+    this.edgeOptions = options;
     if (options !== undefined) {
       // use the parser from the Edge class to fill in all shorthand notations
       Edge.parseOptions(this.options, options);
@@ -357,7 +358,7 @@ class EdgesHandler {
   }
 
   create(properties) {
-    return new Edge(properties, this.body, this.options)
+    return new Edge(properties, this.body, this.options, this.defaultOptions, this.edgeOptions)
   }
 
 

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -43,7 +43,24 @@ class EdgesHandler {
         background: 'none',
         strokeWidth: 2, // px
         strokeColor: '#ffffff',
-        align:'horizontal'
+        align:'horizontal',
+        multi: false,
+        vadjust: 0,
+        bold: {
+          mod: 'bold'
+        },
+        boldital: {
+          mod: 'bold italic'
+        },
+        ital: {
+          mod: 'italic'
+        },
+        mono: {
+          mod: '',
+          size: 15, // px
+          face: 'courier new',
+          vadjust: 2
+        }
       },
       hidden: false,
       hoverWidth: 1.5,

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -49,7 +49,24 @@ class NodesHandler {
         background: 'none',
         strokeWidth: 0, // px
         strokeColor: '#ffffff',
-        align: 'center'
+        align: 'center',
+        vadjust: 0,
+        multi: false,
+        bold: {
+          mod: 'bold'
+        },
+        boldital: {
+          mod: 'bold italic'
+        },
+        ital: {
+          mod: 'italic'
+        },
+        mono: {
+          mod: '',
+          size: 15, // px
+          face: 'courier new',
+          vadjust: 2
+        }
       },
       group: undefined,
       hidden: false,

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -152,6 +152,7 @@ class NodesHandler {
   }
 
   setOptions(options) {
+    this.nodeOptions = options;
     if (options !== undefined) {
       Node.parseOptions(this.options, options);
 
@@ -318,7 +319,7 @@ class NodesHandler {
    * @param constructorClass
    */
   create(properties, constructorClass = Node) {
-    return new constructorClass(properties, this.body, this.images, this.groups, this.options)
+    return new constructorClass(properties, this.body, this.images, this.groups, this.options, this.defaultOptions, this.nodeOptions)
   }
 
 

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -22,12 +22,14 @@ import StraightEdge       from './edges/StraightEdge'
  *                                example for the color
  */
 class Edge {
-  constructor(options, body, globalOptions) {
+  constructor(options, body, globalOptions, defaultOptions, edgeOptions) {
     if (body === undefined) {
       throw "No body provided";
     }
     this.options = util.bridgeObject(globalOptions);
     this.globalOptions = globalOptions;
+    this.defaultOptions = defaultOptions;
+    this.edgeOptions = edgeOptions;
     this.body = body;
 
     // initialize variables
@@ -52,6 +54,7 @@ class Edge {
     this.labelModule = new Label(this.body, this.options, true /* It's an edge label */);
 
     this.setOptions(options);
+    this.labelModule.propagateFonts(this.edgeOptions, options, this.defaultOptions);
   }
 
 

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -46,9 +46,11 @@ import  {printStyle} from "../../../shared/Validator";
  *
  */
 class Node {
-  constructor(options, body, imagelist, grouplist, globalOptions) {
+  constructor(options, body, imagelist, grouplist, globalOptions, defaultOptions, nodeOptions) {
     this.options = util.bridgeObject(globalOptions);
     this.globalOptions = globalOptions;
+    this.defaultOptions = defaultOptions;
+    this.nodeOptions = nodeOptions;
     this.body = body;
 
     this.edges = []; // all edges connected to this node
@@ -69,6 +71,7 @@ class Node {
 
     this.labelModule = new Label(this.body, this.options, false /* Not edge label */);
     this.setOptions(options);
+    this.labelModule.propagateFonts(this.nodeOptions, options, this.defaultOptions);
   }
 
 
@@ -117,7 +120,7 @@ class Node {
     // clear x and y positions
     if (options.x !== undefined) {
       if (options.x === null) {this.x = undefined; this.predefinedPosition = false;}
-      else                    {this.x = parseInt(options.x); this.predefinedPosition = true;}    
+      else                    {this.x = parseInt(options.x); this.predefinedPosition = true;}
     }
     if (options.y !== undefined) {
       if (options.y === null) {this.y = undefined; this.predefinedPosition = false;}

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -55,7 +55,10 @@ class Label {
     if (this.fontOptions.multi) {
       let mods = [ 'bold', 'ital', 'boldital', 'mono' ];
       for (const mod of mods) {
-        let optionsFontMod = options.font[mod];
+        let optionsFontMod;
+        if (options.font) {
+          optionsFontMod = options.font[mod];
+        }
         if (typeof optionsFontMod === 'string') {
           let modOptionsArray = optionsFontMod.split(" ");
           this.fontOptions[mod].size  = modOptionsArray[0].replace("px","");

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -39,14 +39,75 @@ class Label {
   static parseOptions(parentOptions, newOptions, allowDeletion = false) {
     if (typeof newOptions.font === 'string') {
       let newOptionsArray = newOptions.font.split(" ");
-      parentOptions.size  = newOptionsArray[0].replace("px",'');
-      parentOptions.face  = newOptionsArray[1];
-      parentOptions.color = newOptionsArray[2];
+      parentOptions.size    = newOptionsArray[0].replace("px",'');
+      parentOptions.face    = newOptionsArray[1];
+      parentOptions.color   = newOptionsArray[2];
+      parentOptions.vadjust = 0;
     }
     else if (typeof newOptions.font === 'object') {
       util.fillIfDefined(parentOptions, newOptions.font, allowDeletion);
+      if (typeof newOptions.font.bold === 'string') {
+        let newBoldOptionsArray = newOptions.font.bold.split(" ");
+        parentOptions.bold.size    = newBoldOptionsArray[0].replace("px",'');
+        parentOptions.bold.face    = newBoldOptionsArray[1];
+        parentOptions.bold.color   = newBoldOptionsArray[2];
+        parentOptions.bold.vadjust = parentOptions.vadjust;
+        parentOptions.bold.mod     = parentOptions.mod;
+      } else if (typeof newOptions.font.bold === 'object') {
+        parentOptions.bold.size    = newOptions.font.bold.size    || parentOptions.size;
+        parentOptions.bold.face    = newOptions.font.bold.face    || parentOptions.face;
+        parentOptions.bold.color   = newOptions.font.bold.color   || parentOptions.color;
+        parentOptions.bold.vadjust = newOptions.font.bold.vadjust || parentOptions.vadjust;
+        parentOptions.bold.mod     = newOptions.font.bold.mod     || "";
+      }
+      if (typeof newOptions.font.ital === 'string') {
+        let newItalOptionsArray = newOptions.font.ital.split(" ");
+        parentOptions.ital.size    = newItalOptionsArray[0].replace("px",'');
+        parentOptions.ital.face    = newItalOptionsArray[1];
+        parentOptions.ital.color   = newItalOptionsArray[2];
+        parentOptions.ital.vadjust = parentOptions.vadjust;
+        parentOptions.ital.mod     = parentOptions.mod;
+      } else if (typeof newOptions.font.ital === 'object') {
+        parentOptions.ital.size    = newOptions.font.ital.size    || parentOptions.size;
+        parentOptions.ital.face    = newOptions.font.ital.face    || parentOptions.face;
+        parentOptions.ital.color   = newOptions.font.ital.color   || parentOptions.color;
+        parentOptions.ital.vadjust = newOptions.font.ital.vadjust || parentOptions.vadjust;
+        parentOptions.ital.mod     = newOptions.font.ital.mod     || "";
+      }
+      if (typeof newOptions.font.boldital === 'string') {
+        let newBoldItalOptionsArray = newOptions.font.boldital.split(" ");
+        parentOptions.boldital.size    = newBoldItalOptionsArray[0].replace("px",'');
+        parentOptions.boldital.face    = newBoldItalOptionsArray[1];
+        parentOptions.boldital.color   = newBoldItalOptionsArray[2];
+        parentOptions.boldital.vadjust = parentOptions.vadjust;
+        parentOptions.boldital.mod     = parentOptions.mod;
+      } else if (typeof newOptions.font.boldital === 'object') {
+        parentOptions.boldital.size    = newOptions.font.boldital.size    || parentOptions.size;
+        parentOptions.boldital.face    = newOptions.font.boldital.face    || parentOptions.face;
+        parentOptions.boldital.color   = newOptions.font.boldital.color   || parentOptions.color;
+        parentOptions.boldital.vadjust = newOptions.font.boldital.vadjust || parentOptions.vadjust;
+        parentOptions.boldital.mod     = newOptions.font.boldital.mod     || "";
+      }
+      if (typeof newOptions.font.mono === 'string') {
+        let newMonoOptionsArray = newOptions.font.mono.split(" ");
+        parentOptions.mono.size    = newMonoOptionsArray[0].replace("px",'');
+        parentOptions.mono.face    = newMonoOptionsArray[1];
+        parentOptions.mono.color   = newMonoOptionsArray[2];
+        parentOptions.mono.vadjust = parentOptions.vadjust;
+        parentOptions.mono.mod     = parentOptions.mod;
+      } else if (typeof newOptions.font.mono === 'object') {
+        parentOptions.mono.size    = newOptions.font.mono.size    || parentOptions.size;
+        parentOptions.mono.face    = newOptions.font.mono.face    || parentOptions.face;
+        parentOptions.mono.color   = newOptions.font.mono.color   || parentOptions.color;
+        parentOptions.mono.vadjust = newOptions.font.mono.vadjust || parentOptions.vadjust;
+        parentOptions.mono.mod     = newOptions.font.mono.mod     || "";
+      }
     }
     parentOptions.size = Number(parentOptions.size);
+    parentOptions.bold.size = Number(parentOptions.bold.size);
+    parentOptions.ital.size = Number(parentOptions.ital.size);
+    parentOptions.boldital.size = Number(parentOptions.boldital.size);
+    parentOptions.mono.size = Number(parentOptions.mono.size);
   }
 
 
@@ -126,34 +187,36 @@ class Label {
     }
 
     let yLine = this.size.yLine;
-    let [fontColor, strokeColor] = this._getColor(viewFontSize);
     [x, yLine] = this._setAlignment(ctx, x, yLine, baseline);
 
-    // configure context for drawing the text
-    ctx.font = (selected && this.nodeOptions.labelHighlightBold ? 'bold ' : '') + fontSize + "px " + this.fontOptions.face;
-    ctx.fillStyle = fontColor;
-    // When the textAlign property is 'left', make label left-justified
-    if ((!this.isEdgeLabel) && this.fontOptions.align === 'left') {
-      ctx.textAlign = this.fontOptions.align;
-      x = x - 0.5 * this.size.width; // Shift label 1/2-distance to the left
-    } else {
-      ctx.textAlign = 'center';
-    }
-
-    // set the strokeWidth
-    if (this.fontOptions.strokeWidth > 0) {
-      ctx.lineWidth = this.fontOptions.strokeWidth;
-      ctx.strokeStyle = strokeColor;
-      ctx.lineJoin = 'round';
-    }
+    ctx.textAlign = 'left'
+    x = x - 0.5 * this.size.width; // Shift label 1/2-distance to the left
 
     // draw the text
     for (let i = 0; i < this.lineCount; i++) {
-      if (this.fontOptions.strokeWidth > 0) {
-        ctx.strokeText(this.lines[i], x, yLine);
+      if (this.lines[i] && this.lines[i].blocks) {
+        let width = 0;
+        if (this.isEdgeLabel || this.fontOptions.align === 'center') {
+          width += (this.size.width - this.lines[i].width) / 2
+        } else if (this.fontOptions.align === 'right') {
+          width += (this.size.width - this.lines[i].width)
+        }
+        for (let j = 0; j < this.lines[i].blocks.length; j++) {
+          let block = this.lines[i].blocks[j];
+          ctx.font = block.font;
+          let [fontColor, strokeColor] = this._getColor(block.color, viewFontSize);
+          if (this.fontOptions.strokeWidth > 0) {
+            ctx.lineWidth = this.fontOptions.strokeWidth;
+            ctx.strokeStyle = strokeColor;
+            ctx.lineJoin = 'round';
+            ctx.strokeText(block.text, x + width, yLine + block.vadjust);
+          }
+          ctx.fillStyle = fontColor;
+          ctx.fillText(block.text, x + width, yLine + block.vadjust);
+          width += block.width;
+        }
+        yLine += this.lines[i].height;
       }
-      ctx.fillText(this.lines[i], x, yLine);
-      yLine += fontSize;
     }
   }
 
@@ -180,7 +243,6 @@ class Label {
     else {
       ctx.textBaseline = baseline;
     }
-
     return [x,yLine];
   }
 
@@ -192,8 +254,8 @@ class Label {
    * @returns {*[]}
    * @private
    */
-  _getColor(viewFontSize) {
-    let fontColor = this.fontOptions.color || '#000000';
+  _getColor(color, viewFontSize) {
+    let fontColor = color || '#000000';
     let strokeColor = this.fontOptions.strokeColor || '#ffffff';
     if (viewFontSize <= this.nodeOptions.scaling.label.drawThreshold) {
       let opacity = Math.max(0, Math.min(1, 1 - (this.nodeOptions.scaling.label.drawThreshold - viewFontSize)));
@@ -211,12 +273,12 @@ class Label {
    * @returns {{width: number, height: number}}
    */
   getTextSize(ctx, selected = false) {
-    let size = {
-      width: this._processLabel(ctx,selected),
-      height: this.fontOptions.size * this.lineCount,
+    this._processLabel(ctx, selected);
+    return {
+      width: this.size.width,
+      height: this.size.height,
       lineCount: this.lineCount
     };
-    return size;
   }
 
 
@@ -230,9 +292,8 @@ class Label {
    */
   calculateLabelSize(ctx, selected, x = 0, y = 0, baseline = 'middle') {
     if (this.labelDirty === true) {
-      this.size.width = this._processLabel(ctx,selected);
+      this._processLabel(ctx,selected);
     }
-    this.size.height = this.fontOptions.size * this.lineCount;
     this.size.left = x - this.size.width * 0.5;
     this.size.top = y - this.size.height * 0.5;
     this.size.yLine = y + (1 - this.lineCount) * 0.5 * this.fontOptions.size;
@@ -241,36 +302,364 @@ class Label {
       this.size.top += 4;   // distance from node, required because we use hanging. Hanging has less difference between browsers
       this.size.yLine += 4; // distance from node
     }
-
     this.labelDirty = false;
   }
 
+  /**
+   * normalize the markup system
+   */
+  decodeMarkupSystem(markupSystem) {
+    let system = 'none';
+    if (markupSystem === 'markdown' || markupSystem === 'md') {
+      system = 'markdown';
+    } else if (markupSystem === true || markupSystem === 'html') {
+      system = 'html'
+    }
+    return system;
+  }
 
   /**
-   * This calculates the width as well as explodes the label string and calculates the amount of lines.
+   * Explodes a piece of text into single-font blocks using a given markup
+   * @param text
+   * @param markupSystem
+   * @returns [{ text, mod }]
+   */
+  splitBlocks(text, markupSystem) {
+    let system = this.decodeMarkupSystem(markupSystem);
+    if (system === 'none') {
+      return [{
+        text: text,
+        mod: 'normal'
+      }]
+    } else if (system === 'markdown') {
+      return this.splitMarkdownBlocks(text);
+    } else if (system === 'html') {
+      return this.splitHtmlBlocks(text);
+    }
+  }
+
+  splitMarkdownBlocks(text) {
+    let blocks = [];
+    let s = {
+      bold: false,
+      ital: false,
+      mono: false,
+      beginable: true,
+      spacing: false,
+      position: 0,
+      buffer: "",
+      modStack: []
+    };
+    s.mod = function() {
+      return (this.modStack.length === 0) ? 'normal' : this.modStack[0];
+    }
+    s.modName = function() {
+      if (this.modStack.length === 0)
+        return 'normal';
+      else if (this.modStack[0] === 'mono')
+        return 'mono';
+      else {
+        if (s.bold && s.ital) {
+          return 'boldital';
+        } else if (s.bold) {
+          return 'bold';
+        } else if (s.ital) {
+          return 'ital';
+        }
+      }
+    }
+    s.emitBlock = function(override = false) {
+      if (this.spacing) {
+        this.add(" ");
+        this.spacing = false;
+      }
+      if (this.buffer.length > 0) {
+        blocks.push({ text: this.buffer, mod: this.modName() });
+        this.buffer = "";
+      }
+    }
+    s.add = function(text) {
+      if (text === " ") {
+        s.spacing = true;
+      }
+      if (s.spacing) {
+        this.buffer += " ";
+        this.spacing = false;
+      }
+      if (text != " ") {
+        this.buffer += text;
+      }
+    }
+    while (s.position < text.length) {
+      let char = text.charAt(s.position);
+      if (/[ \t]/.test(char)) {
+        if (!s.mono) {
+          s.spacing = true;
+        } else {
+          s.add(char);
+        }
+        s.beginable = true
+      } else if (/\\/.test(char)) {
+        if (s.position < text.length+1) {
+          s.position++;
+          char = text.charAt(s.position);
+          if (/ \t/.test(char)) {
+            s.spacing = true;
+          } else {
+            s.add(char);
+            s.beginable = false;
+          }
+        }
+      } else if (!s.mono && !s.bold && (s.beginable || s.spacing) && /\*/.test(char)) {
+        s.emitBlock();
+        s.bold = true;
+        s.modStack.unshift("bold");
+      } else if (!s.mono && !s.ital && (s.beginable || s.spacing) && /\_/.test(char)) {
+        s.emitBlock();
+        s.ital = true;
+        s.modStack.unshift("ital");
+      } else if (!s.mono && (s.beginable || s.spacing) && /`/.test(char)) {
+        s.emitBlock();
+        s.mono = true;
+        s.modStack.unshift("mono");
+      } else if (!s.mono && (s.mod() === "bold") && /\*/.test(char)) {
+        if ((s.position === text.length-1) || /[.,_` \t\n]/.test(text.charAt(s.position+1))) {
+          s.emitBlock();
+          s.bold = false;
+          s.modStack.shift();
+        } else {
+          s.add(char);
+        }
+      } else if (!s.mono && (s.mod() === "ital") && /\_/.test(char)) {
+        if ((s.position === text.length-1) || /[.,*` \t\n]/.test(text.charAt(s.position+1))) {
+          s.emitBlock();
+          s.ital = false;
+          s.modStack.shift();
+        } else {
+          s.add(char);
+        }
+      } else if (s.mono && (s.mod() === "mono") && /`/.test(char)) {
+        if ((s.position === text.length-1) || (/[.,*_ \t\n]/.test(text.charAt(s.position+1)))) {
+          s.emitBlock();
+          s.mono = false;
+          s.modStack.shift();
+        } else {
+          s.add(char);
+        }
+      } else {
+        s.add(char);
+        s.beginable = false;
+      }
+      s.position++
+    }
+    s.emitBlock();
+    return blocks;
+  }
+
+  splitHtmlBlocks(text) {
+    let blocks = [];
+    let s = {
+      bold: false,
+      ital: false,
+      mono: false,
+      spacing: false,
+      position: 0,
+      buffer: "",
+      modStack: []
+    };
+    s.mod = function() {
+      return (this.modStack.length === 0) ? 'normal' : this.modStack[0];
+    }
+    s.modName = function() {
+      if (this.modStack.length === 0)
+        return 'normal';
+      else if (this.modStack[0] === 'mono')
+        return 'mono';
+      else {
+        if (s.bold && s.ital) {
+          return 'boldital';
+        } else if (s.bold) {
+          return 'bold';
+        } else if (s.ital) {
+          return 'ital';
+        }
+      }
+    }
+    s.emitBlock = function(override = false) {
+      if (this.spacing) {
+        this.add(" ");
+        this.spacing = false;
+      }
+      if (this.buffer.length > 0) {
+        blocks.push({ text: this.buffer, mod: this.modName() });
+        this.buffer = "";
+      }
+    }
+    s.add = function(text) {
+      if (text === " ") {
+        s.spacing = true;
+      }
+      if (s.spacing) {
+        this.buffer += " ";
+        this.spacing = false;
+      }
+      if (text != " ") {
+        this.buffer += text;
+      }
+    }
+    while (s.position < text.length) {
+      let char = text.charAt(s.position);
+      if (/[ \t]/.test(char)) {
+        if (!s.mono) {
+          s.spacing = true;
+        } else {
+          s.add(char);
+        }
+      } else if (/</.test(char)) {
+        if (!s.mono && !s.bold && /<b>/.test(text.substr(s.position,3))) {
+          s.emitBlock();
+          s.bold = true;
+          s.modStack.unshift("bold");
+          s.position += 2;
+        } else if (!s.mono && !s.ital && /<i>/.test(text.substr(s.position,3))) {
+          s.emitBlock();
+          s.ital = true;
+          s.modStack.unshift("ital");
+          s.position += 2;
+        } else if (!s.mono && /<code>/.test(text.substr(s.position,6))) {
+          s.emitBlock();
+          s.mono = true;
+          s.modStack.unshift("mono");
+          s.position += 5;
+        } else if (!s.mono && (s.mod() === 'bold') && /<\/b>/.test(text.substr(s.position,4))) {
+          s.emitBlock();
+          s.bold = false;
+          s.modStack.shift();
+          s.position += 3;
+        } else if (!s.mono && (s.mod() === 'ital') && /<\/i>/.test(text.substr(s.position,4))) {
+          s.emitBlock();
+          s.ital = false;
+          s.modStack.shift();
+          s.position += 3;
+        } else if ((s.mod() === 'mono') && /<\/code>/.test(text.substr(s.position,7))) {
+          s.emitBlock();
+          s.mono = false;
+          s.modStack.shift();
+          s.position += 6;
+        } else {
+          s.add(char);
+        }
+      } else if (/&/.test(char)) {
+        if (/&lt;/.test(text.substr(s.position,4))) {
+          s.add("<");
+          s.position += 3;
+        } else if (/&amp;/.test(text.substr(s.position,5))) {
+          s.add("&");
+          s.position += 4;
+        } else {
+          s.add("&");
+        }
+      } else {
+        s.add(char);
+      }
+      s.position++
+    }
+    s.emitBlock();
+    return blocks;
+  }
+
+  setFont(ctx, selected, mod) {
+    let height
+    let vadjust
+    let color
+    if (mod === 'normal') {
+      ctx.font = (selected && this.nodeOptions.labelHighlightBold ? 'bold ' : '') +
+                 this.fontOptions.size + "px " + this.fontOptions.face;
+      color = this.fontOptions.color;
+      height = this.fontOptions.size;
+      vadjust = this.fontOptions.vadjust;
+    } else {
+      ctx.font = this.fontOptions[mod].mod + " " +
+                 this.fontOptions[mod].size + "px " + this.fontOptions[mod].face;
+      color = this.fontOptions[mod].color;
+      height = this.fontOptions[mod].size;
+      vadjust = this.fontOptions[mod].vadjust || 0;
+    }
+    return {
+      font: ctx.font.replace(/"/g, ""),
+      color: color,
+      height: height,
+      vadjust: vadjust
+    }
+  }
+
+  /**
+   * This explodes the label string into lines and sets the width, height and number of lines.
    * @param ctx
    * @param selected
-   * @returns {number}
    * @private
    */
   _processLabel(ctx,selected) {
     let width = 0;
-    let lines = [''];
+    let height = 0;
+    let nlLines = [];
+    let lines = [];
     let lineCount = 0;
     if (this.nodeOptions.label !== undefined) {
-      lines = String(this.nodeOptions.label).split('\n');
-      lineCount = lines.length;
-      ctx.font = (selected && this.nodeOptions.labelHighlightBold ? 'bold ' : '') + this.fontOptions.size + "px " + this.fontOptions.face;
-      width = ctx.measureText(lines[0]).width;
-      for (let i = 1; i < lineCount; i++) {
-        let lineWidth = ctx.measureText(lines[i]).width;
-        width = lineWidth > width ? lineWidth : width;
+      let nlLines = String(this.nodeOptions.label).split('\n');
+      lineCount = nlLines.length;
+      if (this.nodeOptions.font.multi) {
+        for (let i = 0; i < lineCount; i++) {
+          let blocks = this.splitBlocks(nlLines[i], this.nodeOptions.font.multi);
+          if (blocks) {
+            lines[i] = { width: 0, height: 0, blocks: [] };
+            if (blocks.length === 0) {
+              lines[i].height = this.fontOptions.size;
+            }
+            for (let j = 0; j < blocks.length; j++) {
+              let metrics = this.setFont(ctx, selected, blocks[j].mod)
+              let measure = ctx.measureText(blocks[j].text);
+              lines[i].width += measure.width;
+              lines[i].height = metrics.height > lines[i].height ? metrics.height : lines[i].height;
+              lines[i].blocks[j] = {
+                text: blocks[j].text,
+                font: ctx.font,
+                color: metrics.color,
+                width: measure.width,
+                height: metrics.height,
+                vadjust: metrics.vadjust
+              };
+            }
+            width = lines[i].width > width ? lines[i].width : width;
+            height += lines[i].height;
+          }
+        }
+      } else {
+        for (let i = 0; i < lineCount; i++) {
+          let blocks = this.splitBlocks(nlLines[i], false);
+          lines[i] = { width: 0, height: 0, blocks: [] };
+          ctx.font = (selected && this.nodeOptions.labelHighlightBold ? 'bold ' : '') + this.fontOptions.size + "px " + this.fontOptions.face;
+          let text = nlLines[i];
+          let measure = ctx.measureText(text);
+          lines[i].width += measure.width;
+          lines[i].height = this.fontOptions.size > lines[i].height ? this.fontOptions.size : lines[i].height;
+          lines[i].blocks[0] = {
+            text: text,
+            font: ctx.font,
+            color: this.fontOptions.color,
+            width: measure.width,
+            height: this.fontOptions.size,
+            vadjust: this.fontOptions.vadjust
+          };
+          width = lines[i].width > width ? lines[i].width : width;
+          height += lines[i].height;
+        }
       }
     }
     this.lines = lines;
     this.lineCount = lineCount;
-
-    return width;
+    this.size.width = width;
+    this.size.height = height;
   }
 }
 

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -46,68 +46,117 @@ class Label {
     }
     else if (typeof newOptions.font === 'object') {
       util.fillIfDefined(parentOptions, newOptions.font, allowDeletion);
-      if (typeof newOptions.font.bold === 'string') {
-        let newBoldOptionsArray = newOptions.font.bold.split(" ");
-        parentOptions.bold.size    = newBoldOptionsArray[0].replace("px",'');
-        parentOptions.bold.face    = newBoldOptionsArray[1];
-        parentOptions.bold.color   = newBoldOptionsArray[2];
-        parentOptions.bold.vadjust = parentOptions.vadjust;
-        parentOptions.bold.mod     = parentOptions.mod;
-      } else if (typeof newOptions.font.bold === 'object') {
-        parentOptions.bold.size    = newOptions.font.bold.size    || parentOptions.size;
-        parentOptions.bold.face    = newOptions.font.bold.face    || parentOptions.face;
-        parentOptions.bold.color   = newOptions.font.bold.color   || parentOptions.color;
-        parentOptions.bold.vadjust = newOptions.font.bold.vadjust || parentOptions.vadjust;
-        parentOptions.bold.mod     = newOptions.font.bold.mod     || "";
-      }
-      if (typeof newOptions.font.ital === 'string') {
-        let newItalOptionsArray = newOptions.font.ital.split(" ");
-        parentOptions.ital.size    = newItalOptionsArray[0].replace("px",'');
-        parentOptions.ital.face    = newItalOptionsArray[1];
-        parentOptions.ital.color   = newItalOptionsArray[2];
-        parentOptions.ital.vadjust = parentOptions.vadjust;
-        parentOptions.ital.mod     = parentOptions.mod;
-      } else if (typeof newOptions.font.ital === 'object') {
-        parentOptions.ital.size    = newOptions.font.ital.size    || parentOptions.size;
-        parentOptions.ital.face    = newOptions.font.ital.face    || parentOptions.face;
-        parentOptions.ital.color   = newOptions.font.ital.color   || parentOptions.color;
-        parentOptions.ital.vadjust = newOptions.font.ital.vadjust || parentOptions.vadjust;
-        parentOptions.ital.mod     = newOptions.font.ital.mod     || "";
-      }
-      if (typeof newOptions.font.boldital === 'string') {
-        let newBoldItalOptionsArray = newOptions.font.boldital.split(" ");
-        parentOptions.boldital.size    = newBoldItalOptionsArray[0].replace("px",'');
-        parentOptions.boldital.face    = newBoldItalOptionsArray[1];
-        parentOptions.boldital.color   = newBoldItalOptionsArray[2];
-        parentOptions.boldital.vadjust = parentOptions.vadjust;
-        parentOptions.boldital.mod     = parentOptions.mod;
-      } else if (typeof newOptions.font.boldital === 'object') {
-        parentOptions.boldital.size    = newOptions.font.boldital.size    || parentOptions.size;
-        parentOptions.boldital.face    = newOptions.font.boldital.face    || parentOptions.face;
-        parentOptions.boldital.color   = newOptions.font.boldital.color   || parentOptions.color;
-        parentOptions.boldital.vadjust = newOptions.font.boldital.vadjust || parentOptions.vadjust;
-        parentOptions.boldital.mod     = newOptions.font.boldital.mod     || "";
-      }
-      if (typeof newOptions.font.mono === 'string') {
-        let newMonoOptionsArray = newOptions.font.mono.split(" ");
-        parentOptions.mono.size    = newMonoOptionsArray[0].replace("px",'');
-        parentOptions.mono.face    = newMonoOptionsArray[1];
-        parentOptions.mono.color   = newMonoOptionsArray[2];
-        parentOptions.mono.vadjust = parentOptions.vadjust;
-        parentOptions.mono.mod     = parentOptions.mod;
-      } else if (typeof newOptions.font.mono === 'object') {
-        parentOptions.mono.size    = newOptions.font.mono.size    || parentOptions.size;
-        parentOptions.mono.face    = newOptions.font.mono.face    || parentOptions.face;
-        parentOptions.mono.color   = newOptions.font.mono.color   || parentOptions.color;
-        parentOptions.mono.vadjust = newOptions.font.mono.vadjust || parentOptions.vadjust;
-        parentOptions.mono.mod     = newOptions.font.mono.mod     || "";
+    }
+    parentOptions.size    = Number(parentOptions.size);
+    parentOptions.vadjust = Number(parentOptions.vadjust);
+  }
+
+  propagateFonts(options, groupOptions, defaultOptions) {
+    if (this.fontOptions.multi) {
+      let mods = [ 'bold', 'ital', 'boldital', 'mono' ];
+      for (const mod of mods) {
+        let optionsFontMod = options.font[mod];
+        if (typeof optionsFontMod === 'string') {
+          let modOptionsArray = optionsFontMod.split(" ");
+          this.fontOptions[mod].size  = modOptionsArray[0].replace("px","");
+          this.fontOptions[mod].face  = modOptionsArray[1];
+          this.fontOptions[mod].color = modOptionsArray[2];
+          this.fontOptions[mod].vadjust = this.fontOptions.vadjust;
+          this.fontOptions[mod].mod = defaultOptions.font[mod].mod;
+        } else {
+          // We need to be crafty about loading the modded fonts. We want as
+          // much 'natural' versatility as we can get, so a simple global
+          // change propagates in an expected way, even if not stictly logical.
+
+          // face: We want to capture any direct settings and overrides, but
+          //       fall back to the base font if there aren't any. We make a
+          //       special exception for mono, since we probably don't want to
+          //       sync to a the base font face.
+          //
+          //   if the mod face is in the node's options, use it
+          //   else if the mod face is in the global options, use it
+          //   else if the face is in the global options, use it
+          //   else use the base font's face.
+          if (optionsFontMod && optionsFontMod.hasOwnProperty('face')) {
+            this.fontOptions[mod].face = optionsFontMod.face;
+          } else if (groupOptions.font[mod] && groupOptions.font[mod].hasOwnProperty('face')) {
+            this.fontOptions[mod].face = groupOptions.font[mod].face;
+          } else if (mod === 'mono') {
+            this.fontOptions[mod].face = defaultOptions.font[mod].face;
+          } else if (groupOptions.font.hasOwnProperty('face')) {
+            this.fontOptions[mod].face = groupOptions.font.face;
+          } else {
+            this.fontOptions[mod].face = this.fontOptions.face;
+          }
+
+          // color: this is handled just like the face.
+          if (optionsFontMod && optionsFontMod.hasOwnProperty('color')) {
+            this.fontOptions[mod].color = optionsFontMod.color;
+          } else if (groupOptions.font[mod] && groupOptions.font[mod].hasOwnProperty('color')) {
+            this.fontOptions[mod].color = groupOptions.font[mod].color;
+          } else if (groupOptions.font.hasOwnProperty('color')) {
+            this.fontOptions[mod].color = groupOptions.font.color;
+          } else {
+            this.fontOptions[mod].color = this.fontOptions.color;
+          }
+
+          // mod: this is handled just like the face, except we never grab the
+          // base font's mod. We know they're in the defaultOptions, and unless
+          // we've been steered away from them, we use the default.
+          if (optionsFontMod && optionsFontMod.hasOwnProperty('mod')) {
+            this.fontOptions[mod].mod = optionsFontMod.mod;
+          } else if (groupOptions.font[mod] && groupOptions.font[mod].hasOwnProperty('mod')) {
+            this.fontOptions[mod].mod = groupOptions.font[mod].mod;
+          } else if (groupOptions.font.hasOwnProperty('mod')) {
+            this.fontOptions[mod].mod = groupOptions.font.mod;
+          } else {
+            this.fontOptions[mod].mod = defaultOptions.font[mod].mod;
+          }
+
+          // size: It's important that we size up defaults similarly if we're
+          //       using default faces unless overriden. We want to preserve the
+          //       ratios closely - but if faces have changed, all bets are off.
+          //
+          //   if the mod size is in the node's options, use it
+          //   else if the mod size is in the global options, use it
+          //   else if the mod face is the same as the default and the base face
+          //     is the same as the default, scale the mod size using the same
+          //     ratio
+          //   else if the size is in the global options, use it
+          //   else use the base font's size.
+          if (optionsFontMod && optionsFontMod.hasOwnProperty('size')) {
+            this.fontOptions[mod].size = optionsFontMod.size;
+          } else if (groupOptions.font[mod] && groupOptions.font[mod].hasOwnProperty('size')) {
+            this.fontOptions[mod].size = groupOptions.font[mod].size;
+          } else if ((this.fontOptions[mod].face === defaultOptions.font[mod].face) &&
+                     (this.fontOptions.face === defaultOptions.font.face)) {
+            let ratio = this.fontOptions.size / Number(defaultOptions.font.size);
+            this.fontOptions[mod].size = defaultOptions.font[mod].size * ratio;
+          } else if (groupOptions.font.hasOwnProperty('size')) {
+            this.fontOptions[mod].size = groupOptions.font.size;
+          } else {
+            this.fontOptions[mod].size = this.fontOptions.size;
+          }
+
+          // vadjust: this is handled just like the size.
+          if (optionsFontMod && optionsFontMod.hasOwnProperty('vadjust')) {
+            this.fontOptions[mod].vadjust = optionsFontMod.vadjust;
+          } else if (groupOptions.font[mod] && groupOptions.font[mod].hasOwnProperty('vadjust')) {
+            this.fontOptions[mod].vadjust = groupOptions.font[mod].vadjust;
+          } else if ((this.fontOptions[mod].face === defaultOptions.font[mod].face) &&
+                     (this.fontOptions.face === defaultOptions.font.face)) {
+            let ratio = this.fontOptions.size / Number(defaultOptions.font.size);
+            this.fontOptions[mod].vadjust = defaultOptions.font[mod].vadjust * Math.round(ratio);
+          } else if (groupOptions.font.hasOwnProperty('vadjust')) {
+            this.fontOptions[mod].vadjust = groupOptions.font.vadjust;
+          } else {
+            this.fontOptions[mod].vadjust = this.fontOptions.vadjust;
+          }
+        }
+        this.fontOptions[mod].size    = Number(this.fontOptions[mod].size);
+        this.fontOptions[mod].vadjust = Number(this.fontOptions[mod].vadjust);
       }
     }
-    parentOptions.size = Number(parentOptions.size);
-    parentOptions.bold.size = Number(parentOptions.bold.size);
-    parentOptions.ital.size = Number(parentOptions.ital.size);
-    parentOptions.boldital.size = Number(parentOptions.boldital.size);
-    parentOptions.mono.size = Number(parentOptions.mono.size);
   }
 
 

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -47,6 +47,40 @@ let allOptions = {
       strokeWidth: { number }, // px
       strokeColor: { string },
       align: { string: ['horizontal', 'top', 'middle', 'bottom'] },
+      vadjust: { number },
+      multi: { boolean, string },
+      bold: {
+        color: { string },
+        size: { number }, // px
+        face: { string },
+        mod: { string },
+        vadjust: { number },
+        __type__: { object, string }
+      },
+      boldital: {
+        color: { string },
+        size: { number }, // px
+        face: { string },
+        mod: { string },
+        vadjust: { number },
+        __type__: { object, string }
+      },
+      ital: {
+        color: { string },
+        size: { number }, // px
+        face: { string },
+        mod: { string },
+        vadjust: { number },
+        __type__: { object, string }
+      },
+      mono: {
+        color: { string },
+        size: { number }, // px
+        face: { string },
+        mod: { string },
+        vadjust: { number },
+        __type__: { object, string }
+      },
       __type__: { object, string }
     },
     hidden: { boolean },
@@ -181,6 +215,40 @@ let allOptions = {
       background: { string },
       strokeWidth: { number }, // px
       strokeColor: { string },
+      vadjust: { number },
+      multi: { boolean, string },
+      bold: {
+        color: { string },
+        size: { number }, // px
+        face: { string },
+        mod: { string },
+        vadjust: { number },
+        __type__: { object, string }
+      },
+      boldital: {
+        color: { string },
+        size: { number }, // px
+        face: { string },
+        mod: { string },
+        vadjust: { number },
+        __type__: { object, string }
+      },
+      ital: {
+        color: { string },
+        size: { number }, // px
+        face: { string },
+        mod: { string },
+        vadjust: { number },
+        __type__: { object, string }
+      },
+      mono: {
+        color: { string },
+        size: { number }, // px
+        face: { string },
+        mod: { string },
+        vadjust: { number },
+        __type__: { object, string }
+      },
       __type__: { object, string }
     },
     group: { string, number, 'undefined': 'undefined' },


### PR DESCRIPTION
(Replaced by PR #2385)

fixes #1603
fixes #1936

Adds multifont rendering capability to network node and edge labels. Existing networks are not altered.

`font.multi` designates html or markdown. Bold, italic and code (monospaced) markup is supported.

`font.bold` designates the bold font properties, `font.italic` the italic font properties, `font.bolditalic` the bold-italic font properties, and `font.mono` the monospace font properties.

A `vadjust` property has also been added to the fonts that may be used to adjust any baseline mismatching between fonts.

Properties may be assigned in the network node and edge options, or on individual nodes and edges.

The `network/labels/labelMultifont.html` example provides illustration and some finer details.

The documents are also updated.