### PR TITLE
added code-climate checks for develop branch

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,26 @@
+languages:
+  JavaScript: true
+engines:
+  eslint:
+    enabled: true
+  csslint:
+    enabled: true
+  markdownlint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        javascript:
+          mass_threshold: 300
+  fixme :
+    enabled: true
+ratings:
+  paths:
+  - "**/*.js"
+  - "**/*.css"
+  - "**/*.md"
+exclude_paths:
+  - "dist/**/*"
+  - "docs/**/*"
+  - "examples/**/*"

--- a/.csslintrc
+++ b/.csslintrc
@@ -1,4 +1,5 @@
 {
+  "adjoining-classes": false,
   "box-model": false,
   "box-sizing": false,
   "order-alphabetical": false

--- a/.csslintrc
+++ b/.csslintrc
@@ -1,3 +1,4 @@
 {
+  "box-model": false,
   "box-sizing": false
 }

--- a/.csslintrc
+++ b/.csslintrc
@@ -1,4 +1,5 @@
 {
   "box-model": false,
-  "box-sizing": false
+  "box-sizing": false,
+  "order-alphabetical": false
 }

--- a/.csslintrc
+++ b/.csslintrc
@@ -1,0 +1,3 @@
+{
+  "box-sizing": false
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "complexity": [2, 50],
+    "max-statements": [2, 100]
+  }
+}

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,6 @@
+// Markdown Lint Rules
+// https://github.com/mivok/markdownlint/blob/master/docs/RULES.md
+
+rules
+  "~MD012", // alert on multiple consecutive blank lines
+  "~MD013", // line length should be no more than 80 characters

--- a/.mdlrc
+++ b/.mdlrc
@@ -4,3 +4,4 @@
 rules
   "~MD012", // alert on multiple consecutive blank lines
   "~MD013", // line length should be no more than 80 characters
+  "~MD014", // Dollar signs used before commands without showing output

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,7 +14,7 @@ http://visjs.org
 - Fixed #2170: Improved the contribution docs (#1991, #2158, #2178, #2183, #2213, #2218, #2219)
 - Implemented #1969: generate individual css files for network and timeline (#1970)
 - Cleanup bower.json (#1968)
-- Removed feature-request page from website (TODO)
+- Fixed #2114: Removed feature-request page from website
 - Distinguish better between `devDependencies` and `dependencies` (#1967)
 - Typos and minor docs improvements (#1958, #2028, #2050, #2093, #2222, #2223, #2224)
 - Replaced `gulp-minify-css` with `gulp-clean-css` (#1953)
@@ -266,7 +266,7 @@ http://visjs.org
 ### General
 
 - Fixed #1353: Custom bundling with browserify requiring manual installation
-  of `babelify`.  
+  of `babelify`.
 
 ### Network
 
@@ -451,7 +451,7 @@ http://visjs.org
 - Fixed #1033: Moved item data not updated in DataSet when using an asynchronous
   `onMove` handler.
 - Fixed #239: Do not zoom/move the window when the mouse is on the left panel
-  with group labels.   
+  with group labels.
 
 
 ## 2015-07-03, version 4.4.0


### PR DESCRIPTION
Code-Climate provides a nice opportunity to get a feeling for eslint and csslint status.
I would like to integrate linting into the build process but before that we should get the major issues out of the way.
Rules that make no sense for use should be disabled.