### PR TITLE
Fix #2936: 0 nodeId not shown in getConnectedNodes(edgeId) in EdgeHalnder.js

### DIFF
--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -385,8 +385,8 @@ class EdgesHandler {
     let nodeList = [];
     if (this.body.edges[edgeId] !== undefined) {
       let edge = this.body.edges[edgeId];
-      if (edge.fromId) {nodeList.push(edge.fromId);}
-      if (edge.toId)   {nodeList.push(edge.toId);}
+      if (edge.fromId || edge.fromId === 0) {nodeList.push(edge.fromId);}
+      if (edge.toId || edge.toId === 0)   {nodeList.push(edge.toId);}
     }
     return nodeList;
   }


### PR DESCRIPTION
fixes #2936