### PR TITLE
Fix graph2D options

### DIFF
--- a/lib/timeline/optionsGraph2d.js
+++ b/lib/timeline/optionsGraph2d.js
@@ -66,15 +66,15 @@ let allOptions = {
     visible: {'boolean': bool},
     alignZeros: {'boolean': bool},
     left:{
-      range: {min:{number},max:{number},__type__: {object}},
+      range: {min:{number,'undefined': 'undefined'},max:{number,'undefined': 'undefined'},__type__: {object}},
       format: {'function': 'function'},
-      title: {text:{string,number},style:{string},__type__: {object}},
+      title: {text:{string,number,'undefined': 'undefined'},style:{string,'undefined': 'undefined'},__type__: {object}},
       __type__: {object}
     },
     right:{
-      range: {min:{number},max:{number},__type__: {object}},
+      range: {min:{number,'undefined': 'undefined'},max:{number,'undefined': 'undefined'},__type__: {object}},
       format: {'function': 'function'},
-      title: {text:{string,number},style:{string},__type__: {object}},
+      title: {text:{string,number,'undefined': 'undefined'},style:{string,'undefined': 'undefined'},__type__: {object}},
       __type__: {object}
     },
     __type__: {object}


### PR DESCRIPTION
This pull request fixes https://github.com/almende/vis/issues/2458. Some of the options missed the `undefined` value. See also the default values of `DataAxis` [here](https://github.com/almende/vis/blob/9703462783923ceb52107f0f3fe070de7cb0fe8f/lib/timeline/component/DataAxis.js) for comparison. 