### PR TITLE
Fix image with borders

### DIFF
--- a/lib/network/modules/components/nodes/shapes/Image.js
+++ b/lib/network/modules/components/nodes/shapes/Image.js
@@ -42,11 +42,11 @@ class Image extends CircleImageBase {
       ctx.save();
       // if borders are zero width, they will be drawn with width 1 by default. This prevents that
       if (borderWidth > 0) {
-        this.enableBorderDashes(ctx);
+        this.enableBorderDashes(ctx, values);
         //draw the border
         ctx.stroke();
         //disable dashed border for other elements
-        this.disableBorderDashes(ctx);
+        this.disableBorderDashes(ctx, values);
       }
       ctx.restore();
 


### PR DESCRIPTION
`image with borders` functionality has a bug to fix.
See the following network example:
http://visjs.org/examples/network/nodeStyles/imagesWithBorders.html
```
Uncaught TypeError: Cannot read property 'borderDashes' of undefined
    at Image.enableBorderDashes (vis.js:36032)
    at Image.draw (vis.js:37207)
    at Node.draw (vis.js:34480)
    at CanvasRenderer._drawNodes (vis.js:43900)
    at CanvasRenderer._redraw (vis.js:43814)
    at vis.js:43763
```

It seemed `enableBorderDashes()` checks `values.borderDashes` at `NodeBase.js`,
https://github.com/almende/vis/blob/develop/lib/network/modules/components/nodes/util/NodeBase.js#L63..L92
however, the function is not called with `values` at `shapes/Image.js`.

I have fixed it and confirmed `imageWithBorders` example worked well.

fixes #2609 ?