### PR TITLE
Adjusted graph3d doc for autoscaling; ref Issue #2540

### DIFF
--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -548,13 +548,17 @@ var options = {
       <td>xMax</td>
       <td>number</td>
       <td>none</td>
-      <td>The maximum value for the x-axis.</td>
+      <td>The maximum value for the x-axis.
+         If not set, the largest value for x in the data set is used.
+      </td>
     </tr>
     <tr>
       <td>xMin</td>
       <td>number</td>
       <td>none</td>
-      <td>The minimum value for the x-axis.</td>
+      <td>The minimum value for the x-axis.
+         If not set, the smallest value for x in the data set is used.
+      </td>
     </tr>
     <tr>
       <td>xStep</td>
@@ -591,13 +595,17 @@ var options = {
       <td>yMax</td>
       <td>number</td>
       <td>none</td>
-      <td>The maximum value for the y-axis.</td>
+      <td>The maximum value for the y-axis.
+         If not set, the largest value for y in the data set is used.
+      </td>
     </tr>
     <tr>
       <td>yMin</td>
       <td>number</td>
       <td>none</td>
-      <td>The minimum value for the y-axis.</td>
+      <td>The minimum value for the y-axis.
+         If not set, the smallest value for y in the data set is used.
+      </td>
     </tr>
     <tr>
       <td>yStep</td>
@@ -615,16 +623,20 @@ var options = {
     </tr>
 
     <tr>
-      <td>zMin</td>
-      <td>number</td>
-      <td>none</td>
-      <td>The minimum value for the z-axis.</td>
-    </tr>
-    <tr>
       <td>zMax</td>
       <td>number</td>
       <td>none</td>
-      <td>The maximum value for the z-axis.</td>
+      <td>The maximum value for the z-axis.
+         If not set, the largest value for z in the data set is used.
+      </td>
+    </tr>
+    <tr>
+      <td>zMin</td>
+      <td>number</td>
+      <td>none</td>
+      <td>The minimum value for the z-axis.
+         If not set, the smallest value for z in the data set is used.
+      </td>
     </tr>
     <tr>
       <td>zStep</td>

--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -547,7 +547,7 @@ var options = {
     <tr>
       <td>xMax</td>
       <td>number</td>
-      <td>none</td>
+      <td>from data</td>
       <td>The maximum value for the x-axis.
          If not set, the largest value for x in the data set is used.
       </td>
@@ -555,7 +555,7 @@ var options = {
     <tr>
       <td>xMin</td>
       <td>number</td>
-      <td>none</td>
+      <td>from data</td>
       <td>The minimum value for the x-axis.
          If not set, the smallest value for x in the data set is used.
       </td>
@@ -594,7 +594,7 @@ var options = {
     <tr>
       <td>yMax</td>
       <td>number</td>
-      <td>none</td>
+      <td>from data</td>
       <td>The maximum value for the y-axis.
          If not set, the largest value for y in the data set is used.
       </td>
@@ -602,7 +602,7 @@ var options = {
     <tr>
       <td>yMin</td>
       <td>number</td>
-      <td>none</td>
+      <td>from data</td>
       <td>The minimum value for the y-axis.
          If not set, the smallest value for y in the data set is used.
       </td>
@@ -625,7 +625,7 @@ var options = {
     <tr>
       <td>zMax</td>
       <td>number</td>
-      <td>none</td>
+      <td>from data</td>
       <td>The maximum value for the z-axis.
          If not set, the largest value for z in the data set is used.
       </td>
@@ -633,7 +633,7 @@ var options = {
     <tr>
       <td>zMin</td>
       <td>number</td>
-      <td>none</td>
+      <td>from data</td>
       <td>The minimum value for the z-axis.
          If not set, the smallest value for z in the data set is used.
       </td>


### PR DESCRIPTION
Added comments to `graph3d` documentation on how Min/Max of data-values are set if these are not explicitly defined.

This is a response to an observation in Issue #2540.