### PR TITLE
Timeline 'showTooltips' option

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1027,6 +1027,13 @@ function (option, path) {
     </tr>
 
     <tr>
+      <td>showTooltips</td>
+      <td>boolean</td>
+      <td><code>true</code></td>
+      <td>If true, items with titles will display a tooltip. If false, item tooltips are prevented from showing.</td>
+    </tr>
+
+    <tr>
       <td>stack</td>
       <td>boolean</td>
       <td><code>true</code></td>

--- a/examples/timeline/items/tooltip.html
+++ b/examples/timeline/items/tooltip.html
@@ -12,7 +12,7 @@
 
   <script src="../../../dist/vis.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
-  
+
 </head>
 <body>
 
@@ -37,6 +37,12 @@
 </p>
 
 <div id="tooltips-cap"></div>
+
+<p>
+  Disable item tooltips.
+</p>
+
+<div id="tooltips-hide"></div>
 
 <script type="text/javascript">
   // Create a DataSet (allows two way data-binding)
@@ -78,6 +84,15 @@
 
   var timelineCap = new vis.Timeline(document.getElementById('tooltips-cap'),
       items, cap_options);
+
+  // Hide options
+  var hide_options = {
+    showTooltips: false
+  }
+
+  var timelineHide = new vis.Timeline(document.getElementById('tooltips-hide'),
+      items, hide_options);
+
 </script>
 
 </body>

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -95,6 +95,8 @@ function ItemSet(body, options) {
       axis: 20
     },
 
+    showTooltips: true,
+
     tooltip: {
       followMouse: false,
       overflowMethod: 'flip'
@@ -337,7 +339,7 @@ ItemSet.prototype.setOptions = function(options) {
     var fields = [
       'type', 'rtl', 'align', 'order', 'stack', 'stackSubgroups', 'selectable', 'multiselect', 'itemsAlwaysDraggable', 
       'multiselectPerGroup', 'groupOrder', 'dataAttributes', 'template', 'groupTemplate', 'visibleFrameTemplate',
-      'hide', 'snap', 'groupOrderSwap', 'tooltip', 'tooltipOnItemUpdateTime'
+      'hide', 'snap', 'groupOrderSwap', 'showTooltips', 'tooltip', 'tooltipOnItemUpdateTime'
     ];
     util.selectiveExtend(fields, this.options, options);
 

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1893,7 +1893,7 @@ ItemSet.prototype._onMouseOver = function (event) {
   }
 
   var title = item.getTitle();
-  if (title) {
+  if (this.options.showTooltips && title) {
     if (this.popup == null) {
       this.popup = new Popup(this.body.dom.root,
           this.options.tooltip.overflowMethod || 'flip');
@@ -1943,7 +1943,7 @@ ItemSet.prototype._onMouseMove = function (event) {
   var item = this.itemFromTarget(event);
   if (!item) return;
 
-  if (this.options.tooltip.followMouse) {
+  if (this.options.showTooltips && this.options.tooltip.followMouse) {
     if (this.popup) {
       if (!this.popup.hidden) {
         var container = this.body.dom.centerContainer;

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -137,6 +137,7 @@ let allOptions = {
   template: {'function': 'function'},
   groupTemplate: {'function': 'function'},
   visibleFrameTemplate: {string, 'function': 'function'},
+  showTooltips: { 'boolean': bool},
   tooltip: {
     followMouse: { 'boolean': bool },
     overflowMethod: { 'string': ['cap', 'flip'] },
@@ -243,6 +244,7 @@ let configureOptions = {
     //  scale: ['millisecond', 'second', 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'],
     //  step: [1, 1, 10, 1]
     //},
+    showTooltips: true,
     tooltip: {
       followMouse: false,
       overflowMethod: 'flip'


### PR DESCRIPTION
Adds 'showTooltips' option to override popups displayed for items with titles. 