### PR TITLE
Fixed Timeline.setGroups for Array

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -271,13 +271,11 @@ Timeline.prototype.setGroups = function(groups) {
     newDataSet = null;
   }
   else {
-    var filter = {
-      filter : function(group){
-        return group.visible !== false;
-      }
+    var filter = function(group) {
+      return group.visible !== false;
     }
     if (groups instanceof DataSet || groups instanceof DataView) {
-      newDataSet = new DataView(groups,filter);
+      newDataSet = new DataView(groups,{filter: filter});
     }
     else {
       // turn an array into a dataset


### PR DESCRIPTION
Quote from docs: "`groups` can be an Array with Objects, a DataSet (offering 2 way data binding), or a DataView (offering 1 way data binding)".

However, in #2315  the array support was broken.

The specific change can be seen by comparing [develop](https://github.com/almende/vis/blob/develop/lib/timeline/Timeline.js#L284) to [master](https://github.com/almende/vis/blob/master/lib/timeline/Timeline.js#L267)

The problem is `groups.filter(filter)`, because `filter` is:
```javascript
var filter = {
  filter : function(group){
    return group.visible !== false;
  }
}
```
`groups` _should_ be an `Array`, so `groups.filter` is expecting a function, but is given an object. This results in `Uncaught TypeError: #<Object> is not a function` (to test for yourself just put `[].filter({})` in your development console).

So I changed `filter` to be the function, and pass in `{filter: filter}` to `DataView`. I felt this was a cleaner solution than passing in `filter.filter` to `groups.filter` because the function is the shared information.