### PR TITLE
fix(network) selected image: setting image doesn't affect current image

### DIFF
--- a/lib/network/modules/components/nodes/util/CircleImageBase.js
+++ b/lib/network/modules/components/nodes/util/CircleImageBase.js
@@ -14,12 +14,22 @@ class CircleImageBase extends NodeBase {
   }
 
   setImages(imageObj, imageObjAlt) {
-    if (imageObj) {
-      this.imageObj = imageObj;
+    if (!this.selected) {
+      if (imageObj) {
+        this.imageObj = imageObj;
 
-      if (imageObjAlt) {
-        this.imageObjAlt = imageObjAlt;
+        if (imageObjAlt) {
+          this.imageObjAlt = imageObjAlt;
+        }
       }
+
+    // if node currently selected keep current image
+    } else if (imageObjAlt) {
+      this.imageObj = imageObjAlt;
+      this.imageObjAlt = imageObj;
+
+    } else {
+      this.imageObj = imageObj;
     }
   }
 


### PR DESCRIPTION
In our private project, I encountered the case where a selected image was redrawn. In that case, the node switched back to the unselected image. This PR fixes this.