### PR TITLE
[timeline] Update docs and example to suggest being explicit about item overrides

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -357,7 +357,7 @@ var items = new vis.DataSet([
       <td class="indent">editable.updateTime</td>
       <td>boolean</td>
       <td>no</td>
-      <td>If true, items can be dragged to another moment int time. See section <a href="#Editing_Items">Editing Items</a> for a detailed explanation.</td>
+      <td>If true, items can be dragged to another moment in time. See section <a href="#Editing_Items">Editing Items</a> for a detailed explanation.</td>
     </tr>
   </table>
 
@@ -1697,6 +1697,14 @@ var items = new vis.DataSet([
   {id: 2, content: 'editable item', start: '2013-04-14'}
 ]);
 </pre>
+
+  <p>
+    Individual manipulation actions (<code>updateTime</code>, <code>updateGroup</code> and <code>remove</code>) can also be set on individual items. If any of the item-level
+    actions are specified (and <code>overrideItems</code> is not <code>false</code>) then that takes precedence over the settings at the timeline level. Current behavior is
+    that if any of the item-level actions are not specified, those items get <code>undefined</code> value (rather than inheriting from the timeline level). This may change
+    in future major releases, and code that specifies all item level values will handle major release changes better. That is, instead of using
+    <code>editable: {updateTime : true}</code>, use <code>editable: {updateTime : true, updateGroup: false, remove: false}</code>.
+  </p>
 
   <p>
     One can specify callback functions to validate changes made by the user. There are a number of callback functions for this purpose:

--- a/examples/timeline/editing/individualEditableItems.html
+++ b/examples/timeline/editing/individualEditableItems.html
@@ -34,7 +34,7 @@
 <div id="visualization"></div>
 
 <script>
-  // create groups to highligh groupUpdate
+  // create groups to highlight groupUpdate
   var groups = new vis.DataSet([
     {id: 1, content: 'Group 1'},
     {id: 2, content: 'Group 2'}
@@ -45,9 +45,9 @@
     {id: 2, content: 'Editable', editable: true, start: '2010-08-23T23:00:00', group: 2},
     {id: 3, content: 'Read-only', editable: false, start: '2010-08-24T16:00:00', group: 1},
     {id: 4, content: 'Read-only', editable: false, start: '2010-08-26', end: '2010-09-02', group: 2},
-    {id: 5, content: 'Edit Time Only', editable: { updateTime: true }, start: '2010-08-28', group: 1},
-    {id: 6, content: 'Edit Group Only', editable: { updateGroup: true }, start: '2010-08-29', group: 2},
-    {id: 7, content: 'Remove Only', editable: { remove: true }, start: '2010-08-31', end: '2010-09-03', group: 1},
+    {id: 5, content: 'Edit Time Only', editable: { updateTime: true, updateGroup: false, remove: false }, start: '2010-08-28', group: 1},
+    {id: 6, content: 'Edit Group Only', editable: { updateTime: false, updateGroup: true, remove: false }, start: '2010-08-29', group: 2},
+    {id: 7, content: 'Remove Only', editable: { updateTime: false, updateGroup: false, remove: true }, start: '2010-08-31', end: '2010-09-03', group: 1},
     {id: 8, content: 'Default', start: '2010-09-04T12:00:00', group: 2}
   ]);
 


### PR DESCRIPTION
This is to reduce breakage if the fallback / default changes in a future release.

https://github.com/almende/vis/issues/2797 proposes a particular way forward, but this is precursor work to help either that breaking change or an alternative proposal to have less impact on existing users.