### PR TITLE
Fix issue with updating an item's group

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1196,14 +1196,6 @@ ItemSet.prototype._addItem = function(item) {
  * @private
  */
 ItemSet.prototype._updateItem = function(item, itemData) {
-  var oldGroupId = item.data.group;
-  var oldSubGroupId = item.data.subgroup;
-
-  if (oldGroupId != itemData.group) {
-    var oldGroup = this.groups[oldGroupId];
-    if (oldGroup) oldGroup.remove(item);
-  }
-
   // update the items data (will redraw the item when displayed)
   item.setData(itemData);
 
@@ -1213,14 +1205,6 @@ ItemSet.prototype._updateItem = function(item, itemData) {
     item.groupShowing = false;
   } else if (group && group.data && group.data.showNested) {
     item.groupShowing = true;
-  }
-  // update group
-  if (group) {
-    if (oldGroupId != item.data.group) {
-      group.add(item);
-    } else if (oldSubGroupId != item.data.subgroup) {
-      group.changeSubgroup(item, oldSubGroupId);
-    }
   }
 };
 
@@ -1587,10 +1571,11 @@ ItemSet.prototype._moveToGroup = function(item, groupId) {
     var oldGroup = item.parent;
     oldGroup.remove(item);
     oldGroup.order();
+    
+    item.data.group = group.groupId;
+    
     group.add(item);
     group.order();
-
-    item.data.group = group.groupId;
   }
 };
 

--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -61,8 +61,13 @@ Item.prototype.unselect = function() {
  */
 Item.prototype.setData = function(data) {
   var groupChanged = data.group != undefined && this.data.group != data.group;
-  if (groupChanged) {
+  if (groupChanged && this.parent != null) {
     this.parent.itemSet._moveToGroup(this, data.group);
+  }
+  
+  var subGroupChanged = data.subgroup != undefined && this.data.subgroup != data.subgroup;
+  if (subGroupChanged && this.parent != null) {
+    this.parent.changeSubgroup(this, this.data.subgroup, data.subgroup);
   }
 
   this.data = data;


### PR DESCRIPTION
Add check for parent existence when changing group in Item.setData.
Add subgroup updates to Item.setData.
Remove group updating logic from ItemSet._updateItem.
Fixes #2939