### PR TITLE
Fix option fallback to main font for mod-fonts when setting options

### DIFF
--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -717,12 +717,26 @@ class Label {
   }
 
   getFormattingValues(ctx, selected, hover, mod) {
+    var getValue = function(fontOptions, mod, option) {
+      if (mod === "normal") {
+        if (option === 'mod' ) return "";
+        return fontOptions[option];
+      }
+
+      if (fontOptions[mod][option]) {
+        return fontOptions[mod][option];
+      } else {
+        // Take from parent font option
+        return fontOptions[option];
+      }
+    };
+
     let values = {
-      color: (mod === "normal") ? this.fontOptions.color : this.fontOptions[mod].color,
-      size: (mod === "normal") ? this.fontOptions.size : this.fontOptions[mod].size,
-      face: (mod === "normal") ? this.fontOptions.face : this.fontOptions[mod].face,
-      mod: (mod === "normal") ? "" : this.fontOptions[mod].mod,
-      vadjust: (mod === "normal") ? this.fontOptions.vadjust : this.fontOptions[mod].vadjust,
+      color  : getValue(this.fontOptions, mod, 'color'  ),
+      size   : getValue(this.fontOptions, mod, 'size'   ),
+      face   : getValue(this.fontOptions, mod, 'face'   ),
+      mod    : getValue(this.fontOptions, mod, 'mod'    ),
+      vadjust: getValue(this.fontOptions, mod, 'vadjust'),
       strokeWidth: this.fontOptions.strokeWidth,
       strokeColor: this.fontOptions.strokeColor
     };


### PR DESCRIPTION
This is a fix for #3047.

In `Label.getFormattingValues()`, values for the font options are collected. The issue here is that when an option is missing for a mod-font, the value is not retrieved from the main font. This would be the expected behavior according to the documentation.

This PR adds the fallback to a main font option value.