### PR TITLE
Cheap fix for bug #2795

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -521,7 +521,9 @@ TimeStep.prototype.getLabelMinor = function(date) {
   if (date == undefined) {
     date = this.current;
   }
-  if (date instanceof Date) date = this.moment(date);
+  if (date instanceof Date) {
+    date = this.moment(date)
+  }
 
   if (typeof(this.format.minorLabels) === "function") {
     return this.format.minorLabels(date, this.scale, this.step);
@@ -541,8 +543,10 @@ TimeStep.prototype.getLabelMajor = function(date) {
   if (date == undefined) {
     date = this.current;
   }
-  if (date instanceof Date) date = this.moment(date);
-  
+  if (date instanceof Date) {
+    date = this.moment(date)
+  }
+
   if (typeof(this.format.majorLabels) === "function") {
     return this.format.majorLabels(date, this.scale, this.step);
   }

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -521,6 +521,7 @@ TimeStep.prototype.getLabelMinor = function(date) {
   if (date == undefined) {
     date = this.current;
   }
+  if (date instanceof Date) date = this.moment(date);
 
   if (typeof(this.format.minorLabels) === "function") {
     return this.format.minorLabels(date, this.scale, this.step);
@@ -540,6 +541,7 @@ TimeStep.prototype.getLabelMajor = function(date) {
   if (date == undefined) {
     date = this.current;
   }
+  if (date instanceof Date) date = this.moment(date);
   
   if (typeof(this.format.majorLabels) === "function") {
     return this.format.majorLabels(date, this.scale, this.step);


### PR DESCRIPTION
This fix ensures that the getLabelMinor and getLabelMajor always returns a Moment object. Especially useful if you use a custom function for the timeline labels (https://github.com/almende/vis/issues/2795).