### PR TITLE
make sure a given element isn’t undefined before accessing properties

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1488,17 +1488,19 @@ exports.topMost = function (pile, accessors) {
     accessors = [accessors];
   }
   for (const member of pile) {
-    candidate = member[accessors[0]];
-    for (let i = 1; i < accessors.length; i++){
-      if (candidate) {
-        candidate = candidate[accessors[i]]
-      } else {
-        continue;
+    if (member) {
+      candidate = member[accessors[0]];
+      for (let i = 1; i < accessors.length; i++){
+        if (candidate) {
+          candidate = candidate[accessors[i]]
+        } else {
+          continue;
+        }
       }
-    }
-    if (candidate) {
-      break;
+      if (candidate) {
+        break;
+      }
     }
   }
   return candidate;
-}
+};


### PR DESCRIPTION
fixes #2402 

the util.topMost functions searches a pile of candidates for the first that defines an accessor. But no check was being done for the presence of a candidate before checking. An added conditional now prevents this from happening.
