### PR TITLE
[Timeline] Modify redraw logic to treat scroll as needing restack.

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -616,8 +616,10 @@ ItemSet.prototype.redraw = function() {
   // TODO: would be nicer to get this as a trigger from Range
   var visibleInterval = range.end - range.start;
   var zoomed = (visibleInterval != this.lastVisibleInterval) || (this.props.width != this.props.lastWidth);
-  if (zoomed) this.stackDirty = true;
+  var scrolled = range.start != this.lastRangeStart;
+  if (zoomed || scrolled) this.stackDirty = true;
   this.lastVisibleInterval = visibleInterval;
+  this.lastRangeStart = range.start;
   this.props.lastWidth = this.props.width;
 
   var restack = this.stackDirty;


### PR DESCRIPTION
This addresses #1982 and #1417.

It possibly reduces performance, but correctness seems better. I tried the performance example, and it seems OK (like before the change, albeit on a VM, which might not show full impact).