### PR TITLE
moved babel plugins from devDependencies to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,6 @@ var options = {};
 var timeline = new Timeline(container, data, options);
 ```
 
-Install the application dependencies via npm:
-
-    $ npm install vis moment
-
 The application can be bundled and minified:
 
     $ browserify app.js -o dist/app-bundle.js -t babelify
@@ -287,6 +283,39 @@ And loaded into a webpage:
   <script src="dist/app-bundle.min.js"></script>
 </body>
 </html>
+```
+
+#### Example 4: Integrate vis.js components directly in your webpack build
+
+You can integrate e.g. the timeline component directly in you webpack build.
+Therefor you just import the component-files from root direcory (starting with "index-").
+
+```js
+var visTimeline = require('vis/index-timeline-graph2d');
+
+var container = document.getElementById('visualization');
+var data = new DataSet();
+var timeline = new Timeline(container, data, {});
+```
+
+To get this to work you'll need to add the some babel-loader-setting:
+
+```js
+module: {
+	loaders: [{
+		test: /node_modules[\\\/]vis[\\\/].*\.js$/,
+		loader: 'babel',
+		query: {
+			cacheDirectory: true,
+			presets: ["es2015"],
+			plugins: [
+				"transform-es3-property-literals",
+				"transform-es3-member-expression-literals",
+				"transform-runtime"
+			]
+		}
+	}]
+}
 ```
 
 ## Test

--- a/package.json
+++ b/package.json
@@ -29,8 +29,14 @@
     "watch-dev": "gulp watch --bundle"
   },
   "dependencies": {
+		"babel-core": "^6.21.0",
+		"babel-loader": "^6.2.10",
     "babel-polyfill": "^6.20.0",
-    "babel-runtime": "^6.20.0",
+		"babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
+		"babel-plugin-transform-es3-property-literals": "^6.8.0",
+		"babel-plugin-transform-runtime": "^6.15.0",
+		"babel-preset-es2015": "^6.18.0",
+		"babel-runtime": "^6.20.0",
     "emitter-component": "^1.1.1",
     "moment": "^2.12.0",
     "propagating-hammerjs": "^1.4.6",
@@ -39,12 +45,6 @@
   },
   "devDependencies": {
     "async": "^2.0.0-rc.2",
-    "babel-core": "^6.21.0",
-    "babel-loader": "^6.2.10",
-    "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
-    "babel-plugin-transform-es3-property-literals": "^6.8.0",
-    "babel-plugin-transform-runtime": "^6.15.0",
-    "babel-preset-es2015": "^6.18.0",
     "babelify": "^7.3.0",
     "clean-css": "^3.4.10",
     "gulp": "^3.9.1",


### PR DESCRIPTION
If you want to integrate the vis.js sources in a project you need some babel-pugins.

see #2353