### PR TITLE
fix groupFromTarget when no group is defined in ItemSet.js

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -2220,7 +2220,7 @@ ItemSet.prototype.groupFromTarget = function(event) {
   var clientY = event.center ? event.center.y : event.clientY;
   var groupIds = this.groupIds;
   
-  if (groupIds.length <= 0) {
+  if (groupIds.length > 0) {
     groupIds = this.groupsData.getIds({
       order: this.options.groupOrder
     });


### PR DESCRIPTION
Whenever the groupFromTarget function is called in vis timeline and no group are defined this error is displayed in the console : 
```js
Uncaught TypeError: Cannot read property 'getIds' of null
    at ItemSet.groupFromTarget (ItemSet.js:2224)
    at Timeline.getEventProperties (Timeline.js:542)
    at HTMLDivElement.Timeline.dom.root.onmousemove (Timeline.js:143)
```

It for example breaks dragging a custom time bar.

The bug is just an incorrect check of the length of the group : it tries to get the groups when there is a negative number of group, which clearly cannot work. This bug was introduced in the develop branch (the code fixed here is not present in master)