### PR TITLE
Allow per-item disabling of limitSize

### DIFF
--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -174,7 +174,7 @@ RangeItem.prototype.repositionX = function(limitSize) {
   var contentWidth;
 
   // limit the width of the range, as browsers cannot draw very wide divs
-  if (limitSize === undefined || limitSize === true) {
+  if (this.data.limitSize !== false && (limitSize === undefined || limitSize === true)) {
     if (start < -parentWidth) {
       start = -parentWidth;
     }


### PR DESCRIPTION
I have an application for the vis.js timeline that requires item DIVs to always be their full size, however due to concerns over browser DIV size limitations there is code to keep them limited in size. Accordingly this patch allows the selective disabling of this limiting by adding `limitSize: false` to an Item's data.