### PR TITLE
Fix to include group ID with click events when expanding nested groups

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -2229,8 +2229,16 @@ ItemSet.prototype.itemFromRelatedTarget = function(event) {
  */
 ItemSet.prototype.groupFromTarget = function(event) {
   var clientY = event.center ? event.center.y : event.clientY;
-  for (var i = 0; i < this.groupIds.length; i++) {
-    var groupId = this.groupIds[i];
+  var groupIds = this.groupIds;
+  
+  if (groupIds.length <= 0) {
+    groupIds = this.groupsData.getIds({
+      order: this.options.groupOrder
+    });
+  }
+  
+  for (var i = 0; i < groupIds.length; i++) {
+    var groupId = groupIds[i];
     var group = this.groups[groupId];
     var foreground = group.dom.foreground;
     var top = util.getAbsoluteTop(foreground);


### PR DESCRIPTION
Add check for empty groupIds array and get full list from data set. Fixes #2877