### PR TITLE
Network: Fix tree collision in hierarchical layout

### DIFF
--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -381,9 +381,11 @@ class LayoutEngine {
     // the main method to shift the trees
     let shiftTrees = () => {
       let treeSizes = getTreeSizes();
+      let shiftBy = 0;
       for (let i = 0; i < treeSizes.length - 1; i++) {
         let diff = treeSizes[i].max - treeSizes[i+1].min;
-        shiftTree(i + 1, diff + this.options.hierarchical.treeSpacing);
+        shiftBy += diff + this.options.hierarchical.treeSpacing;
+        shiftTree(i + 1, shiftBy);
       }
     };
 


### PR DESCRIPTION
Using the 'directed' sort method, the layout engine seemed to ignore treeSpacing (or only apply it to the first tree). This would also lead to trees colliding with one another, and having their nodes tangled in space. This complaint surfaced in a couple bugs, including #2494. This should be a step toward fixing that. For whatever reason, this code never runs when using the "hubsize" sort method.