### PR TITLE
Documentation: more precision on verticalScroll

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1137,7 +1137,7 @@ function (option, path) {
       <td>verticalScroll</td>
       <td>Boolean</td>
       <td><code>false</code></td>
-      <td> Show a vertical scroll on the side of the group list and link it to the scroll event when zoom is not triggered. Notice that defining this option as <code>true</code> will NOT override <code>horizontalScroll</code>. The scroll event will be vertically ignored, but a vertical scrollbar will be visible
+      <td> Show a vertical scroll on the side of the group list and link it to the scroll event when zoom is not triggered. Notice that defining this option as <code>true</code> will NOT override <code>horizontalScroll</code>. The scroll event will be vertically ignored, but a vertical scrollbar will be visible. The scrollbar will be visible only if <code>maxHeight</code> is defined.
       </td>
     </tr>
 


### PR DESCRIPTION
This addition of information allow people to understand that the verticalScroll works with maxHeight. If maxHeight is not set and verticalScroll is set to true, the verticalScroll will never be shown.