### PR TITLE
Fix #2994: select edge with id zero

### DIFF
--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -156,7 +156,7 @@ class SelectionHandler {
 
 
   /**
-   * Get the top node at the a specific point (like a click)
+   * Get the top node at the passed point (like a click)
    *
    * @param {{x: Number, y: Number}} pointer
    * @return {Node | undefined} node
@@ -212,11 +212,10 @@ class SelectionHandler {
 
 
   /**
-   * Place holder. To implement change the getNodeAt to a _getObjectAt. Have the _getObjectAt call
-   * getNodeAt and _getEdgesAt, then priortize the selection to user preferences.
+   * Get the edges nearest to the passed point (like a click)
    *
-   * @param pointer
-   * @returns {undefined}
+   * @param {{x: Number, y: Number}} pointer
+   * @return {Edge | undefined} node
    */
   getEdgeAt(pointer, returnEdge = true) {
     // Iterate over edges, pick closest within 10
@@ -239,7 +238,7 @@ class SelectionHandler {
         }
       }
     }
-    if (overlappingEdge) {
+    if (overlappingEdge !== null) {
       if (returnEdge === true) {
         return this.body.edges[overlappingEdge];
       }


### PR DESCRIPTION
Fixes #2994.

Also edited the header comment of `Selectionhandler.getEdgeAt()`.