### PR TITLE
[Timeline] Fixed tool-tip surviving after item deleted

### DIFF
--- a/lib/shared/Popup.js
+++ b/lib/shared/Popup.js
@@ -93,6 +93,13 @@ class Popup {
     this.hidden = true;
     this.frame.style.visibility = "hidden";
   }
+
+  /**
+   * Remove the popup window
+   */
+  destroy() {
+    this.frame.parentNode.removeChild(this.frame); // Remove element from DOM
+  }
 }
 
 export default Popup;

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -869,7 +869,8 @@ ItemSet.prototype.getGroups = function() {
  */
 ItemSet.prototype.removeItem = function(id) {
   var item = this.itemsData.get(id),
-      dataset = this.itemsData.getDataSet();
+      dataset = this.itemsData.getDataSet(),
+      itemObj = this.items[id];
 
   if (item) {
     // confirm deletion
@@ -878,6 +879,12 @@ ItemSet.prototype.removeItem = function(id) {
         // remove by id here, it is possible that an item has no id defined
         // itself, so better not delete by the item itself
         dataset.remove(id);
+
+        // Remove it's popup
+        if (itemObj.popup) {
+          itemObj.popup.destroy();
+          itemObj.popup = null;
+        }
       }
     });
   }


### PR DESCRIPTION
Previously if you deleted an item with a tooltip, it would stay in the DOM (and even worse, it would stay visible). This meant that if you kept deleting items, you would have a lot of tooltips floating on-top of each-other, never going away. This PR fixes that.