### PR TITLE
Fix placement label for dot shape

### DIFF
--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -47,7 +47,9 @@ class ShapeBase extends NodeBase {
     ctx.restore();
 
     if (this.options.label !== undefined) {
-      let yLabel = y + 0.5 * this.height + 3; // the + 3 is to offset it a bit below the node.
+      // Need to call following here in order to ensure value for `this.labelModule.size.height`
+      this.labelModule.calculateLabelSize(ctx, selected, hover, x, y, 'hanging')
+      let yLabel = y + 0.5 * this.height + 0.5 * this.labelModule.size.height;
       this.labelModule.draw(ctx, x, yLabel, selected, hover, 'hanging');
     }
 
@@ -63,7 +65,7 @@ class ShapeBase extends NodeBase {
     if (this.options.label !== undefined && this.labelModule.size.width > 0) {
       this.boundingBox.left = Math.min(this.boundingBox.left, this.labelModule.size.left);
       this.boundingBox.right = Math.max(this.boundingBox.right, this.labelModule.size.left + this.labelModule.size.width);
-      this.boundingBox.bottom = Math.max(this.boundingBox.bottom, this.boundingBox.bottom + this.labelModule.size.height + 3);
+      this.boundingBox.bottom = Math.max(this.boundingBox.bottom, this.boundingBox.bottom + this.labelModule.size.height);
     }
   }
 


### PR DESCRIPTION
Fix for #2968. Placement of multiline label for shape `dot` now takes height of label into account.