### PR TITLE
Set CircleImageBase.imageObjAlt always when options change

### DIFF
--- a/lib/network/modules/components/nodes/util/CircleImageBase.js
+++ b/lib/network/modules/components/nodes/util/CircleImageBase.js
@@ -26,12 +26,12 @@ class CircleImageBase extends NodeBase {
   }
 
   setImages(imageObj, imageObjAlt) {
-    if (imageObj) {
-      this.imageObj = imageObj;
-
-      if (imageObjAlt) {
-        this.imageObjAlt = imageObjAlt;
-      }
+    if (imageObjAlt && this.selected) {
+      this.imageObj    = imageObjAlt;
+      this.imageObjAlt = imageObj;
+    } else {
+      this.imageObj    = imageObj;
+      this.imageObjAlt = imageObjAlt;
     }
   }
 


### PR DESCRIPTION
Variable `imageObjAlt` must always be set in `CircleImageBase.setImages()`, even if it is `undefined`.
This makes the method reentrant, so that consecutive calls to `setOptions()` set the images properly.

This PR replaces PR #2894. Consult that PR for further info.