### PR TITLE
replace { bool } with { boolean: bool } to fix #2500

### DIFF
--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -16,29 +16,29 @@ let any = 'any';
 
 let allOptions = {
   configure: {
-    enabled: { bool },
-    filter: { bool, string, array, 'function': 'function' },
+    enabled: { boolean: bool },
+    filter: { boolean: bool, string, array, 'function': 'function' },
     container: { dom },
-    showButton: { bool },
-    __type__: { object, bool, string, array, 'function': 'function' }
+    showButton: { boolean: bool },
+    __type__: { object, boolean: bool, string, array, 'function': 'function' }
   },
   edges: {
     arrows: {
-      to: { enabled: { bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, bool } },
-      middle: { enabled: { bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, bool } },
-      from: { enabled: { bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, bool } },
+      to: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean: bool } },
+      middle: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean: bool } },
+      from: { enabled: { boolean: bool }, scaleFactor: { number }, type: { string: ['arrow', 'circle'] }, __type__: { object, boolean: bool } },
       __type__: { string: ['from', 'to', 'middle'], object }
     },
-    arrowStrikethrough: { bool },
+    arrowStrikethrough: { boolean: bool },
     color: {
       color: { string },
       highlight: { string },
       hover: { string },
-      inherit: { string: ['from', 'to', 'both'], bool },
+      inherit: { string: ['from', 'to', 'both'], boolean: bool },
       opacity: { number },
       __type__: { object, string }
     },
-    dashes: { bool, array },
+    dashes: { boolean: bool, array },
     font: {
       color: { string },
       size: { number }, // px
@@ -48,7 +48,7 @@ let allOptions = {
       strokeColor: { string },
       align: { string: ['horizontal', 'top', 'middle', 'bottom'] },
       vadjust: { number },
-      multi: { bool, string },
+      multi: { boolean: bool, string },
       bold: {
         color: { string },
         size: { number }, // px
@@ -83,22 +83,22 @@ let allOptions = {
       },
       __type__: { object, string }
     },
-    hidden: { bool },
+    hidden: { boolean: bool },
     hoverWidth: { 'function': 'function', number },
     label: { string, 'undefined': 'undefined' },
-    labelHighlightBold: { bool },
+    labelHighlightBold: { boolean: bool },
     length: { number, 'undefined': 'undefined' },
-    physics: { bool },
+    physics: { boolean: bool },
     scaling: {
       min: { number },
       max: { number },
       label: {
-        enabled: { bool },
+        enabled: { boolean: bool },
         min: { number },
         max: { number },
         maxVisible: { number },
         drawThreshold: { number },
-        __type__: { object, bool }
+        __type__: { object, boolean: bool }
       },
       customScalingFunction: { 'function': 'function' },
       __type__: { object }
@@ -106,86 +106,86 @@ let allOptions = {
     selectionWidth: { 'function': 'function', number },
     selfReferenceSize: { number },
     shadow: {
-      enabled: { bool },
+      enabled: { boolean: bool },
       color: { string },
       size: { number },
       x: { number },
       y: { number },
-      __type__: { object, bool }
+      __type__: { object, boolean: bool }
     },
     smooth: {
-      enabled: { bool },
+      enabled: { boolean: bool },
       type: { string: ['dynamic', 'continuous', 'discrete', 'diagonalCross', 'straightCross', 'horizontal', 'vertical', 'curvedCW', 'curvedCCW', 'cubicBezier'] },
       roundness: { number },
-      forceDirection: { string: ['horizontal', 'vertical', 'none'], bool },
-      __type__: { object, bool }
+      forceDirection: { string: ['horizontal', 'vertical', 'none'], boolean: bool },
+      __type__: { object, boolean: bool }
     },
     title: { string, 'undefined': 'undefined' },
     width: { number },
     widthConstraint: {
       maximum: { number },
-      __type__: { object, bool, number }
+      __type__: { object, boolean: bool, number }
     },
     value: { number, 'undefined': 'undefined' },
     __type__: { object }
   },
   groups: {
-    useDefaultGroups: { bool },
+    useDefaultGroups: { boolean: bool },
     __any__: 'get from nodes, will be overwritten below',
     __type__: { object }
   },
   interaction: {
-    dragNodes: { bool },
-    dragView: { bool },
-    hideEdgesOnDrag: { bool },
-    hideNodesOnDrag: { bool },
-    hover: { bool },
+    dragNodes: { boolean: bool },
+    dragView: { boolean: bool },
+    hideEdgesOnDrag: { boolean: bool },
+    hideNodesOnDrag: { boolean: bool },
+    hover: { boolean: bool },
     keyboard: {
-      enabled: { bool },
+      enabled: { boolean: bool },
       speed: { x: { number }, y: { number }, zoom: { number }, __type__: { object } },
-      bindToWindow: { bool },
-      __type__: { object, bool }
+      bindToWindow: { boolean: bool },
+      __type__: { object, boolean: bool }
     },
-    multiselect: { bool },
-    navigationButtons: { bool },
-    selectable: { bool },
-    selectConnectedEdges: { bool },
-    hoverConnectedEdges: { bool },
+    multiselect: { boolean: bool },
+    navigationButtons: { boolean: bool },
+    selectable: { boolean: bool },
+    selectConnectedEdges: { boolean: bool },
+    hoverConnectedEdges: { boolean: bool },
     tooltipDelay: { number },
-    zoomView: { bool },
+    zoomView: { boolean: bool },
     __type__: { object }
   },
   layout: {
     randomSeed: { 'undefined': 'undefined', number },
-    improvedLayout: { bool },
+    improvedLayout: { boolean: bool },
     hierarchical: {
-      enabled: { bool },
+      enabled: { boolean: bool },
       levelSeparation: { number },
       nodeSpacing: { number },
       treeSpacing: { number },
-      blockShifting: { bool },
-      edgeMinimization: { bool },
-      parentCentralization: { bool },
+      blockShifting: { boolean: bool },
+      edgeMinimization: { boolean: bool },
+      parentCentralization: { boolean: bool },
       direction: { string: ['UD', 'DU', 'LR', 'RL'] },   // UD, DU, LR, RL
       sortMethod: { string: ['hubsize', 'directed'] }, // hubsize, directed
-      __type__: { object, bool }
+      __type__: { object, boolean: bool }
     },
     __type__: { object }
   },
   manipulation: {
-    enabled: { bool },
-    initiallyActive: { bool },
-    addNode: { bool, 'function': 'function' },
-    addEdge: { bool, 'function': 'function' },
+    enabled: { boolean: bool },
+    initiallyActive: { boolean: bool },
+    addNode: { boolean: bool, 'function': 'function' },
+    addEdge: { boolean: bool, 'function': 'function' },
     editNode: { 'function': 'function' },
     editEdge: {
       editWithoutDrag: { 'function' : 'function' },
-      __type__: {object, bool, 'function': 'function' }
+      __type__: {object, boolean: bool, 'function': 'function' }
     },
-    deleteNode: { bool, 'function': 'function' },
-    deleteEdge: { bool, 'function': 'function' },
+    deleteNode: { boolean: bool, 'function': 'function' },
+    deleteEdge: { boolean: bool, 'function': 'function' },
     controlNodeStyle: 'get from nodes, will be overwritten below',
-    __type__: { object, bool }
+    __type__: { object, boolean: bool }
   },
   nodes: {
     borderWidth: { number },
@@ -207,9 +207,9 @@ let allOptions = {
       __type__: { object, string }
     },
     fixed: {
-      x: { bool },
-      y: { bool },
-      __type__: { object, bool }
+      x: { boolean: bool },
+      y: { boolean: bool },
+      __type__: { object, boolean: bool }
     },
     font: {
       align: { string },
@@ -220,7 +220,7 @@ let allOptions = {
       strokeWidth: { number }, // px
       strokeColor: { string },
       vadjust: { number },
-      multi: { bool, string },
+      multi: { boolean: bool, string },
       bold: {
         color: { string },
         size: { number }, // px
@@ -259,9 +259,9 @@ let allOptions = {
     heightConstraint: {
       minimum: { number },
       valign: { string },
-      __type__: { object, bool, number }
+      __type__: { object, boolean: bool, number }
     },
-    hidden: { bool },
+    hidden: { boolean: bool },
     icon: {
       face: { string },
       code: { string },  //'\uf007',
@@ -272,7 +272,7 @@ let allOptions = {
     id: { string, number },
     image: { string, 'undefined': 'undefined' }, // --> URL
     label: { string, 'undefined': 'undefined' },
-    labelHighlightBold: { bool },
+    labelHighlightBold: { boolean: bool },
     level: { number, 'undefined': 'undefined' },
     margin: {
       top: { number },
@@ -282,36 +282,36 @@ let allOptions = {
       __type__: { object, number }
     },
     mass: { number },
-    physics: { bool },
+    physics: { boolean: bool },
     scaling: {
       min: { number },
       max: { number },
       label: {
-        enabled: { bool },
+        enabled: { boolean: bool },
         min: { number },
         max: { number },
         maxVisible: { number },
         drawThreshold: { number },
-        __type__: { object, bool }
+        __type__: { object, boolean: bool }
       },
       customScalingFunction: { 'function': 'function' },
       __type__: { object }
     },
     shadow: {
-      enabled: { bool },
+      enabled: { boolean: bool },
       color: { string },
       size: { number },
       x: { number },
       y: { number },
-      __type__: { object, bool }
+      __type__: { object, boolean: bool }
     },
     shape: { string: ['ellipse', 'circle', 'database', 'box', 'text', 'image', 'circularImage', 'diamond', 'dot', 'star', 'triangle', 'triangleDown', 'square', 'icon'] },
     shapeProperties: {
-      borderDashes: { bool, array },
+      borderDashes: { boolean: bool, array },
       borderRadius: { number },
-      interpolation: { bool },
-      useImageSize: { bool },
-      useBorderWithImage: { bool },
+      interpolation: { boolean: bool },
+      useImageSize: { boolean: bool },
+      useBorderWithImage: { boolean: bool },
       __type__: { object }
     },
     size: { number },
@@ -320,14 +320,14 @@ let allOptions = {
     widthConstraint: {
       minimum: { number },
       maximum: { number },
-      __type__: { object, bool, number }
+      __type__: { object, boolean: bool, number }
     },
     x: { number },
     y: { number },
     __type__: { object }
   },
   physics: {
-    enabled: { bool },
+    enabled: { boolean: bool },
     barnesHut: {
       gravitationalConstant: { number },
       centralGravity: { number },
@@ -366,21 +366,21 @@ let allOptions = {
     minVelocity: { number },    // px/s
     solver: { string: ['barnesHut', 'repulsion', 'hierarchicalRepulsion', 'forceAtlas2Based'] },
     stabilization: {
-      enabled: { bool },
+      enabled: { boolean: bool },
       iterations: { number },   // maximum number of iteration to stabilize
       updateInterval: { number },
-      onlyDynamicEdges: { bool },
-      fit: { bool },
-      __type__: { object, bool }
+      onlyDynamicEdges: { boolean: bool },
+      fit: { boolean: bool },
+      __type__: { object, boolean: bool }
     },
     timestep: { number },
-    adaptiveTimestep: { bool },
-    __type__: { object, bool }
+    adaptiveTimestep: { boolean: bool },
+    __type__: { object, boolean: bool }
   },
 
   //globals :
-  autoResize: { bool },
-  clickToUse: { bool },
+  autoResize: { boolean: bool },
+  clickToUse: { boolean: bool },
   locale: { string },
   locales: {
     __any__: { any },


### PR DESCRIPTION
fixes #2500 

ES6 Object Literal Property Value Shorthand was misused in #2452.