### PR TITLE
Label.js: added check on mission var 'options' in propagateFonts(), refactoring.

### DIFF
--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -37,11 +37,7 @@ class Label {
   }
 
   static parseOptions(parentOptions, newOptions, allowDeletion = false) {
-    if (typeof newOptions.font === 'string') {
-      let newOptionsArray = newOptions.font.split(" ");
-      parentOptions.size    = newOptionsArray[0].replace("px",'');
-      parentOptions.face    = newOptionsArray[1];
-      parentOptions.color   = newOptionsArray[2];
+    if (Label.parseFontString(parentOptions, newOptions.font)) {
       parentOptions.vadjust = 0;
     }
     else if (typeof newOptions.font === 'object') {
@@ -50,6 +46,32 @@ class Label {
     parentOptions.size    = Number(parentOptions.size);
     parentOptions.vadjust = Number(parentOptions.vadjust);
   }
+
+
+  /**
+   * If in-variable is a string, parse it as a font specifier.
+   *
+   * Note that following is not done here and have to be done after the call:
+   * - No number conversion (size)
+   * - Not all font options are set (vadjust, mod)
+   *
+   * @param inOptions  {Object} font options to parse
+   * @param outOptions {Object} out-parameter, object in which to store the parse results (if any)
+   *
+   * @return true if font parsed as string, false otherwise
+   */
+  static parseFontString(outOptions, inOptions) {
+    if (!inOptions || typeof inOptions !== 'string') return false;
+
+    let newOptionsArray = inOptions.split(" ");
+
+    outOptions.size  = newOptionsArray[0].replace("px",'');
+    outOptions.face  = newOptionsArray[1];
+    outOptions.color = newOptionsArray[2];
+
+    return true;
+  }
+
 
   // set the width and height constraints based on 'nearest' value
   constrain(elementOptions, options, defaultOptions) {
@@ -141,13 +163,17 @@ class Label {
     if (!this.fontOptions.multi) return;
 
     /**
-     * Get property value from options.font[mod][property] if present.
-     * If mod not passed, use property value from options.font[property].
+     * Resolve the font options path.
+     * If valid, return a reference to the object in question.
+     * Otherwise, just return null.
      *
-     * @return value if found, null otherwise.
+     * param 'mod' is optional.
+     *
+     * options {Object} base object to determine path from
+     * mod {string|undefined} if present, sub path for the mod-font
      */
-    var getP = function(options, mod, property) {
-       if (!options.font) return null;
+    var pathP = function(options, mod) {
+       if (!options || !options.font) return null;
 
       var opt = options.font;
 
@@ -156,7 +182,20 @@ class Label {
         opt = opt[mod];
       }
 
-      if (opt.hasOwnProperty(property)) {
+      return opt;
+    };
+
+
+    /**
+     * Get property value from options.font[mod][property] if present.
+     * If mod not passed, use property value from options.font[property].
+     *
+     * @return value if found, null otherwise.
+     */
+    var getP = function(options, mod, property) {
+      let opt = pathP(options, mod);
+
+      if (opt && opt.hasOwnProperty(property)) {
          return opt[property];
       }
 
@@ -169,16 +208,7 @@ class Label {
       let modOptions  = this.fontOptions[mod];
       let modDefaults = defaultOptions.font[mod];
 
-      let optionsFontMod;
-      if (options.font) {
-        optionsFontMod = options.font[mod];
-      }
-
-      if (typeof optionsFontMod === 'string') {
-        let modOptionsArray = optionsFontMod.split(" ");
-        modOptions.size  = modOptionsArray[0].replace("px","");
-        modOptions.face  = modOptionsArray[1];
-        modOptions.color = modOptionsArray[2];
+      if (Label.parseFontString(modOptions, pathP(options, mod))) {
         modOptions.vadjust = this.fontOptions.vadjust;
         modOptions.mod = modDefaults.mod;
       } else {
@@ -187,10 +217,8 @@ class Label {
         // much 'natural' versatility as we can get, so a simple global
         // change propagates in an expected way, even if not stictly logical.
 
-        // face: We want to capture any direct settings and overrides, but
-        //       fall back to the base font if there aren't any. We make a
-        //       special exception for mono, since we probably don't want to
-        //       sync to a the base font face.
+        // 'face' has a special exception for mono, since we probably
+        // don't want to sync to the base font face.
          modOptions.face =
           getP(options     ,  mod, 'face')          || 
           getP(groupOptions,  mod, 'face')          ||
@@ -199,7 +227,7 @@ class Label {
           this.fontOptions.face
         ;
 
-        // color: this is handled just like the face, except for specific default for 'mono'
+        // 'color' follows the standard flow
          modOptions.color =
           getP(options     ,  mod, 'color') ||
           getP(groupOptions,  mod, 'color') ||
@@ -207,9 +235,7 @@ class Label {
           this.fontOptions.color
         ;
 
-        // mod: this is handled just like the face, except we never grab the
-        // base font's mod. We know they're in the defaultOptions, and unless
-        // we've been steered away from them, we use the default.
+        // 'mode' follows the standard flow
         modOptions.mod =
           getP(options     ,  mod, 'mod') ||
           getP(groupOptions,  mod, 'mod') ||


### PR DESCRIPTION
This is a partial fix for #3025. This ensures that the reported error does not occur, and that the setting of options works as expected.

In addition, the following refactorings:

* Consolidated duplicate code for handling font options in string format.
* Isolated getting a reference to (sub-)font options in a local function in `propagateFonts()`.
* Cleaned up some comments

The latter contains the added check for undefined options.
It should be noted that, of the options passed to `propagateFonts()`:
- `defaultOptions` must always be present
- param `options` can be `undefined` (as evidenced in #3025)
- of `groupOptions`, it is unclear at the time if it can be `undefined`