### PR TITLE
Fix #2614: Timeline docs border overlaps

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -106,6 +106,8 @@ table.events td:nth-child(2) {
 
 pre {
     margin: 20px 0;
+    white-space: pre-wrap;
+    max-width: 100%;
 }
 
 a code {


### PR DESCRIPTION
Same as PR #2932, but on `develop` branch as discussed.