### PR TITLE
Add command line options to mocha for running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "./dist/vis.js",
   "scripts": {
-    "test": "mocha",
+    "test": "mocha --compilers js:babel-core/register",
     "build": "gulp",
     "lint": "eslint lib",
     "watch": "gulp watch",


### PR DESCRIPTION
This PR adds the command line option for `mocha` in `package.json` to get the tests working again. Even though the required babel package were installed, mocha couldn't handle ES6 code.