### PR TITLE
Ensure that setting {editable: true} option works.

### DIFF
--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -101,6 +101,7 @@ PointItem.prototype.redraw = function() {
 
     var editable = (this.options.editable.updateTime || 
                     this.options.editable.updateGroup ||
+                    this.options.editable === true ||
                     this.editable === true) &&
                    this.editable !== false;
 

--- a/test/PointItem.test.js
+++ b/test/PointItem.test.js
@@ -62,4 +62,59 @@ describe('Timeline PointItem', function () {
     var pointItem = new PointItem({start: now}, null, null);
     assert(pointItem.isVisible(range));
   });
+
+  it('should redraw() and then not be dirty', function() {
+    var range = new Range(TestSupport.buildSimpleTimelineRangeBody());
+    var now = moment().toDate();
+    var pointItem = new PointItem({start: now}, null, {editable: false});
+    pointItem.setParent(TestSupport.buildMockItemSet());
+    assert(pointItem.dirty);
+    pointItem.redraw();
+    assert(!pointItem.dirty);
+  });
+
+  it('should redraw() and then have point attached to its parent', function() {
+    var range = new Range(TestSupport.buildSimpleTimelineRangeBody());
+    var now = moment().toDate();
+    var pointItem = new PointItem({start: now}, null, {editable: false});
+    var parent = TestSupport.buildMockItemSet();
+    pointItem.setParent(parent);
+    assert(!parent.dom.foreground.hasChildNodes());
+    pointItem.redraw();
+    assert(parent.dom.foreground.hasChildNodes());
+  });
+
+  it('should redraw() and then have the correct classname for a non-editable item', function() {
+    var range = new Range(TestSupport.buildSimpleTimelineRangeBody());
+    var now = moment().toDate();
+    var pointItem = new PointItem({start: now, editable: false}, null, {editable: false});
+    var parent = TestSupport.buildMockItemSet();
+    pointItem.setParent(parent);
+    pointItem.redraw();
+    assert.equal(pointItem.dom.dot.className, "vis-item vis-dot vis-readonly");
+    assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-readonly");
+  });
+
+  it('should redraw() and then have the correct classname for an editable item (with object option)', function() {
+    var range = new Range(TestSupport.buildSimpleTimelineRangeBody());
+    var now = moment().toDate();
+    var pointItem = new PointItem({start: now}, null, {editable: {updateTime: true, updateGroup: false}});
+    var parent = TestSupport.buildMockItemSet();
+    pointItem.setParent(parent);
+    pointItem.redraw();
+    assert.equal(pointItem.dom.dot.className, "vis-item vis-dot vis-editable");
+    assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-editable");
+  });
+
+  it('should redraw() and then have the correct classname for an editable item (with boolean option)', function() {
+    var range = new Range(TestSupport.buildSimpleTimelineRangeBody());
+    var now = moment().toDate();
+    var pointItem = new PointItem({start: now}, null, {editable: true});
+    var parent = TestSupport.buildMockItemSet();
+    pointItem.setParent(parent);
+    pointItem.redraw();
+    assert.equal(pointItem.dom.dot.className, "vis-item vis-dot vis-editable");
+    assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-editable");
+  });
+
 });

--- a/test/TestSupport.js
+++ b/test/TestSupport.js
@@ -1,5 +1,20 @@
+var vis = require('../dist/vis');
+var DataSet = vis.DataSet;
 
 module.exports = {
+  buildMockItemSet: function() {
+    var itemset = {
+      dom: {
+        foreground: document.createElement('div'),
+        content: document.createElement('div')
+      },
+      itemSet: {
+        itemsData: new DataSet()
+      }
+    };
+    return itemset;
+  },
+
   buildSimpleTimelineRangeBody: function () {
     var body = {
       dom: {


### PR DESCRIPTION
Includes some bonus tests.

I also considered removing this logic:
```
  this.editable = null;
  if (this.data && this.data.hasOwnProperty('editable')){
    if(typeof this.data.editable === 'boolean') {
        this.editable = {
          updateTime: this.data.editable,
          updateGroup: this.data.editable,
          remove: this.data.editable
        }
    }
    else if(typeof options.editable === 'object') {
      this.editable = {};
      util.selectiveExtend(['updateTime', 'updateGroup', 'remove'], this.editable, data.editable);
    };
  }
```
out of the superclass (https://github.com/almende/vis/blob/master/lib/timeline/component/item/Item.js#L34) but that might result in some unexpected behavioural change depending on how it was being used and for other Item subclasses. So this seemed like a minimally intrusive change.