### PR TITLE
Fix for Remove Events triggered by DataView Refresh()

### DIFF
--- a/lib/DataView.js
+++ b/lib/DataView.js
@@ -108,7 +108,7 @@ DataView.prototype.refresh = function () {
     id = oldIds[i];
     if (!newIds[id]) {
       removedIds.push(id);
-      removedItems.push(this._data[id]);
+      removedItems.push(this._data._data[id]);
       delete this._ids[id];
     }
   }


### PR DESCRIPTION
If found an issue with the DataView refresh function.
When items are removed after a call to refresh the oldData property of the remove event does not contain the correct events.

The items in the set are stored in `_data._data` not `_data`. The result was that the remove event's `oldData` property was an array of `undefined`.

_Note: looks like I introduced this issue in [this pr](https://github.com/almende/vis/pull/2189)._