### PR TITLE
Fix redraw order 

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -115,6 +115,10 @@ Core.prototype._create = function (container) {
   this.on('panmove',         this._onDrag.bind(this));
 
   var me = this;
+  
+  this._origRedraw = this._redraw.bind(this);
+  this._redraw = util.throttle(this._origRedraw);
+  
   this.on('_change', function (properties) {
     if (me.itemSet.initialItemSetDrawn && properties && properties.queue == true) {
       me._redraw()
@@ -412,15 +416,7 @@ Core.prototype.setOptions = function (options) {
     this.configurator.setModuleOptions({global: appliedOptions});
   }
 
-  // override redraw with a throttled version
-  if (!this._origRedraw) {
-    this._origRedraw = this._redraw.bind(this);
-    this._redraw = util.throttle(this._origRedraw);
-  } else {
-    // Not the initial run: redraw everything
-    this._redraw();
-  }
-
+  this._redraw();
 };
 
 /**


### PR DESCRIPTION
The code before was causing `_origRedraw` to not be defined in some cases. 
This fixes this issue.