### PR TITLE
Fix missing blur edge event

### DIFF
--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -535,8 +535,8 @@ class SelectionHandler {
           delete this.hoverObj.edges[edgeId];
         }
         // if the blur remains the same and the object is undefined (mouse off) or another
-        // edge has been hovered, we blur the edge
-        else if (object === undefined || object instanceof Edge) {
+        // edge has been hovered, or another node has been hovered we blur the edge.
+        else if (object === undefined || (object instanceof Edge && object.id != edgeId) || (object instanceof Node && !object.hover)) {
           this.blurObject(this.hoverObj.edges[edgeId]);
           delete this.hoverObj.edges[edgeId];
           hoverChanged = true;


### PR DESCRIPTION
This pull request fixes #1911. It issues a missing blur edge event when the user hovers from an edge straight to a node. It further resolves a bug introduced in #2124, which creates multiple blur edge events when the user stays on the same edge. See #1911 for details.