### PR TITLE
Fix YUI Compressor incompatibilities and improve JavaScript correctness

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,8 @@ var webpackModule = {
       loader: 'babel',
       query: {
         cacheDirectory: true,
-        presets: ['es2015']
+        presets: ['es2015'],
+        plugins: ['transform-es3-property-literals', 'transform-es3-member-expression-literals']
       }
     }
   ],

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -519,63 +519,63 @@ class Label {
       }
     }
     while (s.position < text.length) {
-      let char = text.charAt(s.position);
-      if (/[ \t]/.test(char)) {
+      let ch = text.charAt(s.position);
+      if (/[ \t]/.test(ch)) {
         if (!s.mono) {
           s.spacing = true;
         } else {
-          s.add(char);
+          s.add(ch);
         }
         s.beginable = true
-      } else if (/\\/.test(char)) {
+      } else if (/\\/.test(ch)) {
         if (s.position < text.length+1) {
           s.position++;
-          char = text.charAt(s.position);
-          if (/ \t/.test(char)) {
+          ch = text.charAt(s.position);
+          if (/ \t/.test(ch)) {
             s.spacing = true;
           } else {
-            s.add(char);
+            s.add(ch);
             s.beginable = false;
           }
         }
-      } else if (!s.mono && !s.bold && (s.beginable || s.spacing) && /\*/.test(char)) {
+      } else if (!s.mono && !s.bold && (s.beginable || s.spacing) && /\*/.test(ch)) {
         s.emitBlock();
         s.bold = true;
         s.modStack.unshift("bold");
-      } else if (!s.mono && !s.ital && (s.beginable || s.spacing) && /\_/.test(char)) {
+      } else if (!s.mono && !s.ital && (s.beginable || s.spacing) && /\_/.test(ch)) {
         s.emitBlock();
         s.ital = true;
         s.modStack.unshift("ital");
-      } else if (!s.mono && (s.beginable || s.spacing) && /`/.test(char)) {
+      } else if (!s.mono && (s.beginable || s.spacing) && /`/.test(ch)) {
         s.emitBlock();
         s.mono = true;
         s.modStack.unshift("mono");
-      } else if (!s.mono && (s.mod() === "bold") && /\*/.test(char)) {
+      } else if (!s.mono && (s.mod() === "bold") && /\*/.test(ch)) {
         if ((s.position === text.length-1) || /[.,_` \t\n]/.test(text.charAt(s.position+1))) {
           s.emitBlock();
           s.bold = false;
           s.modStack.shift();
         } else {
-          s.add(char);
+          s.add(ch);
         }
-      } else if (!s.mono && (s.mod() === "ital") && /\_/.test(char)) {
+      } else if (!s.mono && (s.mod() === "ital") && /\_/.test(ch)) {
         if ((s.position === text.length-1) || /[.,*` \t\n]/.test(text.charAt(s.position+1))) {
           s.emitBlock();
           s.ital = false;
           s.modStack.shift();
         } else {
-          s.add(char);
+          s.add(ch);
         }
-      } else if (s.mono && (s.mod() === "mono") && /`/.test(char)) {
+      } else if (s.mono && (s.mod() === "mono") && /`/.test(ch)) {
         if ((s.position === text.length-1) || (/[.,*_ \t\n]/.test(text.charAt(s.position+1)))) {
           s.emitBlock();
           s.mono = false;
           s.modStack.shift();
         } else {
-          s.add(char);
+          s.add(ch);
         }
       } else {
-        s.add(char);
+        s.add(ch);
         s.beginable = false;
       }
       s.position++
@@ -636,14 +636,14 @@ class Label {
       }
     }
     while (s.position < text.length) {
-      let char = text.charAt(s.position);
-      if (/[ \t]/.test(char)) {
+      let ch = text.charAt(s.position);
+      if (/[ \t]/.test(ch)) {
         if (!s.mono) {
           s.spacing = true;
         } else {
-          s.add(char);
+          s.add(ch);
         }
-      } else if (/</.test(char)) {
+      } else if (/</.test(ch)) {
         if (!s.mono && !s.bold && /<b>/.test(text.substr(s.position,3))) {
           s.emitBlock();
           s.bold = true;
@@ -675,9 +675,9 @@ class Label {
           s.modStack.shift();
           s.position += 6;
         } else {
-          s.add(char);
+          s.add(ch);
         }
-      } else if (/&/.test(char)) {
+      } else if (/&/.test(ch)) {
         if (/&lt;/.test(text.substr(s.position,4))) {
           s.add("<");
           s.position += 3;
@@ -688,7 +688,7 @@ class Label {
           s.add("&");
         }
       } else {
-        s.add(char);
+        s.add(ch);
       }
       s.position++
     }

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -6,7 +6,7 @@
  * __type__ is a required field for all objects and contains the allowed types of all objects
  */
 let string = 'string';
-let boolean = 'boolean';
+let bool = 'boolean';
 let number = 'number';
 let array = 'array';
 let object = 'object'; // should only be in a __type__ property
@@ -16,29 +16,29 @@ let any = 'any';
 
 let allOptions = {
   configure: {
-    enabled: { boolean },
-    filter: { boolean, string, array, 'function': 'function' },
+    enabled: { bool },
+    filter: { bool, string, array, 'function': 'function' },
     container: { dom },
-    showButton: { boolean },
-    __type__: { object, boolean, string, array, 'function': 'function' }
+    showButton: { bool },
+    __type__: { object, bool, string, array, 'function': 'function' }
   },
   edges: {
     arrows: {
-      to: { enabled: { boolean }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean } },
-      middle: { enabled: { boolean }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean } },
-      from: { enabled: { boolean }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean } },
+      to: { enabled: { bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, bool } },
+      middle: { enabled: { bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, bool } },
+      from: { enabled: { bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, bool } },
       __type__: { string: ['from', 'to', 'middle'], object }
     },
-    arrowStrikethrough: { boolean },
+    arrowStrikethrough: { bool },
     color: {
       color: { string },
       highlight: { string },
       hover: { string },
-      inherit: { string: ['from', 'to', 'both'], boolean },
+      inherit: { string: ['from', 'to', 'both'], bool },
       opacity: { number },
       __type__: { object, string }
     },
-    dashes: { boolean, array },
+    dashes: { bool, array },
     font: {
       color: { string },
       size: { number }, // px
@@ -48,7 +48,7 @@ let allOptions = {
       strokeColor: { string },
       align: { string: ['horizontal', 'top', 'middle', 'bottom'] },
       vadjust: { number },
-      multi: { boolean, string },
+      multi: { bool, string },
       bold: {
         color: { string },
         size: { number }, // px
@@ -83,22 +83,22 @@ let allOptions = {
       },
       __type__: { object, string }
     },
-    hidden: { boolean },
+    hidden: { bool },
     hoverWidth: { 'function': 'function', number },
     label: { string, 'undefined': 'undefined' },
-    labelHighlightBold: { boolean },
+    labelHighlightBold: { bool },
     length: { number, 'undefined': 'undefined' },
-    physics: { boolean },
+    physics: { bool },
     scaling: {
       min: { number },
       max: { number },
       label: {
-        enabled: { boolean },
+        enabled: { bool },
         min: { number },
         max: { number },
         maxVisible: { number },
         drawThreshold: { number },
-        __type__: { object, boolean }
+        __type__: { object, bool }
       },
       customScalingFunction: { 'function': 'function' },
       __type__: { object }
@@ -106,86 +106,86 @@ let allOptions = {
     selectionWidth: { 'function': 'function', number },
     selfReferenceSize: { number },
     shadow: {
-      enabled: { boolean },
+      enabled: { bool },
       color: { string },
       size: { number },
       x: { number },
       y: { number },
-      __type__: { object, boolean }
+      __type__: { object, bool }
     },
     smooth: {
-      enabled: { boolean },
+      enabled: { bool },
       type: { string: ['dynamic', 'continuous', 'discrete', 'diagonalCross', 'straightCross', 'horizontal', 'vertical', 'curvedCW', 'curvedCCW', 'cubicBezier'] },
       roundness: { number },
-      forceDirection: { string: ['horizontal', 'vertical', 'none'], boolean },
-      __type__: { object, boolean }
+      forceDirection: { string: ['horizontal', 'vertical', 'none'], bool },
+      __type__: { object, bool }
     },
     title: { string, 'undefined': 'undefined' },
     width: { number },
     widthConstraint: {
       maximum: { number },
-      __type__: { object, boolean, number }
+      __type__: { object, bool, number }
     },
     value: { number, 'undefined': 'undefined' },
     __type__: { object }
   },
   groups: {
-    useDefaultGroups: { boolean },
+    useDefaultGroups: { bool },
     __any__: 'get from nodes, will be overwritten below',
     __type__: { object }
   },
   interaction: {
-    dragNodes: { boolean },
-    dragView: { boolean },
-    hideEdgesOnDrag: { boolean },
-    hideNodesOnDrag: { boolean },
-    hover: { boolean },
+    dragNodes: { bool },
+    dragView: { bool },
+    hideEdgesOnDrag: { bool },
+    hideNodesOnDrag: { bool },
+    hover: { bool },
     keyboard: {
-      enabled: { boolean },
+      enabled: { bool },
       speed: { x: { number }, y: { number }, zoom: { number }, __type__: { object } },
-      bindToWindow: { boolean },
-      __type__: { object, boolean }
+      bindToWindow: { bool },
+      __type__: { object, bool }
     },
-    multiselect: { boolean },
-    navigationButtons: { boolean },
-    selectable: { boolean },
-    selectConnectedEdges: { boolean },
-    hoverConnectedEdges: { boolean },
+    multiselect: { bool },
+    navigationButtons: { bool },
+    selectable: { bool },
+    selectConnectedEdges: { bool },
+    hoverConnectedEdges: { bool },
     tooltipDelay: { number },
-    zoomView: { boolean },
+    zoomView: { bool },
     __type__: { object }
   },
   layout: {
     randomSeed: { 'undefined': 'undefined', number },
-    improvedLayout: { boolean },
+    improvedLayout: { bool },
     hierarchical: {
-      enabled: { boolean },
+      enabled: { bool },
       levelSeparation: { number },
       nodeSpacing: { number },
       treeSpacing: { number },
-      blockShifting: { boolean },
-      edgeMinimization: { boolean },
-      parentCentralization: { boolean },
+      blockShifting: { bool },
+      edgeMinimization: { bool },
+      parentCentralization: { bool },
       direction: { string: ['UD', 'DU', 'LR', 'RL'] },   // UD, DU, LR, RL
       sortMethod: { string: ['hubsize', 'directed'] }, // hubsize, directed
-      __type__: { object, boolean }
+      __type__: { object, bool }
     },
     __type__: { object }
   },
   manipulation: {
-    enabled: { boolean },
-    initiallyActive: { boolean },
-    addNode: { boolean, 'function': 'function' },
-    addEdge: { boolean, 'function': 'function' },
+    enabled: { bool },
+    initiallyActive: { bool },
+    addNode: { bool, 'function': 'function' },
+    addEdge: { bool, 'function': 'function' },
     editNode: { 'function': 'function' },
     editEdge: {
       editWithoutDrag: { 'function' : 'function' },
-      __type__: {object, boolean, 'function': 'function' }
+      __type__: {object, bool, 'function': 'function' }
     },
-    deleteNode: { boolean, 'function': 'function' },
-    deleteEdge: { boolean, 'function': 'function' },
+    deleteNode: { bool, 'function': 'function' },
+    deleteEdge: { bool, 'function': 'function' },
     controlNodeStyle: 'get from nodes, will be overwritten below',
-    __type__: { object, boolean }
+    __type__: { object, bool }
   },
   nodes: {
     borderWidth: { number },
@@ -207,9 +207,9 @@ let allOptions = {
       __type__: { object, string }
     },
     fixed: {
-      x: { boolean },
-      y: { boolean },
-      __type__: { object, boolean }
+      x: { bool },
+      y: { bool },
+      __type__: { object, bool }
     },
     font: {
       align: { string },
@@ -220,7 +220,7 @@ let allOptions = {
       strokeWidth: { number }, // px
       strokeColor: { string },
       vadjust: { number },
-      multi: { boolean, string },
+      multi: { bool, string },
       bold: {
         color: { string },
         size: { number }, // px
@@ -259,9 +259,9 @@ let allOptions = {
     heightConstraint: {
       minimum: { number },
       valign: { string },
-      __type__: { object, boolean, number }
+      __type__: { object, bool, number }
     },
-    hidden: { boolean },
+    hidden: { bool },
     icon: {
       face: { string },
       code: { string },  //'\uf007',
@@ -272,7 +272,7 @@ let allOptions = {
     id: { string, number },
     image: { string, 'undefined': 'undefined' }, // --> URL
     label: { string, 'undefined': 'undefined' },
-    labelHighlightBold: { boolean },
+    labelHighlightBold: { bool },
     level: { number, 'undefined': 'undefined' },
     margin: {
       top: { number },
@@ -282,36 +282,36 @@ let allOptions = {
       __type__: { object, number }
     },
     mass: { number },
-    physics: { boolean },
+    physics: { bool },
     scaling: {
       min: { number },
       max: { number },
       label: {
-        enabled: { boolean },
+        enabled: { bool },
         min: { number },
         max: { number },
         maxVisible: { number },
         drawThreshold: { number },
-        __type__: { object, boolean }
+        __type__: { object, bool }
       },
       customScalingFunction: { 'function': 'function' },
       __type__: { object }
     },
     shadow: {
-      enabled: { boolean },
+      enabled: { bool },
       color: { string },
       size: { number },
       x: { number },
       y: { number },
-      __type__: { object, boolean }
+      __type__: { object, bool }
     },
     shape: { string: ['ellipse', 'circle', 'database', 'box', 'text', 'image', 'circularImage', 'diamond', 'dot', 'star', 'triangle', 'triangleDown', 'square', 'icon'] },
     shapeProperties: {
-      borderDashes: { boolean, array },
+      borderDashes: { bool, array },
       borderRadius: { number },
-      interpolation: { boolean },
-      useImageSize: { boolean },
-      useBorderWithImage: { boolean },
+      interpolation: { bool },
+      useImageSize: { bool },
+      useBorderWithImage: { bool },
       __type__: { object }
     },
     size: { number },
@@ -320,14 +320,14 @@ let allOptions = {
     widthConstraint: {
       minimum: { number },
       maximum: { number },
-      __type__: { object, boolean, number }
+      __type__: { object, bool, number }
     },
     x: { number },
     y: { number },
     __type__: { object }
   },
   physics: {
-    enabled: { boolean },
+    enabled: { bool },
     barnesHut: {
       gravitationalConstant: { number },
       centralGravity: { number },
@@ -366,21 +366,21 @@ let allOptions = {
     minVelocity: { number },    // px/s
     solver: { string: ['barnesHut', 'repulsion', 'hierarchicalRepulsion', 'forceAtlas2Based'] },
     stabilization: {
-      enabled: { boolean },
+      enabled: { bool },
       iterations: { number },   // maximum number of iteration to stabilize
       updateInterval: { number },
-      onlyDynamicEdges: { boolean },
-      fit: { boolean },
-      __type__: { object, boolean }
+      onlyDynamicEdges: { bool },
+      fit: { bool },
+      __type__: { object, bool }
     },
     timestep: { number },
-    adaptiveTimestep: { boolean },
-    __type__: { object, boolean }
+    adaptiveTimestep: { bool },
+    __type__: { object, bool }
   },
 
   //globals :
-  autoResize: { boolean },
-  clickToUse: { boolean },
+  autoResize: { bool },
+  clickToUse: { bool },
   locale: { string },
   locales: {
     __any__: { any },

--- a/lib/timeline/optionsGraph2d.js
+++ b/lib/timeline/optionsGraph2d.js
@@ -6,7 +6,7 @@
  * __type__ is a required field for all objects and contains the allowed types of all objects
  */
 let string = 'string';
-let boolean = 'boolean';
+let bool = 'boolean';
 let number = 'number';
 let array = 'array';
 let date = 'date';
@@ -18,53 +18,53 @@ let any = 'any';
 
 let allOptions = {
   configure: {
-    enabled: {boolean},
-    filter: {boolean,'function': 'function'},
+    enabled: {bool},
+    filter: {bool,'function': 'function'},
     container: {dom},
-    __type__: {object,boolean,'function': 'function'}
+    __type__: {object,bool,'function': 'function'}
   },
 
   //globals :
   yAxisOrientation: {string:['left','right']},
   defaultGroup: {string},
-  sort: {boolean},
-  sampling: {boolean},
-  stack:{boolean},
+  sort: {bool},
+  sampling: {bool},
+  stack:{bool},
   graphHeight: {string, number},
   shaded: {
-    enabled: {boolean},
+    enabled: {bool},
     orientation: {string:['bottom','top','zero','group']}, // top, bottom, zero, group
     groupId: {object},
-    __type__: {boolean,object}
+    __type__: {bool,object}
   },
   style: {string:['line','bar','points']}, // line, bar
   barChart: {
     width: {number},
     minWidth: {number},
-    sideBySide: {boolean},
+    sideBySide: {bool},
     align: {string:['left','center','right']},
     __type__: {object}
   },
   interpolation: {
-    enabled: {boolean},
+    enabled: {bool},
     parametrization: {string:['centripetal', 'chordal','uniform']}, // uniform (alpha = 0.0), chordal (alpha = 1.0), centripetal (alpha = 0.5)
     alpha: {number},
-    __type__: {object,boolean}
+    __type__: {object,bool}
   },
   drawPoints: {
-    enabled: {boolean},
+    enabled: {bool},
     onRender: { 'function': 'function' },
     size: {number},
     style: {string:['square','circle']}, // square, circle
-    __type__: {object,boolean,'function': 'function'}
+    __type__: {object,bool,'function': 'function'}
   },
   dataAxis: {
-    showMinorLabels: {boolean},
-    showMajorLabels: {boolean},
-    icons: {boolean},
+    showMinorLabels: {bool},
+    showMajorLabels: {bool},
+    icons: {bool},
     width: {string, number},
-    visible: {boolean},
-    alignZeros: {boolean},
+    visible: {bool},
+    alignZeros: {bool},
     left:{
       range: {min:{number},max:{number},__type__: {object}},
       format: {'function': 'function'},
@@ -80,27 +80,27 @@ let allOptions = {
     __type__: {object}
   },
   legend: {
-    enabled: {boolean},
-    icons: {boolean},
+    enabled: {bool},
+    icons: {bool},
     left: {
-      visible: {boolean},
+      visible: {bool},
       position: {string:['top-right','bottom-right','top-left','bottom-left']},
       __type__: {object}
     },
     right: {
-      visible: {boolean},
+      visible: {bool},
       position: {string:['top-right','bottom-right','top-left','bottom-left']},
       __type__: {object}
     },
-    __type__: {object,boolean}
+    __type__: {object,bool}
   },
   groups: {
     visibility: {any},
     __type__: {object}
   },
 
-  autoResize: {boolean},
-  clickToUse: {boolean},
+  autoResize: {bool},
+  clickToUse: {bool},
   end: {number, date, string, moment},
   format: {
     minorLabels: {
@@ -145,12 +145,12 @@ let allOptions = {
   maxMinorChars: {number},
   min: {date, number, string, moment},
   minHeight: {number, string},
-  moveable: {boolean},
-  multiselect: {boolean},
+  moveable: {bool},
+  multiselect: {bool},
   orientation: {string},
-  showCurrentTime: {boolean},
-  showMajorLabels: {boolean},
-  showMinorLabels: {boolean},
+  showCurrentTime: {bool},
+  showMajorLabels: {bool},
+  showMinorLabels: {bool},
   start: {date, number, string, moment},
   timeAxis: {
     scale: {string,'undefined': 'undefined'},
@@ -158,7 +158,7 @@ let allOptions = {
     __type__: {object}
   },
   width: {string, number},
-  zoomable: {boolean},
+  zoomable: {bool},
   zoomKey: {string: ['ctrlKey', 'altKey', 'metaKey', '']},
   zoomMax: {number},
   zoomMin: {number},

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -6,7 +6,7 @@
  * __type__ is a required field for all objects and contains the allowed types of all objects
  */
 let string = 'string';
-let boolean = 'boolean';
+let bool = 'boolean';
 let number = 'number';
 let array = 'array';
 let date = 'date';
@@ -17,28 +17,28 @@ let any = 'any';
 
 let allOptions = {
   configure: {
-    enabled: {boolean},
-    filter: {boolean,'function': 'function'},
+    enabled: {bool},
+    filter: {bool,'function': 'function'},
     container: {dom},
-    __type__: {object,boolean,'function': 'function'}
+    __type__: {object,bool,'function': 'function'}
   },
 
   //globals :
   align: {string},
-  rtl: {boolean, 'undefined': 'undefined'},
-  rollingMode: {boolean, 'undefined': 'undefined'},
-  verticalScroll: {boolean, 'undefined': 'undefined'},
-  horizontalScroll: {boolean, 'undefined': 'undefined'},
-  autoResize: {boolean},
-  clickToUse: {boolean},
+  rtl: {bool, 'undefined': 'undefined'},
+  rollingMode: {bool, 'undefined': 'undefined'},
+  verticalScroll: {bool, 'undefined': 'undefined'},
+  horizontalScroll: {bool, 'undefined': 'undefined'},
+  autoResize: {bool},
+  clickToUse: {bool},
   dataAttributes: {string, array},
   editable: {
-    add: {boolean, 'undefined': 'undefined'},
-    remove: {boolean, 'undefined': 'undefined'},
-    updateGroup: {boolean, 'undefined': 'undefined'},
-    updateTime: {boolean, 'undefined': 'undefined'},
-    overrideItems: {boolean, 'undefined': 'undefined'},
-    __type__: {boolean, object}
+    add: {bool, 'undefined': 'undefined'},
+    remove: {bool, 'undefined': 'undefined'},
+    updateGroup: {bool, 'undefined': 'undefined'},
+    updateTime: {bool, 'undefined': 'undefined'},
+    overrideItems: {bool, 'undefined': 'undefined'},
+    __type__: {bool, object}
   },
   end: {number, date, string, moment},
   format: {
@@ -69,10 +69,10 @@ let allOptions = {
   moment: {'function': 'function'},
   groupOrder: {string, 'function': 'function'},
   groupEditable: {
-	 add: {boolean, 'undefined': 'undefined'},
-	 remove: {boolean, 'undefined': 'undefined'},
-	 order: {boolean, 'undefined': 'undefined'},
-	 __type__: {boolean, object}
+	 add: {bool, 'undefined': 'undefined'},
+	 remove: {bool, 'undefined': 'undefined'},
+	 order: {bool, 'undefined': 'undefined'},
+	 __type__: {bool, object}
   },
   groupOrderSwap: {'function': 'function'},
   height: {string, number},
@@ -82,7 +82,7 @@ let allOptions = {
     repeat: {string},
     __type__: {object, array}
   },
-  itemsAlwaysDraggable: { boolean: boolean },
+  itemsAlwaysDraggable: {bool},
   locale:{string},
   locales:{
     __any__: {any},
@@ -102,9 +102,9 @@ let allOptions = {
   maxMinorChars: {number},
   min: {date, number, string, moment},
   minHeight: {number, string},
-  moveable: {boolean},
-  multiselect: {boolean},
-  multiselectPerGroup: {boolean},
+  moveable: {bool},
+  multiselect: {bool},
+  multiselectPerGroup: {bool},
   onAdd: {'function': 'function'},
   onUpdate: {'function': 'function'},
   onMove: {'function': 'function'},
@@ -119,18 +119,18 @@ let allOptions = {
     item: {string,'undefined': 'undefined'},
     __type__: {string, object}
   },
-  selectable: {boolean},
-  showCurrentTime: {boolean},
-  showMajorLabels: {boolean},
-  showMinorLabels: {boolean},
-  stack: {boolean},
+  selectable: {bool},
+  showCurrentTime: {bool},
+  showMajorLabels: {bool},
+  showMinorLabels: {bool},
+  stack: {bool},
   snap: {'function': 'function', 'null': 'null'},
   start: {date, number, string, moment},
   template: {'function': 'function'},
   groupTemplate: {'function': 'function'},
   tooltipOnItemUpdateTime: {
-    template: {'function': 'function'}, 
-    __type__: {boolean, object}
+    template: {'function': 'function'},
+    __type__: {bool, object}
   },
   timeAxis: {
     scale: {string,'undefined': 'undefined'},
@@ -139,7 +139,7 @@ let allOptions = {
   },
   type: {string},
   width: {string, number},
-  zoomable: {boolean},
+  zoomable: {bool},
   zoomKey: {string: ['ctrlKey', 'altKey', 'metaKey', '']},
   zoomMax: {number},
   zoomMin: {number},

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "babel-core": "^6.6.5",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
+    "babel-plugin-transform-es3-property-literals": "^6.8.0",
+    "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
     "babelify": "^7.2.0",
     "clean-css": "^3.4.10",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Solves #2445

Reason for changes: (1) To allow the Vis distributed code to be processed by YUI Compressor (e.g. via tools such as Sencha Cmd, where it can be difficult not to use a compressor). (2) Improve general JavaScript correctness.

Summary of changes:

1) Changes to Vis application code:
1.1) Avoid using "boolean" as a variable name because it is a JavaScript reserved word. (Used "bool" instead.)
1.2) Avoid using "char" as a variable name because it is a JavaScript reserved word. (Used "ch" instead.)

2) Changes to Babel configuration:
2.1) Include the 'transform-es3-property-literals' Babel plugin to ensure that reserved words are quoted in object property keys, e.g.:
`  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }`
rather than:
`  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }`
2.2) Include the 'transform-es3-member-expression-literals' Babel plugin to ensure that reserved words are quoted in property accesses, e.g.:
`    return new _Configurator2['default'](this, this.dom.container, configureOptions);`
rather than:
`    return new _Configurator2.default(this, this.dom.container, configureOptions);`
