### PR TITLE
NodesHandler use get(nodeId) instead of _data[nodeId]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 Please make sure to check the following requirements before creating a pull request:
 
 * [ ] All pull requests must be to the [develop branch](https://github.com/almende/vis/tree/develop). Pull requests to the `master` branch will be closed!
-* [ ] Make sure your changes are based on the latest version of the [develop branch](https://github.com/almende/vis/tree/develop). (Use e.g. `git fetch && git rebase origin develop` to update you feature branch).
+* [ ] Make sure your changes are based on the latest version of the [develop branch](https://github.com/almende/vis/tree/develop). (Use e.g. `git fetch && git rebase origin develop` to update your feature branch).
 * [ ] Provide an additional or update an example to demonstrate your changes or new features.
 * [ ] Update the documentation if you introduced new behavior or changed existing behavior.
 * [ ] Reference issue numbers of issues that your pull request addresses. (If you write something like `fixes #1781` in your git commit message this issue gets closed automatically by merging your pull request).

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -106,6 +106,8 @@ table.events td:nth-child(2) {
 
 pre {
     margin: 20px 0;
+    white-space: pre-wrap;
+    max-width: 100%;
 }
 
 a code {

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1055,11 +1055,11 @@ function (option, path) {
       This would be used as an additional way to add content that is constant in size with the visible frame of the item and does not get visibly hidden with the item's internal container: <code>vis-item-overflow</code> which is <code>overflow:hidden</code>.</td>
     </tr>
 
-    <tr class='depricated'>
+    <tr class='deprecated'>
       <td>throttleRedraw</td>
       <td>number</td>
       <td><code>0</code></td>
-      <td>This option is <b>DEPRICATED</b> and no longer supported. It will be removed in the next MAJOR release.</td>
+      <td>This option is <b>DEPRECATED</b> and no longer supported. It will be removed in the next MAJOR release.</td>
     </tr>
 
     <tr class='toggle collapsible' onclick="toggleTable('optionTable','timeAxis', this);">
@@ -1991,7 +1991,7 @@ var options = {
       <td>Weekday</td><td><code>vis-monday</code>, <code>vis-tuesday</code>, <code>vis-wednesday</code>, <code>vis-thursday</code>, <code>vis-friday</code>, <code>vis-saturday</code>, <code>vis-sunday</code></td>
     </tr>
     <tr>
-      <td>Days</td><td><code>vis-date1</code>, <code>vis-date2</code>, ..., <code>vis-date31</code></td>
+      <td>Days</td><td><code>vis-day1</code>, <code>vis-day2</code>, ..., <code>vis-day31</code></td>
     </tr>
     <tr>
       <td>Months</td><td><code>vis-january</code>, <code>vis-february</code>, <code>vis-march</code>, <code>vis-april</code>, <code>vis-may</code>, <code>vis-june</code>, <code>vis-july</code>, <code>vis-august</code>, <code>vis-september</code>, <code>vis-october</code>, <code>vis-november</code>, <code>vis-december</code></td>

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -955,11 +955,27 @@ function (option, path) {
       <td>Orientation of the timeline items: 'top' or 'bottom' (default). Determines whether items are aligned to the top or bottom of the Timeline.</td>
     </tr>
 
-    <tr>
-      <td>rollingMode</td>
+    <tr class='toggle collapsible' onclick="toggleTable('optionTable','rollingMode', this);">
+      <td><span parent="rollingMode" class="right-caret"></span> rollingMode</td>
+      <td>Object</td>
+      <td><code>Object</code></td>
+      <td>Specify how the timeline implements rolling mode.</td>
+    </tr>
+    <tr parent="rollingMode" class="hidden">
+      <td class="indent">rollingMode.follow</td>
       <td>boolean</td>
       <td><code>false</code></td>
       <td>If true, the timeline will initial in a rolling mode - the current time will always be centered. I the user drags the timeline, the timeline will go out of rolling mode and a toggle button will appear. Clicking that button will go back to rolling mode. Zooming in rolling mode will zoom in to the center without consideration of the mouse position.</td>
+    </tr>
+
+    <tr parent="rollingMode" class="hidden">
+      <td class="indent">rollingMode.offset</td>
+      <td>Number</td>
+      <td><code>'0.5'</code></td>
+      <td>
+        Set how far from the left the rolling mode is implemented from. A percentage (i.e. a decimal between 0 and 1)
+        Defaults to the middle or 0.5 (50%)
+      </td>
     </tr>
 
     <tr>

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1308,12 +1308,13 @@ document.getElementById('myTimeline').onclick = function (event) {
     </tr>
 
     <tr>
-      <td>moveTo(time [, options])</td>
+      <td>moveTo(time [, options, callback])</td>
       <td>none</td>
       <td>Move the window such that given time is centered on screen. Parameter <code>time</code> can be a <code>Date</code>, <code>Number</code>, or <code>String</code>. Available options:
         <ul>
           <li><code>animation: boolean or {duration: number, easingFunction: string}</code><br>If true (default) or an Object, the range is animated smoothly to the new window. An object can be provided to specify duration and easing function. Default duration is 500 ms, and default easing function is <code>'easeInOutQuad'</code>. Available easing functions: <code>"linear"</code>, <code>"easeInQuad"</code>, <code>"easeOutQuad"</code>, <code>"easeInOutQuad"</code>, <code>"easeInCubic"</code>, <code>"easeOutCubic"</code>, <code>"easeInOutCubic"</code>, <code>"easeInQuart"</code>, <code>"easeOutQuart"</code>, <code>"easeInOutQuart"</code>, <code>"easeInQuint"</code>, <code>"easeOutQuint"</code>, <code>"easeInOutQuint"</code>.</li>
         </ul>
+        A callback <code>function</code> can be passed as an optional parameter. This function will be called at the end of moveTo function.
       </td>
     </tr>
 
@@ -1422,12 +1423,13 @@ document.getElementById('myTimeline').onclick = function (event) {
     </tr>
 
     <tr>
-      <td>setWindow(start, end [, options])</td>
+      <td>setWindow(start, end [, options, callback])</td>
       <td>none</td>
       <td>Set the current visible window. The parameters <code>start</code> and <code>end</code> can be a <code>Date</code>, <code>Number</code>, or <code>String</code>. If the parameter value of <code>start</code> or <code>end</code> is null, the parameter will be left unchanged. Available options:
         <ul>
           <li><code>animation: boolean or {duration: number, easingFunction: string}</code><br>If true (default) or an Object, the range is animated smoothly to the new window. An object can be provided to specify duration and easing function. Default duration is 500 ms, and default easing function is <code>'easeInOutQuad'</code>. Available easing functions: <code>"linear"</code>, <code>"easeInQuad"</code>, <code>"easeOutQuad"</code>, <code>"easeInOutQuad"</code>, <code>"easeInCubic"</code>, <code>"easeOutCubic"</code>, <code>"easeInOutCubic"</code>, <code>"easeInQuart"</code>, <code>"easeOutQuart"</code>, <code>"easeInOutQuart"</code>, <code>"easeInQuint"</code>, <code>"easeOutQuint"</code>, <code>"easeInOutQuint"</code>.</li>
         </ul>
+        A callback <code>function</code> can be passed as an optional parameter. This function will be called at the end of setWindow function. 
       </td>
     </tr>
 
@@ -1439,21 +1441,23 @@ document.getElementById('myTimeline').onclick = function (event) {
     </tr>
 
      <tr>
-      <td>zoomIn(percentage [, options])</td>
+      <td>zoomIn(percentage [, options, callback])</td>
       <td>none</td>
       <td>Zoom in the current visible window. The parameter <code>percentage</code> can be a <code>Number</code> and must be between 0 and 1. If the parameter value of <code>percentage</code> is null, the window will be left unchanged. Available options:
         <ul>
           <li><code>animation: boolean or {duration: number, easingFunction: string}</code><br>If true (default) or an Object, the range is animated smoothly to the new window. An object can be provided to specify duration and easing function. Default duration is 500 ms, and default easing function is <code>'easeInOutQuad'</code>. Available easing functions: <code>"linear"</code>, <code>"easeInQuad"</code>, <code>"easeOutQuad"</code>, <code>"easeInOutQuad"</code>, <code>"easeInCubic"</code>, <code>"easeOutCubic"</code>, <code>"easeInOutCubic"</code>, <code>"easeInQuart"</code>, <code>"easeOutQuart"</code>, <code>"easeInOutQuart"</code>, <code>"easeInQuint"</code>, <code>"easeOutQuint"</code>, <code>"easeInOutQuint"</code>.</li>
         </ul>
+        A callback <code>function</code> can be passed as an optional parameter. This function will be called at the end of zoomIn function.
       </td>
     </tr>
     <tr>
-      <td>zoomOut(percentage [, options])</td>
+      <td>zoomOut(percentage [, options, callback])</td>
       <td>none</td>
       <td>Zoom out the current visible window. The parameter <code>percentage</code> can be a <code>Number</code> and must be between 0 and 1. If the parameter value of <code>percentage</code> is null, the window will be left unchanged. Available options:
         <ul>
           <li><code>animation: boolean or {duration: number, easingFunction: string}</code><br>If true (default) or an Object, the range is animated smoothly to the new window. An object can be provided to specify duration and easing function. Default duration is 500 ms, and default easing function is <code>'easeInOutQuad'</code>. Available easing functions: <code>"linear"</code>, <code>"easeInQuad"</code>, <code>"easeOutQuad"</code>, <code>"easeInOutQuad"</code>, <code>"easeInCubic"</code>, <code>"easeOutCubic"</code>, <code>"easeInOutCubic"</code>, <code>"easeInQuart"</code>, <code>"easeOutQuart"</code>, <code>"easeInOutQuart"</code>, <code>"easeInQuint"</code>, <code>"easeOutQuint"</code>, <code>"easeInOutQuint"</code>.</li>
         </ul>
+        A callback <code>function</code> can be passed as an optional parameter. This function will be called at the end of zoomOut function.
       </td>
     </tr>
 

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -612,6 +612,7 @@ function (option, path) {
     hour:       'HH:mm',
     weekday:    'ddd D',
     day:        'D',
+    week:       'w',
     month:      'MMM',
     year:       'YYYY'
   },
@@ -622,6 +623,7 @@ function (option, path) {
     hour:       'ddd D MMMM',
     weekday:    'MMMM YYYY',
     day:        'MMMM YYYY',
+    week:       'MMMM YYYY',
     month:      'YYYY',
     year:       ''
   }
@@ -1044,7 +1046,7 @@ function (option, path) {
       <td>function</td>
       <td>When moving items on the Timeline, they will be snapped to nice dates like full hours or days, depending on the current scale. The <code>snap</code> function can be replaced with a custom function, or can be set to <code>null</code> to disable snapping. The signature of the snap function is:
         <pre class="prettyprint lang-js">function snap(date: Date, scale: string, step: number) : Date or number</pre>
-        The parameter <code>scale</code> can be can be 'millisecond', 'second', 'minute', 'hour', 'weekday, 'day, 'month, or 'year'. The parameter <code>step</code> is a number like 1, 2, 4, 5.
+        The parameter <code>scale</code> can be can be 'millisecond', 'second', 'minute', 'hour', 'weekday, 'week', 'day, 'month, or 'year'. The parameter <code>step</code> is a number like 1, 2, 4, 5.
       </td>
     </tr>
 
@@ -1088,10 +1090,11 @@ function (option, path) {
       <td class="indent">timeAxis.scale</td>
       <td>String</td>
       <td>none</td>
-      <td>Set a fixed scale for the time axis of the Timeline. Choose from <code>'millisecond'</code>, <code>'second'</code>, <code>'minute'</code>, <code>'hour'</code>, <code>'weekday'</code>, <code>'day'</code>, <code>'month'</code>, <code>'year'</code>. Example usage:
+      <td>Set a fixed scale for the time axis of the Timeline. Choose from <code>'millisecond'</code>, <code>'second'</code>, <code>'minute'</code>, <code>'hour'</code>, <code>'weekday'</code>, <code>'week'</code>, <code>'day'</code>, <code>'month'</code>, <code>'year'</code>. Example usage:
   <pre class="prettyprint lang-js">var options = {
   timeAxis: {scale: 'minute', step: 5}
 }</pre>
+        <p>Note: The 'week' scale only works properly when <a href="#Localization">locales</a> are enabled.</p>
       </td>
     </tr>
 
@@ -2024,12 +2027,18 @@ var options = {
       <td>Days</td><td><code>vis-day1</code>, <code>vis-day2</code>, ..., <code>vis-day31</code></td>
     </tr>
     <tr>
+      <td>Week</td><td><code>vis-week1</code>, <code>vis-week2</code>, ..., <code>vis-week53</code></td>
+    </tr>
+    <tr>
       <td>Months</td><td><code>vis-january</code>, <code>vis-february</code>, <code>vis-march</code>, <code>vis-april</code>, <code>vis-may</code>, <code>vis-june</code>, <code>vis-july</code>, <code>vis-august</code>, <code>vis-september</code>, <code>vis-october</code>, <code>vis-november</code>, <code>vis-december</code></td>
     </tr>
     <tr>
       <td>Years</td><td><code>vis-year2014</code>, <code>vis-year2015</code>, ...</td>
     </tr>
   </table>
+  <p>
+    Note: the 'week' scale is not included in the automatic zoom levels as its scale is not a direct logical successor of 'days' nor a logical predecessor of 'months'
+  </p>
 
   <p>Examples:</p>
 

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1563,6 +1563,16 @@ timeline.off('select', onSelect);
     </tr>
 
     <tr>
+      <td>drop</td>
+      <td>
+        Passes a properties object as returned by the method <a href="#getEventProperties"><code>Timeline.getEventProperties(event)</code></a>.
+      </td>
+      <td>Fired when dropping inside the Timeline.
+      </td>
+    </tr>
+
+
+    <tr>
       <td>mouseOver</td>
       <td>
         Passes a properties object as returned by the method <a href="#getEventProperties"><code>Timeline.getEventProperties(event)</code></a>.

--- a/examples/network/events/interactionEvents.html
+++ b/examples/network/events/interactionEvents.html
@@ -24,6 +24,7 @@
 <pre id="eventSpan"></pre>
 
 <script type="text/javascript">
+
     // create an array with nodes
     var nodes = new vis.DataSet([
         {id: 1, label: 'Node 1', title: 'I have a popup!'},
@@ -53,6 +54,7 @@
     network.on("click", function (params) {
         params.event = "[original event]";
         document.getElementById('eventSpan').innerHTML = '<h2>Click event:</h2>' + JSON.stringify(params, null, 4);
+        console.log('click event, getNodeAt returns: ' + this.getNodeAt(params.pointer.DOM));
     });
     network.on("doubleClick", function (params) {
         params.event = "[original event]";

--- a/examples/network/other/saveAndLoad.html
+++ b/examples/network/other/saveAndLoad.html
@@ -71,15 +71,6 @@
                 draw();
             }
 
-            function addContextualInformation(elem, index, array) {
-                addId(elem, index);
-                addConnections(elem, index);
-            }
-
-            function addId(elem, index) {
-                elem.id = index;
-            }
-
             function addConnections(elem, index) {
                 // need to replace this with a tree of the network, then get child direct children of the element
                 elem.connections = network.getConnectedNodes(index);
@@ -107,7 +98,7 @@
 
                 var nodes = objectToArray(network.getPositions());
 
-                nodes.forEach(addContextualInformation);
+                nodes.forEach(addConnections);
 
                 // pretty print node data
                 var exportValue = JSON.stringify(nodes, undefined, 2);
@@ -141,30 +132,47 @@
                 return new vis.DataSet(networkNodes);
             }
 
+            function getNodeById(data, id) {
+                for (var n = 0; n < data.length; n++) {
+                    if (data[n].id == id) {  // double equals since id can be numeric or string
+                      return data[n];
+                    }
+                };
+
+                throw 'Can not find id \'' + id + '\' in data';
+            }
+
             function getEdgeData(data) {
                 var networkEdges = [];
 
-                data.forEach(function(node, index, array) {
+                data.forEach(function(node) {
                     // add the connection
                     node.connections.forEach(function(connId, cIndex, conns) {
                         networkEdges.push({from: node.id, to: connId});
+                        let cNode = getNodeById(data, connId);
 
-                        var elementConnections = array[connId].connections;
+                        var elementConnections = cNode.connections;
 
                         // remove the connection from the other node to prevent duplicate connections
                         var duplicateIndex = elementConnections.findIndex(function(connection) {
-                            connection === node.id;
+                          return connection == node.id; // double equals since id can be numeric or string
                         });
 
-                        elementConnections = elementConnections.splice(0, duplicateIndex - 1).concat(elementConnections.splice(duplicateIndex + 1, elementConnections.length))
-                        });
+
+                        if (duplicateIndex != -1) {
+                          elementConnections.splice(duplicateIndex, 1);
+                        };
+                  });
                 });
 
                 return new vis.DataSet(networkEdges);
             }
 
             function objectToArray(obj) {
-                return Object.keys(obj).map(function (key) { return obj[key]; });
+                return Object.keys(obj).map(function (key) {
+                  obj[key].id = key;
+                  return obj[key];
+                });
             }
 
             function resizeExportArea() {

--- a/examples/timeline/interaction/rollingMode.html
+++ b/examples/timeline/interaction/rollingMode.html
@@ -33,7 +33,10 @@
   var options = {
     start: new Date(),
     end: new Date(new Date().getTime() + 1000000),
-    rollingMode: true
+    rollingMode: {
+      follow: true,
+      offset: 0.5
+    }
   };
 
   // create a Timeline

--- a/examples/timeline/styling/weekStyling.html
+++ b/examples/timeline/styling/weekStyling.html
@@ -1,0 +1,111 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>Timeline | Grid styling</title>
+
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment-with-locales.min.js"></script>
+    <script src="../../../dist/vis.js"></script>
+    <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css"/>
+
+    <style type="text/css">
+        body, html {
+            font-family: sans-serif;
+        }
+
+        /* alternating column backgrounds */
+        .vis-time-axis .vis-grid.vis-odd {
+            background: #f5f5f5;
+        }
+    </style>
+
+</head>
+<body>
+
+<p>
+    Week numbers are calculated based on locales. For this to properly work, the timeline must be loaded with a version
+    of moment.js including locales.</p>
+<p>To set a locale for the timeline, specify the option
+    <code>{locale: STRING}</code>.</p>
+<p>To set the scale to use week numbers, use for example <code>{scale: 'week', step: 1}</code>.</p>
+<p>The following timeline is initialized with the 'de' locale and items are added with locally localized moment.js
+    objects. The timeline locale can be switched to another locale at runtime. If you choose the 'en' locale, the week
+    numbers will be calculated according to the US week calendar numbering scheme.</p>
+
+<p>
+    <label for="locale">Select a locale:</label>
+    <select id="locale">
+        <option value="en">en</option>
+        <option value="it">it</option>
+        <option value="nl">nl</option>
+        <option value="de" selected>de</option>
+    </select>
+</p>
+
+<div id="visualization"></div>
+
+<script type="text/javascript">
+    var itemCount = 26;
+
+    // DOM element where the Timeline will be attached
+    var container = document.getElementById('visualization');
+
+    // just a group for the effects
+    var groups = new vis.DataSet();
+    groups.add([{id: 1, content: "ISO Weeks"}, {id: 2, content: "US Weeks"}]);
+
+    // Create a DataSet (allows two way data-binding)
+    var items = new vis.DataSet();
+
+    // create a localized moment object based on the current date
+    var USdate = moment().locale('en').hours(0).minutes(0).seconds(0).milliseconds(0);
+
+    // use the locale-aware weekday function to move to the begin of the current week
+    USdate.weekday(0);
+
+    // Iterate and just add a week to use it again in the next iteration
+    for (var i = 0; i < itemCount; i++) {
+        var USweekNumber = USdate.format('w');
+        var USweekStart = USdate.format();
+        var USweekEnd = USdate.add(1, 'week').format();
+        items.add({
+            id: i,
+            group: 2,
+            content: 'US week ' + USweekNumber,
+            start: USweekStart,
+            end: USweekEnd
+        });
+    }
+
+    // create another localized moment object - the 'de' locale works according to the ISO8601 leap week calendar system
+    var DEdate = moment().locale('de').hours(0).minutes(0).seconds(0).milliseconds(0);
+    DEdate.weekday(0);
+    for (var j = 0; j < itemCount; j++) {
+        var DEweekNumber = DEdate.format('w');
+        var DEweekStart = DEdate.format();
+        var DEweekEnd = DEdate.add(1, 'week').format();
+        items.add({
+            id: itemCount + j,
+            group: 1,
+            content: 'ISO week ' + DEweekNumber,
+            start: DEweekStart,
+            end: DEweekEnd
+        });
+    }
+
+    // Configuration for the Timeline
+    var options = {timeAxis: {scale: 'week', step: 1}, locale: 'de'};
+
+    // Create a Timeline
+    var timeline = new vis.Timeline(container, items, groups, options);
+
+    // update the locale when changing the select box value
+    var select = document.getElementById('locale');
+    select.onchange = function () {
+        timeline.setOptions({
+            locale: this.value
+        });
+    };
+    select.onchange();
+</script>
+</body>
+</html>

--- a/lib/network/CachedImage.js
+++ b/lib/network/CachedImage.js
@@ -1,0 +1,160 @@
+
+/**
+ * Associates a canvas to a given image, containing a number of renderings
+ * of the image at various sizes.
+ *
+ * This technique is known as 'mipmapping'.
+ *
+ * NOTE: Images can also be of type 'data:svg+xml`. This code also works
+ *       for svg, but the mipmapping may not be necessary.
+ */
+class CachedImage {
+  constructor(image) {
+    this.NUM_ITERATIONS = 4;  // Number of items in the coordinates array
+
+    this.image  = new Image();
+    this.canvas = document.createElement('canvas');
+  }
+
+
+  /**
+   * Called when the image has been succesfully loaded.
+   */
+  init() {
+    if (this.initialized()) return;
+
+    var w = this.image.width;
+    var h = this.image.height;
+
+    // Ease external access
+    this.width  = w;
+    this.height = h;
+
+    // Make canvas as small as possible
+    this.canvas.width  = 3*w/4;
+    this.canvas.height = h/2;
+
+    // Coordinates and sizes of images contained in the canvas
+    // Values per row:  [top x, left y, width, height]
+    this.coordinates = [
+      [ 0    , 0  , w/2 , h/2],
+      [ w/2  , 0  , w/4 , h/4],
+      [ w/2  , h/4, w/8 , h/8],
+      [ 5*w/8, h/4, w/16, h/16]
+    ];
+
+    this._fillMipMap();
+  }
+
+
+  /**
+   * @return {Boolean} true if init() has been called, false otherwise.
+   */
+  initialized() {
+    return (this.coordinates !== undefined);
+  }
+
+
+  /**
+   * Redraw main image in various sizes to the context.
+   *
+   * The rationale behind this is to reduce artefacts due to interpolation
+   * at differing zoom levels.
+   *
+   * Source: http://stackoverflow.com/q/18761404/1223531
+   *
+   * This methods takes the resizing out of the drawing loop, in order to
+   * reduce performance overhead.
+   *
+   * @private
+   */
+  _fillMipMap() {
+    var ctx = this.canvas.getContext('2d');
+
+    // First zoom-level comes from the image
+    var to  = this.coordinates[0];
+    ctx.drawImage(this.image, to[0], to[1], to[2], to[3]);
+
+    // The rest are copy actions internal to the canvas/context
+    for (let iterations = 1; iterations < this.NUM_ITERATIONS; iterations++) {
+      let from = this.coordinates[iterations - 1];
+      let to   = this.coordinates[iterations];
+
+      ctx.drawImage(this.canvas,
+        from[0], from[1], from[2], from[3],
+          to[0],   to[1],   to[2],   to[3]
+      );
+    }
+  }
+
+
+  /**
+   * Draw the image, using the mipmap if necessary.
+   *
+   * MipMap is only used if param factor > 2; otherwise, original bitmap
+   * is resized. This is also used to skip mipmap usage, e.g. by setting factor = 1
+   *
+   * Credits to 'Alex de Mulder' for original implementation.
+   *
+   * ctx    {Context} context on which to draw zoomed image
+   * factor {Float}   scale factor at which to draw
+   */
+  drawImageAtPosition(ctx, factor, left, top, width, height) {
+    if (factor > 2 && this.initialized()) {
+      // Determine which zoomed image to use
+      factor *= 0.5;
+      let iterations = 0;
+      while (factor > 2 && iterations < this.NUM_ITERATIONS) {
+        factor *= 0.5;
+        iterations += 1;
+      }
+
+      if (iterations >= this.NUM_ITERATIONS) {
+        iterations = this.NUM_ITERATIONS - 1;
+      }
+      //console.log("iterations: " + iterations);
+
+      let from = this.coordinates[iterations];
+      ctx.drawImage(this.canvas,
+        from[0], from[1], from[2], from[3],
+           left,     top,   width,  height
+      );
+    } else if (this._isImageOk()) {
+      // Draw image directly
+      ctx.drawImage(this.image, left, top, width, height);
+    }
+  }
+
+
+  /**
+   * Check if image is loaded
+   *
+   * Source: http://stackoverflow.com/a/1977898/1223531
+   *
+   * @private
+   */
+  _isImageOk(img) {
+    var img = this.image;
+
+    // During the onload event, IE correctly identifies any images that
+    // weren’t downloaded as not complete. Others should too. Gecko-based
+    // browsers act like NS4 in that they report this incorrectly.
+    if (!img.complete) {
+        return false;
+    }
+
+    // However, they do have two very useful properties: naturalWidth and
+    // naturalHeight. These give the true size of the image. If it failed
+    // to load, either of these should be zero.
+
+    if (typeof img.naturalWidth !== "undefined" && img.naturalWidth === 0) {
+        return false;
+    }
+
+    // No other way of checking: assume it’s ok.
+    return true;
+  }
+}
+
+
+export default CachedImage;

--- a/lib/network/Images.js
+++ b/lib/network/Images.js
@@ -1,29 +1,17 @@
+import CachedImage from './CachedImage';
+
+
 /**
  * @class Images
  * This class loads images and keeps them stored.
  */
-class Images{
+class Images {
     constructor(callback){
         this.images = {};
         this.imageBroken = {};
         this.callback = callback;
     }
     
-    /**
-     * @param {string} url                      The Url to cache the image as 
-      * @return {Image} imageToLoadBrokenUrlOn  The image object
-     */    
-    _addImageToCache (url, imageToCache) {
-        // IE11 fix -- thanks dponch!
-        if (imageToCache.width === 0) {
-            document.body.appendChild(imageToCache);
-            imageToCache.width = imageToCache.offsetWidth;
-            imageToCache.height = imageToCache.offsetHeight;
-            document.body.removeChild(imageToCache);
-        }
-    
-        this.images[url] = imageToCache;
-    }  
     
     /**
      * @param {string} url                      The original Url that failed to load, if the broken image is successfully loaded it will be added to the cache using this Url as the key so that subsequent requests for this Url will return the broken image
@@ -37,12 +25,11 @@ class Images{
         //Clear the old subscription to the error event and put a new in place that only handle errors in loading the brokenImageUrl
         imageToLoadBrokenUrlOn.onerror = () => {
             console.error("Could not load brokenImage:", brokenUrl);
-            //Add an empty image to the cache so that when subsequent load calls are made for the url we don't try load the image and broken image again
-            this._addImageToCache(url, new Image());
+            // cache item will contain empty image, this should be OK for default
         };
         
         //Set the source of the image to the brokenUrl, this is actually what kicks off the loading of the broken image
-        imageToLoadBrokenUrlOn.src = brokenUrl;
+        imageToLoadBrokenUrlOn.image.src = brokenUrl;
     }
     
     /**
@@ -65,28 +52,50 @@ class Images{
         if (cachedImage) return cachedImage;
         
         //Create a new image
-        var img = new Image();
+        var img = new CachedImage();
+
+        // Need to add to cache here, otherwise final return will spawn different copies of the same image,
+        // Also, there will be multiple loads of the same image.
+        this.images[url] = img; 
         
         //Subscribe to the event that is raised if the image loads successfully 
-        img.onload = () => {
-            //Add the image to the cache and then request a redraw
-            this._addImageToCache(url, img);
+        img.image.onload = () => {
+            // Properly init the cached item and then request a redraw
+            this._fixImageCoordinates(img.image);
+            img.init();
             this._redrawWithImage(img);
         };
         
         //Subscribe to the event that is raised if the image fails to load
-        img.onerror = () => {
+        img.image.onerror = () => {
             console.error("Could not load image:", url);
             //Try and load the image specified by the brokenUrl using
             this._tryloadBrokenUrl(url, brokenUrl, img);
         }
         
-        //Set the source of the image to the url, this is actuall what kicks off the loading of the image
-        img.src = url;
+        //Set the source of the image to the url, this is what actually kicks off the loading of the image
+        img.image.src = url;
         
         //Return the new image
         return img;
-    }          
+    }
+
+
+    /**
+     * IE11 fix -- thanks dponch!
+     *
+     * Local helper function
+     *
+     * @private
+     */
+    _fixImageCoordinates(imageToCache) {
+        if (imageToCache.width === 0) {
+            document.body.appendChild(imageToCache);
+            imageToCache.width = imageToCache.offsetWidth;
+            imageToCache.height = imageToCache.offsetHeight;
+            document.body.removeChild(imageToCache);
+        }
+    }
 }
 
 export default Images;

--- a/lib/network/gephiParser.js
+++ b/lib/network/gephiParser.js
@@ -45,11 +45,10 @@ function parseGephi(gephiJSON, optionsObj) {
     var gNode = gNodes[i];
     node['id'] = gNode.id;
     node['attributes'] = gNode.attributes;
-    node['title'] = gNode.title;
     node['x'] = gNode.x;
     node['y'] = gNode.y;
     node['label'] = gNode.label;
-    node['title'] = gNode.attributes !== undefined ? gNode.attributes.title : undefined;
+    node['title'] = gNode.attributes !== undefined ? gNode.attributes.title : gNode.title;
     if (options.nodes.parseColor === true) {
       node['color'] = gNode.color;
     }

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -189,12 +189,7 @@ class Canvas {
     }
     else {
       let ctx = this.frame.canvas.getContext("2d");
-      this.pixelRatio = (window.devicePixelRatio || 1) / (ctx.webkitBackingStorePixelRatio ||
-      ctx.mozBackingStorePixelRatio ||
-      ctx.msBackingStorePixelRatio ||
-      ctx.oBackingStorePixelRatio ||
-      ctx.backingStorePixelRatio || 1);
-
+      this._setPixelRatio(ctx);
       this.frame.canvas.getContext("2d").setTransform(this.pixelRatio, 0, 0, this.pixelRatio, 0, 0);
     }
 
@@ -264,11 +259,7 @@ class Canvas {
     // update the pixel ratio
     let ctx = this.frame.canvas.getContext("2d");
     let previousRatio = this.pixelRatio; // we cache this because the camera state storage needs the old value
-    this.pixelRatio = (window.devicePixelRatio || 1) / (ctx.webkitBackingStorePixelRatio ||
-      ctx.mozBackingStorePixelRatio ||
-      ctx.msBackingStorePixelRatio ||
-      ctx.oBackingStorePixelRatio ||
-      ctx.backingStorePixelRatio || 1);
+    this._setPixelRatio(ctx);
 
     if (width != this.options.width || height != this.options.height || this.frame.style.width != width || this.frame.style.height != height) {
       this._getCameraState(previousRatio);
@@ -296,26 +287,29 @@ class Canvas {
       // this would adapt the width of the canvas to the width from 100% if and only if
       // there is a change.
 
+      let newWidth  = Math.round(this.frame.canvas.clientWidth  * this.pixelRatio);
+      let newHeight = Math.round(this.frame.canvas.clientHeight * this.pixelRatio);
+
       // store the camera if there is a change in size.
-      if (this.frame.canvas.width != Math.round(this.frame.canvas.clientWidth * this.pixelRatio) || this.frame.canvas.height != Math.round(this.frame.canvas.clientHeight * this.pixelRatio)) {
+      if (this.frame.canvas.width !== newWidth || this.frame.canvas.height !== newHeight) {
         this._getCameraState(previousRatio);
       }
 
-      if (this.frame.canvas.width != Math.round(this.frame.canvas.clientWidth * this.pixelRatio)) {
-        this.frame.canvas.width = Math.round(this.frame.canvas.clientWidth * this.pixelRatio);
+      if (this.frame.canvas.width !== newWidth) {
+        this.frame.canvas.width = newWidth;
         emitEvent = true;
       }
-      if (this.frame.canvas.height != Math.round(this.frame.canvas.clientHeight * this.pixelRatio)) {
-        this.frame.canvas.height = Math.round(this.frame.canvas.clientHeight * this.pixelRatio);
+      if (this.frame.canvas.height !== newHeight) {
+        this.frame.canvas.height = newHeight;
         emitEvent = true;
       }
     }
 
     if (emitEvent === true) {
       this.body.emitter.emit('resize', {
-        width:Math.round(this.frame.canvas.width / this.pixelRatio),
-        height:Math.round(this.frame.canvas.height / this.pixelRatio),
-        oldWidth: Math.round(oldWidth / this.pixelRatio),
+        width    : Math.round(this.frame.canvas.width / this.pixelRatio),
+        height   : Math.round(this.frame.canvas.height / this.pixelRatio),
+        oldWidth : Math.round(oldWidth / this.pixelRatio),
         oldHeight: Math.round(oldHeight / this.pixelRatio)
       });
 
@@ -328,6 +322,18 @@ class Canvas {
     this.initialized = true;
     return emitEvent;
   };
+
+
+  /**
+   * @private
+   */
+  _setPixelRatio(ctx) {
+    this.pixelRatio = (window.devicePixelRatio || 1) / (ctx.webkitBackingStorePixelRatio ||
+      ctx.mozBackingStorePixelRatio ||
+      ctx.msBackingStorePixelRatio  ||
+      ctx.oBackingStorePixelRatio   ||
+      ctx.backingStorePixelRatio    || 1);
+  }
 
 
   /**

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -385,8 +385,8 @@ class EdgesHandler {
     let nodeList = [];
     if (this.body.edges[edgeId] !== undefined) {
       let edge = this.body.edges[edgeId];
-      if (edge.fromId) {nodeList.push(edge.fromId);}
-      if (edge.toId)   {nodeList.push(edge.toId);}
+      if (edge.fromId !== undefined) {nodeList.push(edge.fromId);}
+      if (edge.toId !== undefined)   {nodeList.push(edge.toId);}
     }
     return nodeList;
   }

--- a/lib/network/modules/KamadaKawai.js
+++ b/lib/network/modules/KamadaKawai.js
@@ -49,11 +49,14 @@ class KamadaKawai {
     // get the K Matrix
     this._createK_matrix(D_matrix);
 
+    // initial E Matrix
+    this._createE_matrix();
+
     // calculate positions
     let threshold = 0.01;
     let innerThreshold = 1;
     let iterations = 0;
-    let maxIterations = Math.max(1000,Math.min(10*this.body.nodeIndices.length,6000));
+    let maxIterations = Math.max(1000, Math.min(10 * this.body.nodeIndices.length, 6000));
     let maxInnerIterations = 5;
 
     let maxEnergy = 1e9;
@@ -64,10 +67,10 @@ class KamadaKawai {
       [highE_nodeId, maxEnergy, dE_dx, dE_dy] = this._getHighestEnergyNode(ignoreClusters);
       delta_m = maxEnergy;
       subIterations = 0;
-      while(delta_m > innerThreshold && subIterations < maxInnerIterations) {
+      while (delta_m > innerThreshold && subIterations < maxInnerIterations) {
         subIterations += 1;
         this._moveNode(highE_nodeId, dE_dx, dE_dy);
-        [delta_m,dE_dx,dE_dy] = this._getEnergy(highE_nodeId);
+        [delta_m, dE_dx, dE_dy] = this._getEnergy(highE_nodeId);
       }
     }
   }
@@ -87,7 +90,7 @@ class KamadaKawai {
     for (let nodeIdx = 0; nodeIdx < nodesArray.length; nodeIdx++) {
       let m = nodesArray[nodeIdx];
       // by not evaluating nodes with predefined positions we should only move nodes that have no positions.
-      if ((nodes[m].predefinedPosition === false || nodes[m].isCluster === true && ignoreClusters === true) || nodes[m].options.fixed.x === true ||  nodes[m].options.fixed.y === true) {
+      if ((nodes[m].predefinedPosition === false || nodes[m].isCluster === true && ignoreClusters === true) || nodes[m].options.fixed.x === true || nodes[m].options.fixed.y === true) {
         let [delta_m,dE_dx,dE_dy] = this._getEnergy(m);
         if (maxEnergy < delta_m) {
           maxEnergy = delta_m;
@@ -108,24 +111,7 @@ class KamadaKawai {
    * @private
    */
   _getEnergy(m) {
-    let nodesArray = this.body.nodeIndices;
-    let nodes = this.body.nodes;
-
-    let x_m = nodes[m].x;
-    let y_m = nodes[m].y;
-    let dE_dx = 0;
-    let dE_dy = 0;
-    for (let iIdx = 0; iIdx < nodesArray.length; iIdx++) {
-      let i = nodesArray[iIdx];
-      if (i !== m) {
-        let x_i = nodes[i].x;
-        let y_i = nodes[i].y;
-        let denominator = 1.0 / Math.sqrt(Math.pow(x_m - x_i, 2) + Math.pow(y_m - y_i, 2));
-        dE_dx += this.K_matrix[m][i] * ((x_m - x_i) - this.L_matrix[m][i] * (x_m - x_i) * denominator);
-        dE_dy += this.K_matrix[m][i] * ((y_m - y_i) - this.L_matrix[m][i] * (y_m - y_i) * denominator);
-      }
-    }
-
+    let [dE_dx,dE_dy] = this.E_sums[m];
     let delta_m = Math.sqrt(Math.pow(dE_dx, 2) + Math.pow(dE_dy, 2));
     return [delta_m, dE_dx, dE_dy];
   }
@@ -147,15 +133,20 @@ class KamadaKawai {
 
     let x_m = nodes[m].x;
     let y_m = nodes[m].y;
+    let km = this.K_matrix[m];
+    let lm = this.L_matrix[m];
+
     for (let iIdx = 0; iIdx < nodesArray.length; iIdx++) {
       let i = nodesArray[iIdx];
       if (i !== m) {
         let x_i = nodes[i].x;
         let y_i = nodes[i].y;
+        let kmat = km[i];
+        let lmat = lm[i];
         let denominator = 1.0 / Math.pow(Math.pow(x_m - x_i, 2) + Math.pow(y_m - y_i, 2), 1.5);
-        d2E_dx2 += this.K_matrix[m][i] * (1 - this.L_matrix[m][i] * Math.pow(y_m - y_i, 2) * denominator);
-        d2E_dxdy += this.K_matrix[m][i] * (this.L_matrix[m][i] * (x_m - x_i) * (y_m - y_i) * denominator);
-        d2E_dy2 += this.K_matrix[m][i] * (1 - this.L_matrix[m][i] * Math.pow(x_m - x_i, 2) * denominator);
+        d2E_dx2 += kmat * (1 - lmat * Math.pow(y_m - y_i, 2) * denominator);
+        d2E_dxdy += kmat * (lmat * (x_m - x_i) * (y_m - y_i) * denominator);
+        d2E_dy2 += kmat * (1 - lmat * Math.pow(x_m - x_i, 2) * denominator);
       }
     }
     // make the variable names easier to make the solving of the linear system easier to read
@@ -168,6 +159,9 @@ class KamadaKawai {
     // move the node
     nodes[m].x += dx;
     nodes[m].y += dy;
+
+    // Recalculate E_matrix (should be incremental)
+    this._updateE_matrix(m);
   }
 
 
@@ -208,8 +202,82 @@ class KamadaKawai {
     }
   }
 
+  /**
+   *  Create matrix with all energies between nodes
+   *  @private
+   */
+  _createE_matrix() {
+    let nodesArray = this.body.nodeIndices;
+    let nodes = this.body.nodes;
+    this.E_matrix = {};
+    this.E_sums = {};
+    for (let mIdx = 0; mIdx < nodesArray.length; mIdx++) {
+      this.E_matrix[nodesArray[mIdx]] = [];
+    }
+    for (let mIdx = 0; mIdx < nodesArray.length; mIdx++) {
+      let m = nodesArray[mIdx];
+      let x_m = nodes[m].x;
+      let y_m = nodes[m].y;
+      let dE_dx = 0;
+      let dE_dy = 0;
+      for (let iIdx = mIdx; iIdx < nodesArray.length; iIdx++) {
+        let i = nodesArray[iIdx];
+        if (i !== m) {
+          let x_i = nodes[i].x;
+          let y_i = nodes[i].y;
+          let denominator = 1.0 / Math.sqrt(Math.pow(x_m - x_i, 2) + Math.pow(y_m - y_i, 2));
+          this.E_matrix[m][iIdx] = [
+            this.K_matrix[m][i] * ((x_m - x_i) - this.L_matrix[m][i] * (x_m - x_i) * denominator),
+            this.K_matrix[m][i] * ((y_m - y_i) - this.L_matrix[m][i] * (y_m - y_i) * denominator)
+          ];
+          this.E_matrix[i][mIdx] = this.E_matrix[m][iIdx];
+          dE_dx += this.E_matrix[m][iIdx][0];
+          dE_dy += this.E_matrix[m][iIdx][1];
+        }
+      }
+      //Store sum
+      this.E_sums[m] = [dE_dx, dE_dy];
+    }
+  }
 
+  //Update method, just doing single column (rows are auto-updated) (update all sums)
+  _updateE_matrix(m) {
+    let nodesArray = this.body.nodeIndices;
+    let nodes = this.body.nodes;
+    let colm = this.E_matrix[m];
+    let kcolm = this.K_matrix[m];
+    let lcolm = this.L_matrix[m];
+    let x_m = nodes[m].x;
+    let y_m = nodes[m].y;
+    let dE_dx = 0;
+    let dE_dy = 0;
+    for (let iIdx = 0; iIdx < nodesArray.length; iIdx++) {
+      let i = nodesArray[iIdx];
+      if (i !== m) {
+        //Keep old energy value for sum modification below
+        let cell = colm[iIdx];
+        let oldDx = cell[0];
+        let oldDy = cell[1];
 
+        //Calc new energy:
+        let x_i = nodes[i].x;
+        let y_i = nodes[i].y;
+        let denominator = 1.0 / Math.sqrt(Math.pow(x_m - x_i, 2) + Math.pow(y_m - y_i, 2));
+        let dx = kcolm[i] * ((x_m - x_i) - lcolm[i] * (x_m - x_i) * denominator);
+        let dy = kcolm[i] * ((y_m - y_i) - lcolm[i] * (y_m - y_i) * denominator);
+        colm[iIdx] = [dx, dy];
+        dE_dx += dx;
+        dE_dy += dy;
+
+        //add new energy to sum of each column
+        let sum = this.E_sums[i];
+        sum[0] += (dx-oldDx);
+        sum[1] += (dy-oldDy);
+      }
+    }
+    //Store sum at -1 index
+    this.E_sums[m] = [dE_dx, dE_dy];
+  }
 }
 
 export default KamadaKawai;

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -161,9 +161,9 @@ class LayoutEngine {
   positionInitially(nodesArray) {
     if (this.options.hierarchical.enabled !== true) {
       this.randomSeed = this.initialRandomSeed;
+      let radius = nodesArray.length + 50;
       for (let i = 0; i < nodesArray.length; i++) {
         let node = nodesArray[i];
-        let radius = 10 * 0.1 * nodesArray.length + 10;
         let angle = 2 * Math.PI * this.seededRandom();
         if (node.x === undefined) {
           node.x = radius * Math.cos(angle);
@@ -196,33 +196,45 @@ class LayoutEngine {
       if (positionDefined < 0.5 * this.body.nodeIndices.length) {
         let MAX_LEVELS = 10;
         let level = 0;
-        let clusterThreshold = 100;
+        let clusterThreshold = 150;
+        //Performance enhancement, during clustering edges need only be simple straight lines. These options don't propagate outside the clustering phase.
+        let clusterOptions = {
+          clusterEdgeProperties:{
+            smooth: {
+              enabled: false
+            }
+          }
+        };
+
         // if there are a lot of nodes, we cluster before we run the algorithm.
         if (this.body.nodeIndices.length > clusterThreshold) {
           let startLength = this.body.nodeIndices.length;
-          while (this.body.nodeIndices.length > clusterThreshold) {
+          while (this.body.nodeIndices.length > clusterThreshold && level <= MAX_LEVELS) {
             //console.time("clustering")
             level += 1;
             let before = this.body.nodeIndices.length;
             // if there are many nodes we do a hubsize cluster
             if (level % 3 === 0) {
-              this.body.modules.clustering.clusterBridges();
+              this.body.modules.clustering.clusterBridges(clusterOptions);
             }
             else {
-              this.body.modules.clustering.clusterOutliers();
+              this.body.modules.clustering.clusterOutliers(clusterOptions);
             }
             let after = this.body.nodeIndices.length;
-            if ((before == after && level % 3 !== 0) || level > MAX_LEVELS) {
+            if (before == after && level % 3 !== 0) {
               this._declusterAll();
               this.body.emitter.emit("_layoutFailed");
               console.info("This network could not be positioned by this version of the improved layout algorithm. Please disable improvedLayout for better performance.");
               return;
             }
             //console.timeEnd("clustering")
-            //console.log(level,after)
+            //console.log(before,level,after);
           }
           // increase the size of the edges
           this.body.modules.kamadaKawai.setOptions({springLength: Math.max(150, 2 * startLength)})
+        }
+        if (level > MAX_LEVELS){
+          console.info("The clustering didn't succeed within the amount of interations allowed, progressing with partial result.");
         }
 
         // position the system for these nodes and edges

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -3,6 +3,171 @@
 let util = require('../../util');
 import NetworkUtil from '../NetworkUtil';
 
+
+/**
+ * Container for derived data on current network, relating to hierarchy.
+ *
+ * Local, private class.
+ *
+ * TODO: Perhaps move more code for hierarchy state handling to this class.
+ *       Till now, only the required and most obvious has been done.
+ */
+class HierarchicalStatus {
+
+  constructor() {
+    this.childrenReference = {};
+    this.parentReference = {};
+    this.levels = {};
+    this.trees = {};
+
+    this.isTree = false;
+  }
+
+
+  /**
+   * Add the relation between given nodes to the current state.
+   */
+  addRelation(parentNodeId, childNodeId) {
+    if (this.childrenReference[parentNodeId] === undefined) {
+      this.childrenReference[parentNodeId] = [];
+    }
+    this.childrenReference[parentNodeId].push(childNodeId);
+
+    if (this.parentReference[childNodeId] === undefined) {
+      this.parentReference[childNodeId] = [];
+    }
+    this.parentReference[childNodeId].push(parentNodeId);
+  }
+
+
+  /**
+   * Check if the current state is for a tree or forest network.
+   *
+   * This is the case if every node has at most one parent.
+   *
+   * Pre: parentReference init'ed properly for current network
+   */
+  checkIfTree() {
+    for (let i in this.parentReference) {
+      if (this.parentReference[i].length > 1) {
+        this.isTree = false;
+        return;
+      }
+    }
+
+    this.isTree = true;
+  }
+
+
+  /**
+   * Ensure level for given id is defined.
+   *
+   * Sets level to zero for given node id if not already present
+   */
+  ensureLevel(nodeId) {
+    if (this.levels[nodeId] === undefined) {
+      this.levels[nodeId] = 0;
+    }
+  }
+
+
+  /**
+   * get the maximum level of a branch.
+   *
+   * TODO: Never entered; find a test case to test this!
+   */
+  getMaxLevel(nodeId) {
+    let accumulator = {};
+
+    let _getMaxLevel = (nodeId) => {
+      if (accumulator[nodeId] !== undefined) {
+        return accumulator[nodeId];
+      }
+      let level = this.levels[nodeId];
+      if (this.childrenReference[nodeId]) {
+        let children = this.childrenReference[nodeId];
+        if (children.length > 0) {
+          for (let i = 0; i < children.length; i++) {
+            level = Math.max(level,_getMaxLevel(children[i]));
+          }
+        }
+      }
+      accumulator[nodeId] = level;
+      return level;
+    };
+
+    return _getMaxLevel(nodeId);
+  }
+
+
+  levelDownstream(nodeA, nodeB) {
+    if (this.levels[nodeB.id] === undefined) {
+      // set initial level
+      if (this.levels[nodeA.id] === undefined) {
+        this.levels[nodeA.id] = 0;
+      }
+      // set level
+      this.levels[nodeB.id] = this.levels[nodeA.id] + 1;
+    }
+  }
+
+
+  /**
+   * Small util method to set the minimum levels of the nodes to zero.
+   */
+  setMinLevelToZero(nodes) {
+    let minLevel = 1e9;
+    // get the minimum level
+    for (let nodeId in nodes) {
+      if (nodes.hasOwnProperty(nodeId)) {
+        if (this.levels[nodeId] !== undefined) {
+          minLevel = Math.min(this.levels[nodeId], minLevel);
+        }
+      }
+    }
+
+    // subtract the minimum from the set so we have a range starting from 0
+    for (let nodeId in nodes) {
+      if (nodes.hasOwnProperty(nodeId)) {
+        if (this.levels[nodeId] !== undefined) {
+          this.levels[nodeId] -= minLevel;
+        }
+      }
+    }
+  }
+
+
+  /**
+   * Get the min and max xy-coordinates of a given tree
+   */
+  getTreeSize(nodes, index) {
+    let min_x = 1e9;
+    let max_x = -1e9;
+    let min_y = 1e9;
+    let max_y = -1e9;
+
+    for (let nodeId in this.trees) {
+      if (this.trees.hasOwnProperty(nodeId)) {
+        if (this.trees[nodeId] === index) {
+          let node = nodes[nodeId];
+          min_x = Math.min(node.x, min_x);
+          max_x = Math.max(node.x, max_x);
+          min_y = Math.min(node.y, min_y);
+          max_y = Math.max(node.y, max_y);
+        }
+      }
+    }
+
+    return {
+      min_x: min_x,
+      max_x: max_x,
+      min_y: min_y,
+      max_y: max_y
+    };
+  }
+}
+
+
 class LayoutEngine {
   constructor(body) {
     this.body = body;
@@ -308,11 +473,8 @@ class LayoutEngine {
       let definedLevel = false;
       let definedPositions = true;
       let undefinedLevel = false;
-      this.hierarchicalLevels = {};
       this.lastNodeOnLevel = {};
-      this.hierarchicalChildrenReference = {};
-      this.hierarchicalParentReference = {};
-      this.hierarchicalTrees = {};
+      this.hierarchical = new HierarchicalStatus();
       this.treeIndex = -1;
 
       this.distributionOrdering = {};
@@ -328,7 +490,7 @@ class LayoutEngine {
           }
           if (node.options.level !== undefined) {
             definedLevel = true;
-            this.hierarchicalLevels[nodeId] = node.options.level;
+            this.hierarchical.levels[nodeId] = node.options.level;
           }
           else {
             undefinedLevel = true;
@@ -358,9 +520,7 @@ class LayoutEngine {
         // fallback for cases where there are nodes but no edges
         for (let nodeId in this.body.nodes) {
           if (this.body.nodes.hasOwnProperty(nodeId)) {
-            if (this.hierarchicalLevels[nodeId] === undefined) {
-              this.hierarchicalLevels[nodeId] = 0;
-            }
+            this.hierarchical.ensureLevel(nodeId);
           }
         }
         // check the distribution of the nodes per level.
@@ -402,9 +562,9 @@ class LayoutEngine {
 
     // shift a single tree by an offset
     let shiftTree = (index, offset) => {
-      for (let nodeId in this.hierarchicalTrees) {
-        if (this.hierarchicalTrees.hasOwnProperty(nodeId)) {
-          if (this.hierarchicalTrees[nodeId] === index) {
+      for (let nodeId in this.hierarchical.trees) {
+        if (this.hierarchical.trees.hasOwnProperty(nodeId)) {
+          if (this.hierarchical.trees[nodeId] === index) {
             let node = this.body.nodes[nodeId];
             let pos = this._getPositionForHierarchy(node);
             this._setPositionForHierarchy(node, pos + offset, undefined, true);
@@ -415,18 +575,12 @@ class LayoutEngine {
 
     // get the width of a tree
     let getTreeSize = (index) => {
-      let min = 1e9;
-      let max = -1e9;
-      for (let nodeId in this.hierarchicalTrees) {
-        if (this.hierarchicalTrees.hasOwnProperty(nodeId)) {
-          if (this.hierarchicalTrees[nodeId] === index) {
-            let pos = this._getPositionForHierarchy(this.body.nodes[nodeId]);
-            min = Math.min(pos, min);
-            max = Math.max(pos, max);
-          }
-        }
+      let res = this.hierarchical.getTreeSize(this.body.nodes, index);
+      if (this._isVertical()) {
+        return {min: res.min_x, max: res.max_x};
+      } else {
+        return {min: res.min_y, max: res.max_y};
       }
-      return {min:min, max:max};
     };
 
     // get the width of all trees
@@ -445,8 +599,8 @@ class LayoutEngine {
         return;
       }
       map[source.id] = true;
-      if (this.hierarchicalChildrenReference[source.id]) {
-        let children = this.hierarchicalChildrenReference[source.id];
+      if (this.hierarchical.childrenReference[source.id]) {
+        let children = this.hierarchical.childrenReference[source.id];
         if (children.length > 0) {
           for (let i = 0; i < children.length; i++) {
             getBranchNodes(this.body.nodes[children[i]], map);
@@ -465,7 +619,7 @@ class LayoutEngine {
       for (let branchNode in branchMap) {
         if (branchMap.hasOwnProperty(branchNode)) {
           let node = this.body.nodes[branchNode];
-          let level = this.hierarchicalLevels[node.id];
+          let level = this.hierarchical.levels[node.id];
           let position = this._getPositionForHierarchy(node);
 
           // get the space around the node.
@@ -484,39 +638,18 @@ class LayoutEngine {
       return [min, max, minSpace, maxSpace];
     };
 
-    // get the maximum level of a branch.
-    let getMaxLevel = (nodeId) => {
-      let accumulator = {};
-      let _getMaxLevel = (nodeId) => {
-        if (accumulator[nodeId] !== undefined) {
-          return accumulator[nodeId];
-        }
-        let level = this.hierarchicalLevels[nodeId];
-        if (this.hierarchicalChildrenReference[nodeId]) {
-          let children = this.hierarchicalChildrenReference[nodeId];
-          if (children.length > 0) {
-            for (let i = 0; i < children.length; i++) {
-              level = Math.max(level,_getMaxLevel(children[i]));
-            }
-          }
-        }
-        accumulator[nodeId] = level;
-        return level;
-      };
-      return _getMaxLevel(nodeId);
-    };
 
     // check what the maximum level is these nodes have in common.
     let getCollisionLevel = (node1, node2) => {
-      let maxLevel1 = getMaxLevel(node1.id);
-      let maxLevel2 = getMaxLevel(node2.id);
+      let maxLevel1 = this.hierarchical.getMaxLevel(node1.id);
+      let maxLevel2 = this.hierarchical.getMaxLevel(node2.id);
       return Math.min(maxLevel1, maxLevel2);
     };
 
     // check if two nodes have the same parent(s)
     let hasSameParent = (node1, node2) => {
-      let parents1 = this.hierarchicalParentReference[node1.id];
-      let parents2 = this.hierarchicalParentReference[node2.id];
+      let parents1 = this.hierarchical.parentReference[node1.id];
+      let parents2 = this.hierarchical.parentReference[node2.id];
       if (parents1 === undefined || parents2 === undefined) {
         return false;
       }
@@ -539,7 +672,7 @@ class LayoutEngine {
         if (levelNodes.length > 1) {
           for (let j = 0; j < levelNodes.length - 1; j++) {
             if (hasSameParent(levelNodes[j],levelNodes[j+1]) === true)  {
-              if (this.hierarchicalTrees[levelNodes[j].id] === this.hierarchicalTrees[levelNodes[j+1].id])  {
+              if (this.hierarchical.trees[levelNodes[j].id] === this.hierarchical.trees[levelNodes[j+1].id])  {
                 callback(levelNodes[j],levelNodes[j+1], centerParents);
               }
             }}
@@ -593,7 +726,7 @@ class LayoutEngine {
       //  console.log("ts",node.id);
         let nodeId = node.id;
         let allEdges = node.edges;
-        let nodeLevel = this.hierarchicalLevels[node.id];
+        let nodeLevel = this.hierarchical.levels[node.id];
 
         // gather constants
         let C2 = this.options.hierarchical.levelSeparation * this.options.hierarchical.levelSeparation;
@@ -604,7 +737,7 @@ class LayoutEngine {
           if (edge.toId != edge.fromId) {
             let otherNode = edge.toId == nodeId ? edge.from : edge.to;
             referenceNodes[allEdges[i].id] = otherNode;
-            if (this.hierarchicalLevels[otherNode.id] < nodeLevel) {
+            if (this.hierarchical.levels[otherNode.id] < nodeLevel) {
               aboveEdges.push(edge);
             }
           }
@@ -802,7 +935,7 @@ class LayoutEngine {
     if (map === undefined) {
       useMap = false;
     }
-    let level = this.hierarchicalLevels[node.id];
+    let level = this.hierarchical.levels[node.id];
     if (level !== undefined) {
       let index = this.distributionIndex[node.id];
       let position = this._getPositionForHierarchy(node);
@@ -837,16 +970,16 @@ class LayoutEngine {
    * @private
    */
   _centerParent(node) {
-    if (this.hierarchicalParentReference[node.id]) {
-      let parents = this.hierarchicalParentReference[node.id];
+    if (this.hierarchical.parentReference[node.id]) {
+      let parents = this.hierarchical.parentReference[node.id];
       for (var i = 0; i < parents.length; i++) {
         let parentId = parents[i];
         let parentNode = this.body.nodes[parentId];
-        if (this.hierarchicalChildrenReference[parentId]) {
+        if (this.hierarchical.childrenReference[parentId]) {
           // get the range of the children
           let minPos = 1e9;
           let maxPos = -1e9;
-          let children = this.hierarchicalChildrenReference[parentId];
+          let children = this.hierarchical.childrenReference[parentId];
           if (children.length > 0) {
             for (let i = 0; i < children.length; i++) {
               let childNode = this.body.nodes[children[i]];
@@ -893,7 +1026,7 @@ class LayoutEngine {
             // we get the X or Y values we need and store them in pos and previousPos. The get and set make sure we get X or Y
             if (handledNodeCount > 0) {pos = this._getPositionForHierarchy(nodeArray[i-1]) + this.options.hierarchical.nodeSpacing;}
             this._setPositionForHierarchy(node, pos, level);
-            this._validataPositionAndContinue(node, level, pos);
+            this._validatePositionAndContinue(node, level, pos);
 
             handledNodeCount++;
           }
@@ -913,14 +1046,14 @@ class LayoutEngine {
    */
   _placeBranchNodes(parentId, parentLevel) {
     // if this is not a parent, cancel the placing. This can happen with multiple parents to one child.
-    if (this.hierarchicalChildrenReference[parentId] === undefined) {
+    if (this.hierarchical.childrenReference[parentId] === undefined) {
       return;
     }
 
     // get a list of childNodes
     let childNodes = [];
-    for (let i = 0; i < this.hierarchicalChildrenReference[parentId].length; i++) {
-      childNodes.push(this.body.nodes[this.hierarchicalChildrenReference[parentId][i]]);
+    for (let i = 0; i < this.hierarchical.childrenReference[parentId].length; i++) {
+      childNodes.push(this.body.nodes[this.hierarchical.childrenReference[parentId][i]]);
     }
 
     // use the positions to order the nodes.
@@ -929,7 +1062,7 @@ class LayoutEngine {
     // position the childNodes
     for (let i = 0; i < childNodes.length; i++) {
       let childNode = childNodes[i];
-      let childNodeLevel = this.hierarchicalLevels[childNode.id];
+      let childNodeLevel = this.hierarchical.levels[childNode.id];
       // check if the child node is below the parent node and if it has already been positioned.
       if (childNodeLevel > parentLevel && this.positionedNodes[childNode.id] === undefined) {
         // get the amount of space required for this node. If parent the width is based on the amount of children.
@@ -939,7 +1072,7 @@ class LayoutEngine {
         if (i === 0) {pos = this._getPositionForHierarchy(this.body.nodes[parentId]);}
         else         {pos = this._getPositionForHierarchy(childNodes[i-1]) + this.options.hierarchical.nodeSpacing;}
         this._setPositionForHierarchy(childNode, pos, childNodeLevel);
-        this._validataPositionAndContinue(childNode, childNodeLevel, pos);
+        this._validatePositionAndContinue(childNode, childNodeLevel, pos);
       }
       else {
         return;
@@ -966,7 +1099,11 @@ class LayoutEngine {
    * @param pos
    * @private
    */
-  _validataPositionAndContinue(node, level, pos) {
+  _validatePositionAndContinue(node, level, pos) {
+    // This only works for strict hierarchical networks, i.e. trees and forests
+    // Early exit if this is not the case
+    if (!this.hierarchical.isTree) return;
+
     // if overlap has been detected, we shift the branch
     if (this.lastNodeOnLevel[level] !== undefined) {
       let previousPos = this._getPositionForHierarchy(this.body.nodes[this.lastNodeOnLevel[level]]);
@@ -1013,7 +1150,7 @@ class LayoutEngine {
     for (nodeId in this.body.nodes) {
       if (this.body.nodes.hasOwnProperty(nodeId)) {
         node = this.body.nodes[nodeId];
-        let level = this.hierarchicalLevels[nodeId] === undefined ? 0 : this.hierarchicalLevels[nodeId];
+        let level = this.hierarchical.levels[nodeId] === undefined ? 0 : this.hierarchical.levels[nodeId];
         if (this.options.hierarchical.direction === 'UD' || this.options.hierarchical.direction === 'DU') {
           node.y = this.options.hierarchical.levelSeparation * level;
           node.options.fixed.y = true;
@@ -1043,7 +1180,7 @@ class LayoutEngine {
     for (let nodeId in this.body.nodes) {
       if (this.body.nodes.hasOwnProperty(nodeId)) {
         let node = this.body.nodes[nodeId];
-        if (this.hierarchicalLevels[nodeId] === undefined) {
+        if (this.hierarchical.levels[nodeId] === undefined) {
           hubSize = node.edges.length < hubSize ? hubSize : node.edges.length;
         }
       }
@@ -1062,15 +1199,8 @@ class LayoutEngine {
     let hubSize = 1;
 
     let levelDownstream = (nodeA, nodeB) => {
-      if (this.hierarchicalLevels[nodeB.id] === undefined) {
-        // set initial level
-        if (this.hierarchicalLevels[nodeA.id] === undefined) {
-          this.hierarchicalLevels[nodeA.id] = 0;
-        }
-        // set level
-        this.hierarchicalLevels[nodeB.id] = this.hierarchicalLevels[nodeA.id] + 1;
-      }
-    };
+      this.hierarchical.levelDownstream(nodeA, nodeB);
+    }
 
     while (hubSize > 0) {
       // determine hubs
@@ -1089,8 +1219,11 @@ class LayoutEngine {
     }
   }
 
+
   /**
    * TODO: release feature
+   * TODO: Determine if this feature is needed at all
+   *
    * @private
    */
   _determineLevelsCustomCallback() {
@@ -1101,10 +1234,12 @@ class LayoutEngine {
 
     };
 
+    // TODO: perhaps move to HierarchicalStatus.
+    //       But I currently don't see the point, this method is not used.
     let levelByDirection = (nodeA, nodeB, edge) => {
-      let levelA = this.hierarchicalLevels[nodeA.id];
+      let levelA = this.hierarchical.levels[nodeA.id];
       // set initial level
-      if (levelA === undefined) {this.hierarchicalLevels[nodeA.id] = minLevel;}
+      if (levelA === undefined) {this.hierarchical.levels[nodeA.id] = minLevel;}
 
       let diff = customCallback(
         NetworkUtil.cloneOptions(nodeA,'node'),
@@ -1112,11 +1247,11 @@ class LayoutEngine {
         NetworkUtil.cloneOptions(edge,'edge')
       );
 
-      this.hierarchicalLevels[nodeB.id] = this.hierarchicalLevels[nodeA.id] + diff;
+      this.hierarchical.levels[nodeB.id] = this.hierarchical.levels[nodeA.id] + diff;
     };
 
     this._crawlNetwork(levelByDirection);
-    this._setMinLevelToZero();
+    this.hierarchical.setMinLevelToZero(this.body.nodes);
   }
 
   /**
@@ -1127,45 +1262,21 @@ class LayoutEngine {
    */
   _determineLevelsDirected() {
     let minLevel = 10000;
+
     let levelByDirection = (nodeA, nodeB, edge) => {
-      let levelA = this.hierarchicalLevels[nodeA.id];
+      let levelA = this.hierarchical.levels[nodeA.id];
       // set initial level
-      if (levelA === undefined) {this.hierarchicalLevels[nodeA.id] = minLevel;}
+      if (levelA === undefined) {this.hierarchical.levels[nodeA.id] = minLevel;}
       if (edge.toId == nodeB.id) {
-        this.hierarchicalLevels[nodeB.id] = this.hierarchicalLevels[nodeA.id] + 1;
+        this.hierarchical.levels[nodeB.id] = this.hierarchical.levels[nodeA.id] + 1;
       }
       else {
-        this.hierarchicalLevels[nodeB.id] = this.hierarchicalLevels[nodeA.id] - 1;
+        this.hierarchical.levels[nodeB.id] = this.hierarchical.levels[nodeA.id] - 1;
       }
     };
+
     this._crawlNetwork(levelByDirection);
-    this._setMinLevelToZero();
-  }
-
-
-  /**
-   * Small util method to set the minimum levels of the nodes to zero.
-   * @private
-   */
-  _setMinLevelToZero() {
-    let minLevel = 1e9;
-    // get the minimum level
-    for (let nodeId in this.body.nodes) {
-      if (this.body.nodes.hasOwnProperty(nodeId)) {
-        if (this.hierarchicalLevels[nodeId] !== undefined) {
-          minLevel = Math.min(this.hierarchicalLevels[nodeId], minLevel);
-        }
-      }
-    }
-
-    // subtract the minimum from the set so we have a range starting from 0
-    for (let nodeId in this.body.nodes) {
-      if (this.body.nodes.hasOwnProperty(nodeId)) {
-        if (this.hierarchicalLevels[nodeId] !== undefined) {
-          this.hierarchicalLevels[nodeId] -= minLevel;
-        }
-      }
-    }
+    this.hierarchical.setMinLevelToZero(this.body.nodes);
   }
 
 
@@ -1175,21 +1286,13 @@ class LayoutEngine {
    */
   _generateMap() {
     let fillInRelations = (parentNode, childNode) => {
-      if (this.hierarchicalLevels[childNode.id] > this.hierarchicalLevels[parentNode.id]) {
-        let parentNodeId = parentNode.id;
-        let childNodeId = childNode.id;
-        if (this.hierarchicalChildrenReference[parentNodeId] === undefined) {
-          this.hierarchicalChildrenReference[parentNodeId] = [];
-        }
-        this.hierarchicalChildrenReference[parentNodeId].push(childNodeId);
-        if (this.hierarchicalParentReference[childNodeId] === undefined) {
-          this.hierarchicalParentReference[childNodeId] = [];
-        }
-        this.hierarchicalParentReference[childNodeId].push(parentNodeId);
+      if (this.hierarchical.levels[childNode.id] > this.hierarchical.levels[parentNode.id]) {
+        this.hierarchical.addRelation(parentNode.id, childNode.id);
       }
     };
 
     this._crawlNetwork(fillInRelations);
+    this.hierarchical.checkIfTree();
   }
 
 
@@ -1206,8 +1309,8 @@ class LayoutEngine {
     let crawler = (node, tree) => {
       if (progress[node.id] === undefined) {
 
-        if (this.hierarchicalTrees[node.id] === undefined) {
-          this.hierarchicalTrees[node.id] = tree;
+        if (this.hierarchical.trees[node.id] === undefined) {
+          this.hierarchical.trees[node.id] = tree;
           this.treeIndex = Math.max(tree, this.treeIndex);
         }
 
@@ -1272,9 +1375,9 @@ class LayoutEngine {
       else {
         this.body.nodes[parentId].y += diff;
       }
-      if (this.hierarchicalChildrenReference[parentId] !== undefined) {
-        for (let i = 0; i < this.hierarchicalChildrenReference[parentId].length; i++) {
-          shifter(this.hierarchicalChildrenReference[parentId][i]);
+      if (this.hierarchical.childrenReference[parentId] !== undefined) {
+        for (let i = 0; i < this.hierarchical.childrenReference[parentId].length; i++) {
+          shifter(this.hierarchical.childrenReference[parentId][i]);
         }
       }
     };
@@ -1292,18 +1395,18 @@ class LayoutEngine {
   _findCommonParent(childA,childB) {
     let parents = {};
     let iterateParents = (parents,child) => {
-      if (this.hierarchicalParentReference[child] !== undefined) {
-        for (let i = 0; i < this.hierarchicalParentReference[child].length; i++) {
-          let parent = this.hierarchicalParentReference[child][i];
+      if (this.hierarchical.parentReference[child] !== undefined) {
+        for (let i = 0; i < this.hierarchical.parentReference[child].length; i++) {
+          let parent = this.hierarchical.parentReference[child][i];
           parents[parent] = true;
           iterateParents(parents, parent)
         }
       }
     };
     let findParent = (parents, child) => {
-      if (this.hierarchicalParentReference[child] !== undefined) {
-        for (let i = 0; i < this.hierarchicalParentReference[child].length; i++) {
-          let parent = this.hierarchicalParentReference[child][i];
+      if (this.hierarchical.parentReference[child] !== undefined) {
+        for (let i = 0; i < this.hierarchical.parentReference[child].length; i++) {
+          let parent = this.hierarchical.parentReference[child][i];
           if (parents[parent] !== undefined) {
             return {foundParent:parent, withChild:child};
           }
@@ -1350,6 +1453,18 @@ class LayoutEngine {
     }
   }
 
+
+  /**
+   * Utility function to cut down on typing this all the time.
+   *
+   * TODO: use this in all applicable situations in this class.
+   *
+   * @private
+   */
+  _isVertical() {
+    return (this.options.hierarchical.direction === 'UD' || this.options.hierarchical.direction === 'DU');
+  }
+
   /**
    * Abstract the getting of the position of a node so we do not have to repeat the direction check all the time.
    * @param node
@@ -1384,9 +1499,6 @@ class LayoutEngine {
       }
     }
   }
-
-
-
 }
 
 export default LayoutEngine;

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -171,7 +171,7 @@ class NodesHandler {
         for (let nodeId in this.body.nodes) {
           if (this.body.nodes.hasOwnProperty(nodeId)) {
             this.body.nodes[nodeId].updateLabelModule();
-            this.body.nodes[nodeId]._reset();
+            this.body.nodes[nodeId].needsRefresh();
           }
         }
       }
@@ -180,12 +180,12 @@ class NodesHandler {
       if (options.size !== undefined) {
         for (let nodeId in this.body.nodes) {
           if (this.body.nodes.hasOwnProperty(nodeId)) {
-            this.body.nodes[nodeId]._reset();
+            this.body.nodes[nodeId].needsRefresh();
           }
         }
       }
 
-      // update the state of the letiables if needed
+      // update the state of the variables if needed
       if (options.hidden !== undefined || options.physics !== undefined) {
         this.body.emitter.emit('_dataChanged');
       }

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -330,7 +330,7 @@ class NodesHandler {
       if (nodes.hasOwnProperty(nodeId)) {
         node = nodes[nodeId];
       }
-      let data = this.body.data.nodes._data[nodeId];
+      let data = this.body.data.nodes.get(nodeId);
       if (node !== undefined && data !== undefined) {
         if (clearPositions === true) {
           node.setOptions({x:null, y:null});

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -64,7 +64,7 @@ class NodesHandler {
         mono: {
           mod: '',
           size: 15, // px
-          face: 'courier new',
+          face: 'monospace',
           vadjust: 2
         }
       },

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -156,7 +156,7 @@ class SelectionHandler {
 
 
   /**
-   * Get the top node at the a specific point (like a click)
+   * Get the top node at the passed point (like a click)
    *
    * @param {{x: Number, y: Number}} pointer
    * @return {Node | undefined} node
@@ -212,11 +212,10 @@ class SelectionHandler {
 
 
   /**
-   * Place holder. To implement change the getNodeAt to a _getObjectAt. Have the _getObjectAt call
-   * getNodeAt and _getEdgesAt, then priortize the selection to user preferences.
+   * Get the edges nearest to the passed point (like a click)
    *
-   * @param pointer
-   * @returns {undefined}
+   * @param {{x: Number, y: Number}} pointer
+   * @return {Edge | undefined} node
    */
   getEdgeAt(pointer, returnEdge = true) {
     // Iterate over edges, pick closest within 10
@@ -239,7 +238,7 @@ class SelectionHandler {
         }
       }
     }
-    if (overlappingEdge) {
+    if (overlappingEdge !== null) {
       if (returnEdge === true) {
         return this.body.edges[overlappingEdge];
       }

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -209,7 +209,7 @@ class Edge {
   choosify(options) {
     this.chooser = true;
 
-    let pile = [options, this.options, this.defaultOptions];
+    let pile = [options, this.options, this.edgeOptions, this.defaultOptions];
 
     let chosen = util.topMost(pile, 'chosen');
     if (typeof chosen === 'boolean') {

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -352,7 +352,7 @@ class Node {
           break;
       }
     }
-    this._reset();
+    this.needsRefresh();
   }
 
 
@@ -361,7 +361,7 @@ class Node {
    */
   select() {
     this.selected = true;
-    this._reset();
+    this.needsRefresh();
   }
 
 
@@ -370,18 +370,16 @@ class Node {
    */
   unselect() {
     this.selected = false;
-    this._reset();
+    this.needsRefresh();
   }
 
 
 
   /**
    * Reset the calculated size of the node, forces it to recalculate its size
-   * @private
    */
-  _reset() {
-    this.shape.width = undefined;
-    this.shape.height = undefined;
+  needsRefresh() {
+    this.shape.refreshNeeded = true;
   }
 
 

--- a/lib/network/modules/components/algorithms/FloydWarshall.js
+++ b/lib/network/modules/components/algorithms/FloydWarshall.js
@@ -4,7 +4,8 @@
 
 
 class FloydWarshall {
-  constructor(){}
+  constructor() {
+  }
 
   getDistances(body, nodesArray, edgesArray) {
     let D_matrix = {};
@@ -12,11 +13,11 @@ class FloydWarshall {
 
     // prepare matrix with large numbers
     for (let i = 0; i < nodesArray.length; i++) {
-      D_matrix[nodesArray[i]] = {};
-      D_matrix[nodesArray[i]] = {};
+      let node = nodesArray[i];
+      let cell = {};
+      D_matrix[node] = cell;
       for (let j = 0; j < nodesArray.length; j++) {
-        D_matrix[nodesArray[i]][nodesArray[j]] = (i == j ? 0 : 1e9);
-        D_matrix[nodesArray[i]][nodesArray[j]] = (i == j ? 0 : 1e9);
+        cell[nodesArray[j]] = (i == j ? 0 : 1e9);
       }
     }
 
@@ -34,10 +35,18 @@ class FloydWarshall {
 
     // Adapted FloydWarshall based on unidirectionality to greatly reduce complexity.
     for (let k = 0; k < nodeCount; k++) {
-      for (let i = 0; i < nodeCount-1; i++) {
-        for (let j = i+1; j < nodeCount; j++) {
-          D_matrix[nodesArray[i]][nodesArray[j]] = Math.min(D_matrix[nodesArray[i]][nodesArray[j]],D_matrix[nodesArray[i]][nodesArray[k]] + D_matrix[nodesArray[k]][nodesArray[j]])
-          D_matrix[nodesArray[j]][nodesArray[i]] = D_matrix[nodesArray[i]][nodesArray[j]];
+      let knode = nodesArray[k];
+      let kcolm = D_matrix[knode];
+      for (let i = 0; i < nodeCount - 1; i++) {
+        let inode = nodesArray[i];
+        let icolm = D_matrix[inode];
+        for (let j = i + 1; j < nodeCount; j++) {
+          let jnode = nodesArray[j];
+          let jcolm = D_matrix[jnode];
+
+          let val = Math.min(icolm[jnode], icolm[knode] + kcolm[jnode]);
+          icolm[jnode] = val;
+          jcolm[inode] = val;
         }
       }
     }

--- a/lib/network/modules/components/nodes/shapes/Box.js
+++ b/lib/network/modules/components/nodes/shapes/Box.js
@@ -9,7 +9,7 @@ class Box extends NodeBase {
   }
 
   resize(ctx, selected = this.selected, hover = this.hover) {
-    if ((this.width === undefined) || this.labelModule.differentState(selected, hover)) {
+    if (this.needsRefresh(selected, hover)) {
       this.textSize = this.labelModule.getTextSize(ctx, selected, hover);
       this.width = this.textSize.width + this.margin.right + this.margin.left;
       this.height = this.textSize.height + this.margin.top + this.margin.bottom;

--- a/lib/network/modules/components/nodes/shapes/Circle.js
+++ b/lib/network/modules/components/nodes/shapes/Circle.js
@@ -8,8 +8,8 @@ class Circle extends CircleImageBase {
     this._setMargins(labelModule);
   }
 
-  resize(ctx, selected = this.selected, hover = this.hover, values = { size: this.options.size}) {
-    if ((this.width === undefined) || (this.labelModule.differentState(selected, hover))) {
+  resize(ctx, selected = this.selected, hover = this.hover) {
+    if (this.needsRefresh(selected, hover)) {
       this.textSize = this.labelModule.getTextSize(ctx, selected, hover);
       var diameter = Math.max(this.textSize.width + this.margin.right + this.margin.left,
                               this.textSize.height + this.margin.top + this.margin.bottom);
@@ -26,8 +26,9 @@ class Circle extends CircleImageBase {
     this.left = x - this.width / 2;
     this.top = y - this.height / 2;
 
-    this._drawRawCircle(ctx, x, y, selected, hover, values);
+    this._drawRawCircle(ctx, x, y, values);
 
+    // TODO: values overwritten by updateBoundingBox(); is this bit necessary?
     this.boundingBox.top = y - values.size;
     this.boundingBox.left = x - values.size;
     this.boundingBox.right = x + values.size;

--- a/lib/network/modules/components/nodes/shapes/CircularImage.js
+++ b/lib/network/modules/components/nodes/shapes/CircularImage.js
@@ -7,26 +7,23 @@ class CircularImage extends CircleImageBase {
     super(options, body, labelModule);
 
     this.setImages(imageObj, imageObjAlt);
-
-    this._swapToImageResizeWhenImageLoaded = true;
   }
 
   resize(ctx, selected = this.selected, hover = this.hover) {
-    if ((this.imageObj.src === undefined) ||
+    var imageAbsent = (this.imageObj.src === undefined) ||
         (this.imageObj.width === undefined) ||
-        (this.imageObj.height === undefined) ||
-        (this.labelModule.differentState(selected, hover))) {
+        (this.imageObj.height === undefined);
+
+    if (imageAbsent) {
       var diameter = this.options.size * 2;
       this.width = diameter;
       this.height = diameter;
-      this._swapToImageResizeWhenImageLoaded = true;
       this.radius = 0.5*this.width;
-    } else {
-      if (this._swapToImageResizeWhenImageLoaded) {
-        this.width = undefined;
-        this.height = undefined;
-        this._swapToImageResizeWhenImageLoaded = false;
-      }
+			return;
+    }
+
+    // At this point, an image is present, i.e. this.imageObj is valid.
+    if (this.needsRefresh(selected, hover)) {
       this._resizeImage();
     }
   }
@@ -37,15 +34,14 @@ class CircularImage extends CircleImageBase {
       this.switchImages(selected);
     }
 
-    this.resize();
+    this.selected = selected;
 
+    this.resize(ctx, selected, hover);
     this.left = x - this.width / 2;
     this.top = y - this.height / 2;
 
-    let size = Math.min(0.5*this.height, 0.5*this.width);
-
     // draw the background circle. IMPORTANT: the stroke in this method is used by the clip method below.
-    this._drawRawCircle(ctx, x, y, selected, hover, values);
+    this._drawRawCircle(ctx, x, y, values);
 
     // now we draw in the circle, we save so we can revert the clip operation after drawing.
     ctx.save();
@@ -61,11 +57,14 @@ class CircularImage extends CircleImageBase {
     this.updateBoundingBox(x,y);
   }
 
+  // TODO: compare with Circle.updateBoundingBox(), consolidate? More stuff is happening here
   updateBoundingBox(x,y) {
     this.boundingBox.top = y - this.options.size;
     this.boundingBox.left = x - this.options.size;
     this.boundingBox.right = x + this.options.size;
     this.boundingBox.bottom = y + this.options.size;
+
+    // TODO: compare with Image.updateBoundingBox(), consolidate?
     this.boundingBox.left = Math.min(this.boundingBox.left, this.labelModule.size.left);
     this.boundingBox.right = Math.max(this.boundingBox.right, this.labelModule.size.left + this.labelModule.size.width);
     this.boundingBox.bottom = Math.max(this.boundingBox.bottom, this.boundingBox.bottom + this.labelOffset);

--- a/lib/network/modules/components/nodes/shapes/Database.js
+++ b/lib/network/modules/components/nodes/shapes/Database.js
@@ -9,7 +9,7 @@ class Database extends NodeBase {
   }
 
   resize(ctx, selected, hover) {
-    if ((this.width === undefined) || (this.labelModule.differentState(selected, hover))) {
+    if (this.needsRefresh(selected, hover)) {
       this.textSize = this.labelModule.getTextSize(ctx, selected, hover);
       var size = this.textSize.width + this.margin.right + this.margin.left;
       this.width = size;

--- a/lib/network/modules/components/nodes/shapes/Diamond.js
+++ b/lib/network/modules/components/nodes/shapes/Diamond.js
@@ -7,10 +7,6 @@ class Diamond extends ShapeBase {
     super(options, body, labelModule)
   }
 
-  resize(ctx, selected = this.selected, hover = this.hover, values) {
-    this._resizeShape(selected, hover, values);
-  }
-
   draw(ctx, x, y, selected, hover, values) {
     this._drawShape(ctx, 'diamond', 4, x, y, selected, hover, values);
   }

--- a/lib/network/modules/components/nodes/shapes/Dot.js
+++ b/lib/network/modules/components/nodes/shapes/Dot.js
@@ -7,10 +7,6 @@ class Dot extends ShapeBase {
     super(options, body, labelModule)
   }
 
-  resize(ctx, selected = this.selected, hover = this.hover, values) {
-    this._resizeShape(selected, hover, values);
-  }
-
   draw(ctx, x, y, selected, hover, values) {
     this._drawShape(ctx, 'circle', 2, x, y, selected, hover, values);
   }

--- a/lib/network/modules/components/nodes/shapes/Ellipse.js
+++ b/lib/network/modules/components/nodes/shapes/Ellipse.js
@@ -8,7 +8,7 @@ class Ellipse extends NodeBase {
   }
 
   resize(ctx, selected = this.selected, hover = this.hover) {
-    if ((this.width === undefined) || (this.labelModule.differentState(selected, hover))) {
+    if (this.needsRefresh(selected, hover)) {
       var textSize = this.labelModule.getTextSize(ctx, selected, hover);
 
       this.height = textSize.height * 2;

--- a/lib/network/modules/components/nodes/shapes/Icon.js
+++ b/lib/network/modules/components/nodes/shapes/Icon.js
@@ -9,7 +9,7 @@ class Icon extends NodeBase {
   }
 
   resize(ctx, selected, hover) {
-    if ((this.width === undefined) || (this.labelModule.differentState(selected, hover))) {
+    if (this.needsRefresh(selected, hover)) {
       this.iconSize = {
         width: Number(this.options.icon.size),
         height: Number(this.options.icon.size)

--- a/lib/network/modules/components/nodes/shapes/Image.js
+++ b/lib/network/modules/components/nodes/shapes/Image.js
@@ -9,8 +9,10 @@ class Image extends CircleImageBase {
     this.setImages(imageObj, imageObjAlt);
   }
 
-  resize() {
-    this._resizeImage();
+  resize(ctx, selected = this.selected, hover = this.hover) {
+    if (this.needsRefresh(selected, hover)) {
+      this._resizeImage();
+    }
   }
 
   draw(ctx, x, y, selected, hover, values) {
@@ -21,7 +23,7 @@ class Image extends CircleImageBase {
 
     this.selected = selected;
 
-    this.resize();
+    this.resize(ctx, selected, hover);
     this.left = x - this.width / 2;
     this.top = y - this.height / 2;
 

--- a/lib/network/modules/components/nodes/shapes/Square.js
+++ b/lib/network/modules/components/nodes/shapes/Square.js
@@ -7,10 +7,6 @@ class Square extends ShapeBase {
     super(options, body, labelModule)
   }
 
-  resize() {
-    this._resizeShape();
-  }
-
   draw(ctx, x, y, selected, hover, values) {
     this._drawShape(ctx, 'square', 2, x, y, selected, hover, values);
   }

--- a/lib/network/modules/components/nodes/shapes/Star.js
+++ b/lib/network/modules/components/nodes/shapes/Star.js
@@ -7,10 +7,6 @@ class Star extends ShapeBase {
     super(options, body, labelModule)
   }
 
-  resize(ctx, selected, hover, values) {
-    this._resizeShape(selected, hover, values);
-  }
-
   draw(ctx, x, y, selected, hover, values) {
     this._drawShape(ctx, 'star', 4, x, y, selected, hover, values);
   }

--- a/lib/network/modules/components/nodes/shapes/Text.js
+++ b/lib/network/modules/components/nodes/shapes/Text.js
@@ -9,7 +9,7 @@ class Text extends NodeBase {
   }
 
   resize(ctx, selected, hover) {
-    if ((this.width === undefined) || this.labelModule.differentState(selected, hover)) {
+    if (this.needsRefresh(selected, hover)) {
       this.textSize = this.labelModule.getTextSize(ctx, selected, hover);
       this.width = this.textSize.width + this.margin.right + this.margin.left;
       this.height = this.textSize.height + this.margin.top + this.margin.bottom;

--- a/lib/network/modules/components/nodes/shapes/Triangle.js
+++ b/lib/network/modules/components/nodes/shapes/Triangle.js
@@ -7,10 +7,6 @@ class Triangle extends ShapeBase {
     super(options, body, labelModule)
   }
 
-  resize(ctx) {
-    this._resizeShape();
-  }
-
   draw(ctx, x, y, selected, hover, values) {
     this._drawShape(ctx, 'triangle', 3, x, y, selected, hover, values);
   }

--- a/lib/network/modules/components/nodes/shapes/TriangleDown.js
+++ b/lib/network/modules/components/nodes/shapes/TriangleDown.js
@@ -7,10 +7,6 @@ class TriangleDown extends ShapeBase {
     super(options, body, labelModule)
   }
 
-  resize(ctx) {
-    this._resizeShape();
-  }
-
   draw(ctx, x, y, selected, hover, values) {
     this._drawShape(ctx, 'triangleDown', 3, x, y, selected, hover, values);
   }

--- a/lib/network/modules/components/nodes/util/CircleImageBase.js
+++ b/lib/network/modules/components/nodes/util/CircleImageBase.js
@@ -1,4 +1,6 @@
-import NodeBase from '../util/NodeBase'
+import NodeBase from './NodeBase';
+import CachedImage from '../../../../CachedImage';
+
 
 /**
  * NOTE: This is a bad base class
@@ -122,37 +124,12 @@ class CircleImageBase extends NodeBase {
       // draw shadow if enabled
       this.enableShadow(ctx, values);
 
-      let factor = (this.imageObj.width / this.width) / this.body.view.scale;
-      if (factor > 2 && this.options.shapeProperties.interpolation === true) {
-        let w = this.imageObj.width;
-        let h = this.imageObj.height;
-        var can2 = document.createElement('canvas');
-        can2.width = w;
-        can2.height = w;
-        var ctx2 = can2.getContext('2d');
-
-        factor *= 0.5;
-        w *= 0.5;
-        h *= 0.5;
-        ctx2.drawImage(this.imageObj, 0, 0, w, h);
-
-        let distance = 0;
-        let iterations = 1;
-        while (factor > 2 && iterations < 4) {
-          ctx2.drawImage(can2, distance, 0, w, h, distance+w, 0, w/2, h/2);
-          distance += w;
-          factor *= 0.5;
-          w *= 0.5;
-          h *= 0.5;
-          iterations += 1;
-        }
-        ctx.drawImage(can2, distance, 0, w, h, this.left, this.top, this.width, this.height);
-      }
-      else {
-        // draw image
-        ctx.drawImage(this.imageObj, this.left, this.top, this.width, this.height);
+      let factor = 1;
+      if (this.options.shapeProperties.interpolation === true) {
+        factor = (this.imageObj.width / this.width) / this.body.view.scale;
       }
 
+      this.imageObj.drawImageAtPosition(ctx, factor, this.left, this.top, this.width, this.height);
 
       // disable shadows for other elements.
       this.disableShadow(ctx, values);

--- a/lib/network/modules/components/nodes/util/CircleImageBase.js
+++ b/lib/network/modules/components/nodes/util/CircleImageBase.js
@@ -26,12 +26,12 @@ class CircleImageBase extends NodeBase {
   }
 
   setImages(imageObj, imageObjAlt) {
-    if (imageObj) {
-      this.imageObj = imageObj;
-
-      if (imageObjAlt) {
-        this.imageObjAlt = imageObjAlt;
-      }
+    if (imageObjAlt && this.selected) {
+      this.imageObj    = imageObjAlt;
+      this.imageObjAlt = imageObj;
+    } else {
+      this.imageObj    = imageObj;
+      this.imageObjAlt = imageObjAlt;
     }
   }
 

--- a/lib/network/modules/components/nodes/util/CircleImageBase.js
+++ b/lib/network/modules/components/nodes/util/CircleImageBase.js
@@ -1,10 +1,22 @@
 import NodeBase from '../util/NodeBase'
 
+/**
+ * NOTE: This is a bad base class
+ *
+ * Child classes are:
+ *
+ *   Image       - uses *only* image methods
+ *   Circle      - uses *only* _drawRawCircle
+ *   CircleImage - uses all
+ *
+ * TODO: Refactor, move _drawRawCircle to different module, derive Circle from NodeBase
+ *       Rename this to ImageBase
+ *       Consolidate common code in Image and CircleImage to base class
+ */
 class CircleImageBase extends NodeBase {
   constructor(options, body, labelModule) {
     super(options, body, labelModule);
     this.labelOffset = 0;
-    this.imageLoaded = false;
     this.selected = false;
   }
 
@@ -38,57 +50,43 @@ class CircleImageBase extends NodeBase {
   }
 
   /**
-   * This function resizes the image by the options size when the image has not yet loaded. If the image has loaded, we
-   * force the update of the size again.
+   * Adjust the node dimensions for a loaded image.
    *
-   * @private
+   * Pre: this.imageObj is valid
    */
   _resizeImage() {
-    let force = false;
-    if (!this.imageObj.width || !this.imageObj.height) { // undefined or 0
-      this.imageLoaded = false;
-    }
-    else if (this.imageLoaded === false) {
-      this.imageLoaded = true;
-      force = true;
-    }
+    var width, height;
 
-    if (!this.width || !this.height || force === true) {  // undefined or 0
-      var width, height, ratio;
-      if (this.imageObj.width && this.imageObj.height) { // not undefined or 0
-        width = 0;
-        height = 0;
-      }
-      if (this.options.shapeProperties.useImageSize === false) {
-        if (this.imageObj.width > this.imageObj.height) {
-          ratio = this.imageObj.width / this.imageObj.height;
-          width = this.options.size * 2 * ratio || this.imageObj.width;
-          height = this.options.size * 2 || this.imageObj.height;
+    if (this.options.shapeProperties.useImageSize === false) {
+      // Use the size property
+      var ratio_width  = 1;
+      var ratio_height = 1;
+
+      // Only calculate the proper ratio if both width and height not zero
+      if (this.imageObj.width && this.imageObj.height) {
+      	if (this.imageObj.width > this.imageObj.height) {
+        	ratio_width = this.imageObj.width / this.imageObj.height;
         }
         else {
-          if (this.imageObj.width && this.imageObj.height) { // not undefined or 0
-            ratio = this.imageObj.height / this.imageObj.width;
-          }
-          else {
-            ratio = 1;
-          }
-          width = this.options.size * 2;
-          height = this.options.size * 2 * ratio;
+        	ratio_height = this.imageObj.height / this.imageObj.width;
         }
       }
-      else {
-        // when not using the size property, we use the image size
-        width = this.imageObj.width;
-        height = this.imageObj.height;
-      }
-      this.width = width;
-      this.height = height;
-      this.radius = 0.5 * this.width;
+
+      width  = this.options.size * 2 * ratio_width;
+      height = this.options.size * 2 * ratio_height;
+    }
+    else {
+      // Use the image size
+      width  = this.imageObj.width;
+      height = this.imageObj.height;
     }
 
+    this.width = width;
+    this.height = height;
+    this.radius = 0.5 * this.width;
   }
 
-  _drawRawCircle(ctx, x, y, selected, hover, values) {
+  _drawRawCircle(ctx, x, y, values) {
     var borderWidth = values.borderWidth / this.body.view.scale;
     ctx.lineWidth = Math.min(this.width, borderWidth);
 

--- a/lib/network/modules/components/nodes/util/NodeBase.js
+++ b/lib/network/modules/components/nodes/util/NodeBase.js
@@ -9,6 +9,7 @@ class NodeBase {
     this.width = undefined;
     this.radius = undefined;
     this.margin = undefined;
+    this.refreshNeeded = true;
     this.boundingBox = {top: 0, left: 0, right: 0, bottom: 0};
   }
 
@@ -88,6 +89,23 @@ class NodeBase {
         values.borderDashes = false;
       }
     }
+  }
+
+
+  /**
+   * Determine if the shape of a node needs to be recalculated.
+   *
+   * @protected
+   */
+  needsRefresh(selected, hover) {
+    if (this.refreshNeeded === true) {
+      // This is probably not the best location to reset this member.
+      // However, in the current logic, it is the most convenient one.
+      this.refreshNeeded = false;
+      return true;
+    }
+
+    return  (this.width === undefined) || (this.labelModule.differentState(selected, hover));
   }
 }
 

--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -47,7 +47,9 @@ class ShapeBase extends NodeBase {
     ctx.restore();
 
     if (this.options.label !== undefined) {
-      let yLabel = y + 0.5 * this.height + 3; // the + 3 is to offset it a bit below the node.
+      // Need to call following here in order to ensure value for `this.labelModule.size.height`
+      this.labelModule.calculateLabelSize(ctx, selected, hover, x, y, 'hanging')
+      let yLabel = y + 0.5 * this.height + 0.5 * this.labelModule.size.height;
       this.labelModule.draw(ctx, x, yLabel, selected, hover, 'hanging');
     }
 
@@ -63,7 +65,7 @@ class ShapeBase extends NodeBase {
     if (this.options.label !== undefined && this.labelModule.size.width > 0) {
       this.boundingBox.left = Math.min(this.boundingBox.left, this.labelModule.size.left);
       this.boundingBox.right = Math.max(this.boundingBox.right, this.labelModule.size.left + this.labelModule.size.width);
-      this.boundingBox.bottom = Math.max(this.boundingBox.bottom, this.boundingBox.bottom + this.labelModule.size.height + 3);
+      this.boundingBox.bottom = Math.max(this.boundingBox.bottom, this.boundingBox.bottom + this.labelModule.size.height);
     }
   }
 

--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -5,8 +5,9 @@ class ShapeBase extends NodeBase {
     super(options, body, labelModule)
   }
 
-  _resizeShape(selected = this.selected, hover = this.hover, values = { size: this.options.size }) {
+  resize(ctx, selected = this.selected, hover = this.hover, values = { size: this.options.size }) {
     if (this.needsRefresh(selected, hover)) {
+      this.labelModule.getTextSize(ctx, selected, hover);
       var size = 2 * values.size;
       this.width = size;
       this.height = size;
@@ -15,7 +16,7 @@ class ShapeBase extends NodeBase {
   }
 
   _drawShape(ctx, shape, sizeMultiplier, x, y, selected, hover, values) {
-    this._resizeShape(selected, hover, values);
+    this.resize(ctx, selected, hover, values);
 
     this.left = x - this.width / 2;
     this.top = y - this.height / 2;

--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -6,7 +6,7 @@ class ShapeBase extends NodeBase {
   }
 
   _resizeShape(selected = this.selected, hover = this.hover, values = { size: this.options.size }) {
-    if ((this.width === undefined) || (this.labelModule.differentState(selected, hover))) {
+    if (this.needsRefresh(selected, hover)) {
       var size = 2 * values.size;
       this.width = size;
       this.height = size;

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -126,124 +126,136 @@ class Label {
     }
   }
 
+
+  /**
+   * Collapse the font options for the multi-font to single objects, from
+   * the chain of option objects passed.
+   *
+   * If an option for a specific multi-font is not present, the parent
+   * option is checked for the given option.
+   *
+   * NOTE: naming of 'groupOptions' is a misnomer; the actual value passed
+   *       is the new values to set from setOptions().
+   */
   propagateFonts(options, groupOptions, defaultOptions) {
-    if (this.fontOptions.multi) {
-      let mods = [ 'bold', 'ital', 'boldital', 'mono' ];
-      for (const mod of mods) {
-        let optionsFontMod;
-        if (options.font) {
-          optionsFontMod = options.font[mod];
-        }
-        if (typeof optionsFontMod === 'string') {
-          let modOptionsArray = optionsFontMod.split(" ");
-          this.fontOptions[mod].size  = modOptionsArray[0].replace("px","");
-          this.fontOptions[mod].face  = modOptionsArray[1];
-          this.fontOptions[mod].color = modOptionsArray[2];
-          this.fontOptions[mod].vadjust = this.fontOptions.vadjust;
-          this.fontOptions[mod].mod = defaultOptions.font[mod].mod;
-        } else {
-          // We need to be crafty about loading the modded fonts. We want as
-          // much 'natural' versatility as we can get, so a simple global
-          // change propagates in an expected way, even if not stictly logical.
+    if (!this.fontOptions.multi) return;
 
-          // face: We want to capture any direct settings and overrides, but
-          //       fall back to the base font if there aren't any. We make a
-          //       special exception for mono, since we probably don't want to
-          //       sync to a the base font face.
-          //
-          //   if the mod face is in the node's options, use it
-          //   else if the mod face is in the global options, use it
-          //   else if the face is in the global options, use it
-          //   else use the base font's face.
-          if (optionsFontMod && optionsFontMod.hasOwnProperty('face')) {
-            this.fontOptions[mod].face = optionsFontMod.face;
-          } else if (groupOptions.font && groupOptions.font[mod] &&
-                     groupOptions.font[mod].hasOwnProperty('face')) {
-            this.fontOptions[mod].face = groupOptions.font[mod].face;
-          } else if (mod === 'mono') {
-            this.fontOptions[mod].face = defaultOptions.font[mod].face;
-          } else if (groupOptions.font &&
-                     groupOptions.font.hasOwnProperty('face')) {
-            this.fontOptions[mod].face = groupOptions.font.face;
-          } else {
-            this.fontOptions[mod].face = this.fontOptions.face;
-          }
+    /**
+     * Get property value from options.font[mod][property] if present.
+     * If mod not passed, use property value from options.font[property].
+     *
+     * @return value if found, null otherwise.
+     */
+    var getP = function(options, mod, property) {
+       if (!options.font) return null;
 
-          // color: this is handled just like the face.
-          if (optionsFontMod && optionsFontMod.hasOwnProperty('color')) {
-            this.fontOptions[mod].color = optionsFontMod.color;
-          } else if (groupOptions.font && groupOptions.font[mod] &&
-                     groupOptions.font[mod].hasOwnProperty('color')) {
-            this.fontOptions[mod].color = groupOptions.font[mod].color;
-          } else if (groupOptions.font &&
-                     groupOptions.font.hasOwnProperty('color')) {
-            this.fontOptions[mod].color = groupOptions.font.color;
-          } else {
-            this.fontOptions[mod].color = this.fontOptions.color;
-          }
+      var opt = options.font;
 
-          // mod: this is handled just like the face, except we never grab the
-          // base font's mod. We know they're in the defaultOptions, and unless
-          // we've been steered away from them, we use the default.
-          if (optionsFontMod && optionsFontMod.hasOwnProperty('mod')) {
-            this.fontOptions[mod].mod = optionsFontMod.mod;
-          } else if (groupOptions.font && groupOptions.font[mod] &&
-                     groupOptions.font[mod].hasOwnProperty('mod')) {
-            this.fontOptions[mod].mod = groupOptions.font[mod].mod;
-          } else if (groupOptions.font &&
-                     groupOptions.font.hasOwnProperty('mod')) {
-            this.fontOptions[mod].mod = groupOptions.font.mod;
-          } else {
-            this.fontOptions[mod].mod = defaultOptions.font[mod].mod;
-          }
-
-          // size: It's important that we size up defaults similarly if we're
-          //       using default faces unless overriden. We want to preserve the
-          //       ratios closely - but if faces have changed, all bets are off.
-          //
-          //   if the mod size is in the node's options, use it
-          //   else if the mod size is in the global options, use it
-          //   else if the mod face is the same as the default and the base face
-          //     is the same as the default, scale the mod size using the same
-          //     ratio
-          //   else if the size is in the global options, use it
-          //   else use the base font's size.
-          if (optionsFontMod && optionsFontMod.hasOwnProperty('size')) {
-            this.fontOptions[mod].size = optionsFontMod.size;
-          } else if (groupOptions.font && groupOptions.font[mod] &&
-                     groupOptions.font[mod].hasOwnProperty('size')) {
-            this.fontOptions[mod].size = groupOptions.font[mod].size;
-          } else if ((this.fontOptions[mod].face === defaultOptions.font[mod].face) &&
-                     (this.fontOptions.face === defaultOptions.font.face)) {
-            let ratio = this.fontOptions.size / Number(defaultOptions.font.size);
-            this.fontOptions[mod].size = defaultOptions.font[mod].size * ratio;
-          } else if (groupOptions.font &&
-                     groupOptions.font.hasOwnProperty('size')) {
-            this.fontOptions[mod].size = groupOptions.font.size;
-          } else {
-            this.fontOptions[mod].size = this.fontOptions.size;
-          }
-
-          // vadjust: this is handled just like the size.
-          if (optionsFontMod && optionsFontMod.hasOwnProperty('vadjust')) {
-            this.fontOptions[mod].vadjust = optionsFontMod.vadjust;
-          } else if (groupOptions.font &&
-                     groupOptions.font[mod] && groupOptions.font[mod].hasOwnProperty('vadjust')) {
-            this.fontOptions[mod].vadjust = groupOptions.font[mod].vadjust;
-          } else if ((this.fontOptions[mod].face === defaultOptions.font[mod].face) &&
-                     (this.fontOptions.face === defaultOptions.font.face)) {
-            let ratio = this.fontOptions.size / Number(defaultOptions.font.size);
-            this.fontOptions[mod].vadjust = defaultOptions.font[mod].vadjust * Math.round(ratio);
-          } else if (groupOptions.font &&
-                     groupOptions.font.hasOwnProperty('vadjust')) {
-            this.fontOptions[mod].vadjust = groupOptions.font.vadjust;
-          } else {
-            this.fontOptions[mod].vadjust = this.fontOptions.vadjust;
-          }
-        }
-        this.fontOptions[mod].size    = Number(this.fontOptions[mod].size);
-        this.fontOptions[mod].vadjust = Number(this.fontOptions[mod].vadjust);
+      if (mod) {
+        if (!opt[mod]) return null;
+        opt = opt[mod];
       }
+
+      if (opt.hasOwnProperty(property)) {
+         return opt[property];
+      }
+
+      return null;
+    };
+
+
+    let mods = [ 'bold', 'ital', 'boldital', 'mono' ];
+    for (const mod of mods) {
+      let modOptions  = this.fontOptions[mod];
+      let modDefaults = defaultOptions.font[mod];
+
+      let optionsFontMod;
+      if (options.font) {
+        optionsFontMod = options.font[mod];
+      }
+
+      if (typeof optionsFontMod === 'string') {
+        let modOptionsArray = optionsFontMod.split(" ");
+        modOptions.size  = modOptionsArray[0].replace("px","");
+        modOptions.face  = modOptionsArray[1];
+        modOptions.color = modOptionsArray[2];
+        modOptions.vadjust = this.fontOptions.vadjust;
+        modOptions.mod = modDefaults.mod;
+      } else {
+
+        // We need to be crafty about loading the modded fonts. We want as
+        // much 'natural' versatility as we can get, so a simple global
+        // change propagates in an expected way, even if not stictly logical.
+
+        // face: We want to capture any direct settings and overrides, but
+        //       fall back to the base font if there aren't any. We make a
+        //       special exception for mono, since we probably don't want to
+        //       sync to a the base font face.
+         modOptions.face =
+          getP(options     ,  mod, 'face')          || 
+          getP(groupOptions,  mod, 'face')          ||
+           (mod === 'mono'? modDefaults.face:null ) ||
+          getP(groupOptions, null, 'face')          ||
+          this.fontOptions.face
+        ;
+
+        // color: this is handled just like the face, except for specific default for 'mono'
+         modOptions.color =
+          getP(options     ,  mod, 'color') ||
+          getP(groupOptions,  mod, 'color') ||
+          getP(groupOptions, null, 'color') ||
+          this.fontOptions.color
+        ;
+
+        // mod: this is handled just like the face, except we never grab the
+        // base font's mod. We know they're in the defaultOptions, and unless
+        // we've been steered away from them, we use the default.
+        modOptions.mod =
+          getP(options     ,  mod, 'mod') ||
+          getP(groupOptions,  mod, 'mod') ||
+          getP(groupOptions, null, 'mod') ||
+          modDefaults.mod
+        ;
+
+
+        // It's important that we size up defaults similarly if we're
+        // using default faces unless overriden. We want to preserve the
+        // ratios closely - but if faces have changed, all bets are off.
+        let ratio;
+
+        // NOTE: Following condition always fails, because modDefaults
+        //       has no explicit font property. This is deliberate, see
+        //       var's 'NodesHandler.defaultOptions.font[mod]'.
+        //       However, I want to keep the original logic while refactoring;
+        //       it appears to be working fine even if ratio is never set.
+        // TODO: examine if this is a bug, fix if necessary.
+        //
+        if ((modOptions.face === modDefaults.face) &&
+            (this.fontOptions.face === defaultOptions.font.face)) {
+
+          ratio = this.fontOptions.size / Number(defaultOptions.font.size);
+        }
+
+
+        modOptions.size =
+          getP(options     ,  mod, 'size')        ||
+          getP(groupOptions,  mod, 'size')        ||
+          (ratio? modDefaults.size * ratio: null) || //   Scale the mod size using the same ratio
+          getP(groupOptions, null, 'size')        ||
+          this.fontOptions.size
+        ;
+
+        modOptions.vadjust =
+          getP(options     , mod, 'vadjust')                     ||
+          getP(groupOptions, mod, 'vadjust')                     ||
+          (ratio? modDefaults.vadjust * Math.round(ratio): null) || // Scale it using the same ratio
+          this.fontOptions.vadjust
+        ;
+
+      }
+
+      modOptions.size    = Number(modOptions.size);
+      modOptions.vadjust = Number(modOptions.vadjust);
     }
   }
 

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -717,12 +717,26 @@ class Label {
   }
 
   getFormattingValues(ctx, selected, hover, mod) {
+    var getValue = function(fontOptions, mod, option) {
+      if (mod === "normal") {
+        if (option === 'mod' ) return "";
+        return fontOptions[option];
+      }
+
+      if (fontOptions[mod][option]) {
+        return fontOptions[mod][option];
+      } else {
+        // Take from parent font option
+        return fontOptions[option];
+      }
+    };
+
     let values = {
-      color: (mod === "normal") ? this.fontOptions.color : this.fontOptions[mod].color,
-      size: (mod === "normal") ? this.fontOptions.size : this.fontOptions[mod].size,
-      face: (mod === "normal") ? this.fontOptions.face : this.fontOptions[mod].face,
-      mod: (mod === "normal") ? "" : this.fontOptions[mod].mod,
-      vadjust: (mod === "normal") ? this.fontOptions.vadjust : this.fontOptions[mod].vadjust,
+      color  : getValue(this.fontOptions, mod, 'color'  ),
+      size   : getValue(this.fontOptions, mod, 'size'   ),
+      face   : getValue(this.fontOptions, mod, 'face'   ),
+      mod    : getValue(this.fontOptions, mod, 'mod'    ),
+      vadjust: getValue(this.fontOptions, mod, 'vadjust'),
       strokeWidth: this.fontOptions.strokeWidth,
       strokeColor: this.fontOptions.strokeColor
     };

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -262,7 +262,7 @@ Core.prototype._create = function (container) {
       y: event.clientY
     }
     me.itemSet._onAddItem(event);
-
+    me.emit('drop', me.getEventProperties(event))
     return false;
   }
 

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -613,8 +613,9 @@ Core.prototype.getVisibleItems = function() {
  *                                    provided to specify duration and easing function.
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
+ * @param {Function} a callback funtion to be executed at the end of this function 
  */
-Core.prototype.fit = function(options) {
+Core.prototype.fit = function(options, callback) {
   var range = this.getDataRange();
 
   // skip range set if there is no min and max date
@@ -627,7 +628,7 @@ Core.prototype.fit = function(options) {
   var min = new Date(range.min.valueOf() - interval * 0.01);
   var max = new Date(range.max.valueOf() + interval * 0.01);
   var animation = (options && options.animation !== undefined) ? options.animation : true;
-  this.range.setRange(min, max, animation);
+  this.range.setRange(min, max, { animation: animation }, callback);
 };
 
 /**
@@ -660,17 +661,28 @@ Core.prototype.getDataRange = function() {
  *                                    provided to specify duration and easing function.
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
+ * @param {Function} a callback funtion to be executed at the end of this function 
  */
-Core.prototype.setWindow = function(start, end, options) {
+Core.prototype.setWindow = function(start, end, options, callback) {
+  if (typeof arguments[2] == "function") {
+    callback = arguments[2]
+    options = {};
+  }
   var animation;
   if (arguments.length == 1) {
     var range = arguments[0];
     animation = (range.animation !== undefined) ? range.animation : true;
-    this.range.setRange(range.start, range.end, animation);
+    this.range.setRange(range.start, range.end, { animation: animation });
+  }
+  else if (arguments.length == 2 && typeof arguments[1] == "function") {
+    var range = arguments[0];
+    callback = arguments[1];
+    animation = (range.animation !== undefined) ? range.animation : true;
+    this.range.setRange(range.start, range.end, { animation: animation }, callback);
   }
   else {
     animation = (options && options.animation !== undefined) ? options.animation : true;
-    this.range.setRange(start, end, animation);
+    this.range.setRange(start, end, { animation: animation }, callback);
   }
 };
 
@@ -684,8 +696,13 @@ Core.prototype.setWindow = function(start, end, options) {
  *                                    provided to specify duration and easing function.
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
+ * @param {Function} a callback funtion to be executed at the end of this function 
  */
-Core.prototype.moveTo = function(time, options) {
+Core.prototype.moveTo = function(time, options, callback) {
+  if (typeof arguments[1] == "function") {
+    callback = arguments[1]
+    options = {};
+  }
   var interval = this.range.end - this.range.start;
   var t = util.convert(time, 'Date').valueOf();
 
@@ -693,7 +710,7 @@ Core.prototype.moveTo = function(time, options) {
   var end = t + interval / 2;
   var animation = (options && options.animation !== undefined) ? options.animation : true;
 
-  this.range.setRange(start, end, animation);
+  this.range.setRange(start, end, { animation: animation }, callback);
 };
 
 /**
@@ -718,9 +735,14 @@ Core.prototype.getWindow = function() {
  *                                    provided to specify duration and easing function.
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
+ * @param {Function} a callback funtion to be executed at the end of this function 
  */
-Core.prototype.zoomIn = function(percentage, options) {
+Core.prototype.zoomIn = function(percentage, options, callback) {
   if (!percentage || percentage < 0 || percentage > 1) return
+  if (typeof arguments[1] == "function") {
+    callback = arguments[1]
+    options = {};
+  }
   var range = this.getWindow();
   var start = range.start.valueOf();
   var end = range.end.valueOf();
@@ -730,7 +752,7 @@ Core.prototype.zoomIn = function(percentage, options) {
   var newStart = start + distance;
   var newEnd = end - distance;
 
-  this.setWindow(newStart, newEnd, options);
+  this.setWindow(newStart, newEnd, options, callback);
 };
 
 /**
@@ -743,9 +765,14 @@ Core.prototype.zoomIn = function(percentage, options) {
  *                                    provided to specify duration and easing function.
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
+ * @param {Function} a callback funtion to be executed at the end of this function 
  */
-Core.prototype.zoomOut = function(percentage, options) {
+Core.prototype.zoomOut = function(percentage, options, callback) {
   if (!percentage || percentage < 0 || percentage > 1) return
+  if (typeof arguments[1] == "function") {
+    callback = arguments[1]
+    options = {};
+  }
   var range = this.getWindow();
   var start = range.start.valueOf();
   var end = range.end.valueOf();
@@ -753,7 +780,7 @@ Core.prototype.zoomOut = function(percentage, options) {
   var newStart = start - interval * percentage / 2;
   var newEnd = end + interval * percentage / 2;
 
-  this.setWindow(newStart, newEnd, options);
+  this.setWindow(newStart, newEnd, options, callback);
 };
 
 /**

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -138,7 +138,10 @@ Range.prototype.startRolling = function() {
     var end = t + interval / 2;
     var animation = (me.options && me.options.animation !== undefined) ? me.options.animation : true;
 
-    me.setRange(start, end, false);
+    var options = {
+      animation: false
+    };
+    me.setRange(start, end, options);
 
     // determine interval to refresh
     var scale = me.conversion(me.body.domProps.center.width).scale;
@@ -169,29 +172,36 @@ Range.prototype.stopRolling = function() {
  * Set a new start and end range
  * @param {Date | Number | String} [start]
  * @param {Date | Number | String} [end]
- * @param {boolean | {duration: number, easingFunction: string}} [animation=false]
- *                                    If true (default), the range is animated
+ * @param {Object} options      Available options:
+ *                              {Boolean | {duration: number, easingFunction: string}} [animation=false]
+ *                                    If true, the range is animated
  *                                    smoothly to the new window. An object can be
  *                                    provided to specify duration and easing function.
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
- * @param {Boolean} [byUser=false]
+ *                              {Boolean} [byUser=false]
+ *                              {Event}  event  Mouse event
+ *                              {Function} a callback funtion to be executed at the end of this function 
  *
  */
-Range.prototype.setRange = function(start, end, animation, byUser, event) {
-  if (byUser !== true) {
-    byUser = false;
+
+Range.prototype.setRange = function(start, end, options, callback) {
+  if (!options) {
+    options = {};
+  }
+  if (options.byUser !== true) {
+    options.byUser = false;
   }
   var finalStart = start != undefined ? util.convert(start, 'Date').valueOf() : null;
   var finalEnd   = end != undefined   ? util.convert(end, 'Date').valueOf()   : null;
   this._cancelAnimation();
 
-  if (animation) { // true or an Object
+  if (options.animation) { // true or an Object
     var me = this;
     var initStart = this.start;
     var initEnd = this.end;
-    var duration = (typeof animation === 'object' && 'duration' in animation) ? animation.duration : 500;
-    var easingName = (typeof animation === 'object' && 'easingFunction' in animation) ? animation.easingFunction : 'easeInOutQuad';
+    var duration = (typeof options.animation === 'object' && 'duration' in options.animation) ? options.animation.duration : 500;
+    var easingName = (typeof options.animation === 'object' && 'easingFunction' in options.animation) ? options.animation.easingFunction : 'easeInOutQuad';
     var easingFunction = util.easingFunctions[easingName];
     if (!easingFunction) {
       throw new Error('Unknown easing function ' + JSON.stringify(easingName) + '. ' +
@@ -217,8 +227,8 @@ Range.prototype.setRange = function(start, end, animation, byUser, event) {
         var params = {
           start: new Date(me.start), 
           end: new Date(me.end), 
-          byUser:byUser,
-          event: event
+          byUser: options.byUser,
+          event: options.event
         }
 
         if (changed) {
@@ -228,6 +238,7 @@ Range.prototype.setRange = function(start, end, animation, byUser, event) {
         if (done) {
           if (anyChanged) {
             me.body.emitter.emit('rangechanged', params);
+            if (callback) { return callback() }
           }
         }
         else {
@@ -247,11 +258,12 @@ Range.prototype.setRange = function(start, end, animation, byUser, event) {
       var params = {
         start: new Date(this.start), 
         end: new Date(this.end), 
-        byUser:byUser, 
-        event: event
+        byUser: options.byUser, 
+        event: options.event
       };
       this.body.emitter.emit('rangechange', params);
       this.body.emitter.emit('rangechanged', params);
+      if (callback) { return callback() }
     }
   }
 };
@@ -600,7 +612,12 @@ Range.prototype._onMouseWheel = function(event) {
       var newStart = this.start - diff;
       var newEnd = this.end - diff;
 
-      this.setRange(newStart, newEnd, false, true, event);
+      var options = {
+        animation: false,
+        byUser: true,
+        event: event
+      }
+      this.setRange(newStart, newEnd, options);
     }
     return;
   }
@@ -698,7 +715,12 @@ Range.prototype._onPinch = function (event) {
     newEnd = safeEnd;
   }
 
-  this.setRange(newStart, newEnd, false, true, event);
+  var options = {
+    animation: false,
+    byUser: true,
+    event: event
+  }
+  this.setRange(newStart, newEnd, options);
 
   this.startToFront = false; // revert to default
   this.endToFront = true; // revert to default
@@ -802,7 +824,12 @@ Range.prototype.zoom = function(scale, center, delta, event) {
     newEnd = safeEnd;
   }
 
-  this.setRange(newStart, newEnd, false, true, event);
+  var options = {
+    animation: false,
+    byUser: true,
+    event: event
+  }
+  this.setRange(newStart, newEnd, options);
 
   this.startToFront = false; // revert to default
   this.endToFront = true; // revert to default
@@ -843,7 +870,12 @@ Range.prototype.moveTo = function(moveTo) {
   var newStart = this.start - diff;
   var newEnd = this.end - diff;
 
-  this.setRange(newStart, newEnd, false, true, null);
+  var options = {
+    animation: false,
+    byUser: true,
+    event: null
+  }
+  this.setRange(newStart, newEnd, options);
 };
 
 module.exports = Range;

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -45,7 +45,11 @@ function Range(body, options) {
     min: null,
     max: null,
     zoomMin: 10,                                // milliseconds
-    zoomMax: 1000 * 60 * 60 * 24 * 365 * 10000  // milliseconds
+    zoomMax: 1000 * 60 * 60 * 24 * 365 * 10000,  // milliseconds
+    rollingMode: {
+      follow: false,
+      offset: 0.5
+    }
   };
   this.options = util.extend({}, this.defaultOptions);
   this.props = {
@@ -94,11 +98,11 @@ Range.prototype.setOptions = function (options) {
     // copy the options that we know
     var fields = [
       'animation', 'direction', 'min', 'max', 'zoomMin', 'zoomMax', 'moveable', 'zoomable',
-      'moment', 'activate', 'hiddenDates', 'zoomKey', 'rtl', 'showCurrentTime', 'rollMode', 'horizontalScroll'
+      'moment', 'activate', 'hiddenDates', 'zoomKey', 'rtl', 'showCurrentTime', 'rollingMode', 'horizontalScroll'
     ];
     util.selectiveExtend(fields, this.options, options);
 
-    if (options.rollingMode) {
+    if (options.rollingMode && options.rollingMode.follow) {
       this.startRolling();
     }
     if ('start' in options || 'end' in options) {
@@ -134,8 +138,8 @@ Range.prototype.startRolling = function() {
     var interval = me.end - me.start;
     var t = util.convert(new Date(), 'Date').valueOf();
 
-    var start = t - interval / 2;
-    var end = t + interval / 2;
+    var start = t - interval * (me.options.rollingMode.offset);
+    var end = t + interval * (1 - me.options.rollingMode.offset);
     var animation = (me.options && me.options.animation !== undefined) ? me.options.animation : true;
 
     var options = {
@@ -647,7 +651,7 @@ Range.prototype._onMouseWheel = function(event) {
     // calculate center, the date to zoom around
     var pointerDate
     if (this.rolling) {
-      pointerDate = (this.start + this.end) / 2;
+      pointerDate = this.start + ((this.end - this.start) * this.options.rollingMode.offset);
     } else {
       var pointer = this.getPointer({x: event.clientX, y: event.clientY}, this.body.dom.center);
       pointerDate = this._pointerToDate(pointer);

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -196,12 +196,12 @@ Range.prototype.setRange = function(start, end, options, callback) {
   if (options.byUser !== true) {
     options.byUser = false;
   }
+  var me = this;
   var finalStart = start != undefined ? util.convert(start, 'Date').valueOf() : null;
   var finalEnd   = end != undefined   ? util.convert(end, 'Date').valueOf()   : null;
   this._cancelAnimation();
 
   if (options.animation) { // true or an Object
-    var me = this;
     var initStart = this.start;
     var initEnd = this.end;
     var duration = (typeof options.animation === 'object' && 'duration' in options.animation) ? options.animation.duration : 500;
@@ -265,8 +265,12 @@ Range.prototype.setRange = function(start, end, options, callback) {
         byUser: options.byUser, 
         event: options.event
       };
+
       this.body.emitter.emit('rangechange', params);
-      this.body.emitter.emit('rangechanged', params);
+      clearTimeout( me.timeoutID );
+      me.timeoutID = setTimeout( function () {
+        me.body.emitter.emit('rangechanged', params);
+      }, 200 );
       if (callback) { return callback() }
     }
   }

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -560,6 +560,7 @@ TimeStep.prototype.getClassName = function() {
   var m = this.moment(this.current);
   var current = m.locale ? m.locale('en') : m.lang('en'); // old versions of moment have .lang() function
   var step = this.step;
+  var classNames = [];
 
   function even(value) {
     return (value / step % 2 == 0) ? ' vis-even' : ' vis-odd';
@@ -592,51 +593,49 @@ TimeStep.prototype.getClassName = function() {
 
   switch (this.scale) {
     case 'millisecond':
-      return today(current) +
-        even(current.milliseconds()).trim();
-
+      classNames.push(today(current));
+      classNames.push(even(current.milliseconds()));
+      break;
     case 'second':
-      return today(current) +
-        even(current.seconds()).trim();
-
+      classNames.push(today(current));
+      classNames.push(even(current.seconds()));
+      break;
     case 'minute':
-      return today(current) +
-        even(current.minutes()).trim();
-
+      classNames.push(today(current));
+      classNames.push(even(current.minutes()));
+      break;
     case 'hour':
-      return 'vis-h' + current.hours() + 
-        (this.step == 4 ? '-h' + (current.hours() + 4) : '') +
-        today(current) +
-        even(current.hours());
-
+      classNames.push('vis-h' + current.hours() + this.step == 4 ? '-h' + (current.hours() + 4) : '');
+      classNames.push(today(current));
+      classNames.push(even(current.hours()));
+      break;
     case 'weekday':
-      return 'vis-' + current.format('dddd').toLowerCase() +
-        today(current) +
-        currentWeek(current) +
-        even(current.date());
-
+      classNames.push('vis-' + current.format('dddd').toLowerCase());
+      classNames.push(today(current));
+      classNames.push(currentWeek(current));
+      classNames.push(even(current.date()));
+      break;
     case 'day':
-      return 'vis-day' + current.date() +
-        ' vis-' + current.format('MMMM').toLowerCase() +
-        today(current) +
-        currentMonth(current) +
-        (this.step <= 2 ? today(current) : '') +
-        (this.step <= 2 ? ' vis-' + current.format('dddd').toLowerCase() : '' + even(current.date() - 1));
-
+      classNames.push('vis-day' + current.date());
+      classNames.push('vis-' + current.format('MMMM').toLowerCase());
+      classNames.push(today(current));
+      classNames.push(currentMonth(current));
+      classNames.push(this.step <= 2 ? today(current) : '');
+      classNames.push(this.step <= 2 ? 'vis-' + current.format('dddd').toLowerCase() : '');
+      classNames.push(even(current.date() - 1));
+      break;
     case 'month':
-      return 'vis-' + current.format('MMMM').toLowerCase() +
-        currentMonth(current) +
-        even(current.month());
-
+      classNames.push('vis-' + current.format('MMMM').toLowerCase());
+      classNames.push(currentMonth(current));
+      classNames.push(even(current.month()));
+      break;
     case 'year':
-      var year = current.year();
-      return 'vis-year' + year +
-        currentYear(current) +
-        even(year);
-
-    default:
-      return '';
+      classNames.push('vis-year' + current.year());
+      classNames.push(currentYear(current));
+      classNames.push(even(current.year()));
+      break;
   }
+  return classNames.filter(String).join(" ");
 };
 
 module.exports = TimeStep;

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -69,6 +69,7 @@ TimeStep.FORMAT = {
     hour:       'HH:mm',
     weekday:    'ddd D',
     day:        'D',
+    week:       'w',
     month:      'MMM',
     year:       'YYYY'
   },
@@ -79,6 +80,7 @@ TimeStep.FORMAT = {
     hour:       'ddd D MMMM',
     weekday:    'MMMM YYYY',
     day:        'MMMM YYYY',
+    week:       'MMMM YYYY',
     month:      'YYYY',
     year:       ''
   }
@@ -101,7 +103,7 @@ TimeStep.prototype.setMoment = function (moment) {
 /**
  * Set custom formatting for the minor an major labels of the TimeStep.
  * Both `minorLabels` and `majorLabels` are an Object with properties:
- * 'millisecond', 'second', 'minute', 'hour', 'weekday', 'day', 'month', 'year'.
+ * 'millisecond', 'second', 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'.
  * @param {{minorLabels: Object, majorLabels: Object}} format
  */
 TimeStep.prototype.setFormat = function (format) {
@@ -153,6 +155,7 @@ TimeStep.prototype.roundToMinor = function() {
       this.current.year(this.step * Math.floor(this.current.year() / this.step));
       this.current.month(0);
     case 'month':        this.current.date(1);
+    case 'week':         this.current.weekday(0);
     case 'day':          // intentional fall through
     case 'weekday':      this.current.hours(0);
     case 'hour':         this.current.minutes(0);
@@ -170,6 +173,7 @@ TimeStep.prototype.roundToMinor = function() {
       case 'hour':         this.current.subtract(this.current.hours() % this.step, 'hours'); break;
       case 'weekday':      // intentional fall through
       case 'day':          this.current.subtract((this.current.date() - 1) % this.step, 'day'); break;
+      case 'week':         this.current.subtract(this.current.week() % this.step, 'week'); break;
       case 'month':        this.current.subtract(this.current.month() % this.step, 'month');  break;
       case 'year':         this.current.subtract(this.current.year() % this.step, 'year'); break;
       default: break;
@@ -210,6 +214,21 @@ TimeStep.prototype.next = function() {
       break;
     case 'weekday':      // intentional fall through
     case 'day':          this.current.add(this.step, 'day'); break;
+    case 'week':
+      if (this.current.weekday() !== 0){ // we had a month break not correlating with a week's start before
+        this.current.weekday(0); // switch back to week cycles
+        this.current.add(this.step, 'week');
+      } else { // first day of the week
+        var nextWeek = this.current.clone();
+        nextWeek.add(1, 'week');
+        if(nextWeek.isSame(this.current, 'month')){ // is the first day of the next week in the same month?
+          this.current.add(this.step, 'week'); // the default case
+        } else { // inject a step at each first day of the month
+          this.current.add(this.step, 'week');
+          this.current.date(1);
+        }
+      }
+      break;
     case 'month':        this.current.add(this.step, 'month'); break;
     case 'year':         this.current.add(this.step, 'year'); break;
     default: break;
@@ -224,6 +243,7 @@ TimeStep.prototype.next = function() {
       case 'hour':         if(this.current.hours() > 0 && this.current.hours() < this.step) this.current.hours(0);  break;
       case 'weekday':      // intentional fall through
       case 'day':          if(this.current.date() < this.step+1) this.current.date(1); break;
+      case 'week':         if(this.current.week() < this.step) this.current.week(1); break; // week numbering starts at 1, not 0
       case 'month':        if(this.current.month() < this.step) this.current.month(0);  break;
       case 'year':         break; // nothing to do for year
       default:             break;
@@ -260,7 +280,7 @@ TimeStep.prototype.getCurrent = function() {
  * @param {{scale: string, step: number}} params
  *                               An object containing two properties:
  *                               - A string 'scale'. Choose from 'millisecond', 'second',
- *                                 'minute', 'hour', 'weekday', 'day', 'month', 'year'.
+ *                                 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'.
  *                               - A number 'step'. A step size, by default 1.
  *                                 Choose for example 1, 2, 5, or 10.
  */
@@ -338,7 +358,7 @@ TimeStep.prototype.setMinimumStep = function(minimumStep) {
  * Static function
  * @param {Date} date    the date to be snapped.
  * @param {string} scale Current scale, can be 'millisecond', 'second',
- *                       'minute', 'hour', 'weekday, 'day', 'month', 'year'.
+ *                       'minute', 'hour', 'weekday, 'day', 'week', 'month', 'year'.
  * @param {number} step  Current step (1, 2, 4, 5, ...
  * @return {Date} snappedDate
  */
@@ -369,6 +389,20 @@ TimeStep.snap = function(date, scale, step) {
     clone.minutes(0);
     clone.seconds(0);
     clone.milliseconds(0);
+  }
+  else if (scale == 'week') {
+      if (clone.weekday() > 2) { // doing it the momentjs locale aware way
+          clone.weekday(0);
+          clone.add(1, 'week');
+      }
+      else {
+          clone.weekday(0);
+      }
+
+      clone.hours(0);
+      clone.minutes(0);
+      clone.seconds(0);
+      clone.milliseconds(0);
   }
   else if (scale == 'day') {
     //noinspection FallthroughInSwitchStatementJS
@@ -452,6 +486,7 @@ TimeStep.prototype.isMajor = function() {
     switch (this.scale) {
       case 'year':
       case 'month':
+      case 'week':
       case 'weekday':
       case 'day':
       case 'hour':
@@ -465,6 +500,7 @@ TimeStep.prototype.isMajor = function() {
   }
   else if (this.switchedMonth == true) {
     switch (this.scale) {
+      case 'week':
       case 'weekday':
       case 'day':
       case 'hour':
@@ -501,6 +537,8 @@ TimeStep.prototype.isMajor = function() {
     case 'weekday': // intentional fall through
     case 'day':
       return (date.date() == 1);
+    case 'week':
+      return (date.date() == 1);
     case 'month':
       return (date.month() == 0);
     case 'year':
@@ -530,7 +568,15 @@ TimeStep.prototype.getLabelMinor = function(date) {
   }
 
   var format = this.format.minorLabels[this.scale];
-  return (format && format.length > 0) ? this.moment(date).format(format) : '';
+  // noinspection FallThroughInSwitchStatementJS
+  switch (this.scale) {
+    case 'week':
+      if(this.isMajor() && date.weekday() !== 0){
+          return "";
+      }
+    default:
+      return (format && format.length > 0) ? this.moment(date).format(format) : '';
+  }
 };
 
 /**
@@ -623,6 +669,11 @@ TimeStep.prototype.getClassName = function() {
       classNames.push(this.step <= 2 ? today(current) : '');
       classNames.push(this.step <= 2 ? 'vis-' + current.format('dddd').toLowerCase() : '');
       classNames.push(even(current.date() - 1));
+      break;
+    case 'week':
+      classNames.push('vis-week' + current.format('w'));
+      classNames.push(currentWeek(current));
+      classNames.push(even(current.week()));
       break;
     case 'month':
       classNames.push('vis-' + current.format('MMMM').toLowerCase());

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -382,7 +382,7 @@ Timeline.prototype.focus = function(id, options) {
     var interval = Math.max((this.range.end - this.range.start), (end - start) * 1.1);
 
     var animation = (options && options.animation !== undefined) ? options.animation : true;
-    this.range.setRange(middle - interval / 2, middle + interval / 2, animation);
+    this.range.setRange(middle - interval / 2, middle + interval / 2, { animation: animation });
   }
 };
 
@@ -409,7 +409,7 @@ Timeline.prototype.fit = function (options) {
   else {
     // exactly fit the items (plus a small margin)
     range = this.getItemRange();
-    this.range.setRange(range.min, range.max, animation);
+    this.range.setRange(range.min, range.max, { animation: animation });
   }
 };
 

--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -217,7 +217,7 @@ CustomTime.prototype._onDrag = function (event) {
   this.body.emitter.emit('timechange', {
     id: this.options.id,
     time: new Date(this.customTime.valueOf()),
-    event: util.elementsCensor(event)
+    event: event
   });
 
   event.stopPropagation();
@@ -235,7 +235,7 @@ CustomTime.prototype._onDragEnd = function (event) {
   this.body.emitter.emit('timechanged', {
     id: this.options.id,
     time: new Date(this.customTime.valueOf()),
-    event: util.elementsCensor(event)
+    event: event
   });
 
   event.stopPropagation();

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -2233,8 +2233,16 @@ ItemSet.prototype.itemFromRelatedTarget = function(event) {
  */
 ItemSet.prototype.groupFromTarget = function(event) {
   var clientY = event.center ? event.center.y : event.clientY;
-  for (var i = 0; i < this.groupIds.length; i++) {
-    var groupId = this.groupIds[i];
+  var groupIds = this.groupIds;
+  
+  if (groupIds.length <= 0) {
+    groupIds = this.groupsData.getIds({
+      order: this.options.groupOrder
+    });
+  }
+  
+  for (var i = 0; i < groupIds.length; i++) {
+    var groupId = groupIds[i];
     var group = this.groups[groupId];
     var foreground = group.dom.foreground;
     var top = util.getAbsoluteTop(foreground);

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -2044,6 +2044,10 @@ ItemSet.prototype._onAddItem = function (event) {
         newItemData.end = snap ? snap(end, scale, step) : end;
       }
     } else {
+      newItemData = {
+        start: snap ? snap(start, scale, step) : start,
+        content: 'new item'
+      };
       newItemData[this.itemsData._fieldId] = util.randomUUID();
 
       // when default type is a range, add a default end date to the new item

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1196,14 +1196,6 @@ ItemSet.prototype._addItem = function(item) {
  * @private
  */
 ItemSet.prototype._updateItem = function(item, itemData) {
-  var oldGroupId = item.data.group;
-  var oldSubGroupId = item.data.subgroup;
-
-  if (oldGroupId != itemData.group) {
-    var oldGroup = this.groups[oldGroupId];
-    if (oldGroup) oldGroup.remove(item);
-  }
-
   // update the items data (will redraw the item when displayed)
   item.setData(itemData);
 
@@ -1213,14 +1205,6 @@ ItemSet.prototype._updateItem = function(item, itemData) {
     item.groupShowing = false;
   } else if (group && group.data && group.data.showNested) {
     item.groupShowing = true;
-  }
-  // update group
-  if (group) {
-    if (oldGroupId != item.data.group) {
-      group.add(item);
-    } else if (oldSubGroupId != item.data.subgroup) {
-      group.changeSubgroup(item, oldSubGroupId);
-    }
   }
 };
 
@@ -1587,10 +1571,11 @@ ItemSet.prototype._moveToGroup = function(item, groupId) {
     var oldGroup = item.parent;
     oldGroup.remove(item);
     oldGroup.order();
+    
+    item.data.group = group.groupId;
+    
     group.add(item);
     group.order();
-
-    item.data.group = group.groupId;
   }
 };
 

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -546,7 +546,7 @@ ItemSet.prototype.getVisibleItems = function() {
   for (var groupId in this.groups) {
     if (this.groups.hasOwnProperty(groupId)) {
       var group = this.groups[groupId];
-      var rawVisibleItems = group.visibleItems;
+      var rawVisibleItems = group.isVisible ? group.visibleItems : [];
 
       // filter the "raw" set with visibleItems into a set which is really
       // visible by pixels

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -2031,25 +2031,17 @@ ItemSet.prototype._onAddItem = function (event) {
     var scale = this.body.util.getScale();
     var step = this.body.util.getStep();
 
-    var newItemData = {
-      start: snap ? snap(start, scale, step) : start,
-      content: 'new item'
-    };
-
+    var newItemData;
     if (event.type == 'drop') {
-      var itemData = JSON.parse(event.dataTransfer.getData("text"))
-      newItemData.content = itemData.content; // content is required 
-      newItemData.type = itemData.type || 'box';
-      newItemData[this.itemsData._fieldId] = itemData.id || util.randomUUID();
+      newItemData = JSON.parse(event.dataTransfer.getData("text"))
+      newItemData.content = newItemData.content ? newItemData.content : 'new item'
+      newItemData.start = newItemData.start ? newItemData.start : (snap ? snap(start, scale, step) : start) 
+      newItemData.type = newItemData.type || 'box';
+      newItemData[this.itemsData._fieldId] = newItemData.id || util.randomUUID();
 
-      if (itemData.type == 'range' || (itemData.end && itemData.start)) {
-        if (!itemData.end) {
-          var end = this.body.util.toTime(x + this.props.width / 5);
-          newItemData.end = snap ? snap(end, scale, step) : end;
-        } else {
-          newItemData.end = itemData.end;
-          newItemData.start = itemData.start;
-        }
+      if (newItemData.type == 'range' && !newItemData.end) {
+        var end = this.body.util.toTime(x + this.props.width / 5);
+        newItemData.end = snap ? snap(end, scale, step) : end;
       }
     } else {
       newItemData[this.itemsData._fieldId] = util.randomUUID();

--- a/lib/timeline/component/TimeAxis.js
+++ b/lib/timeline/component/TimeAxis.js
@@ -227,6 +227,7 @@ TimeAxis.prototype._repaintLabels = function () {
   var x;
   var xNext;
   var isMajor, nextIsMajor;
+  var showMinorGrid;
   var width = 0, prevWidth;
   var line;
   var labelMinor;
@@ -255,7 +256,10 @@ TimeAxis.prototype._repaintLabels = function () {
 
     prevWidth = width;
     width = xNext - x;
-    var showMinorGrid = (width >= prevWidth * 0.4); // prevent displaying of the 31th of the month on a scale of 5 days
+    switch (step.scale) {
+      case 'week':         showMinorGrid = true; break;
+      default:             showMinorGrid = (width >= prevWidth * 0.4); break; // prevent displaying of the 31th of the month on a scale of 5 days
+    }
 
     if (this.options.showMinorLabels && showMinorGrid) {
       var label = this._repaintMinorText(x, labelMinor, orientation, className);

--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -61,8 +61,13 @@ Item.prototype.unselect = function() {
  */
 Item.prototype.setData = function(data) {
   var groupChanged = data.group != undefined && this.data.group != data.group;
-  if (groupChanged) {
+  if (groupChanged && this.parent != null) {
     this.parent.itemSet._moveToGroup(this, data.group);
+  }
+  
+  var subGroupChanged = data.subgroup != undefined && this.data.subgroup != data.subgroup;
+  if (subGroupChanged && this.parent != null) {
+    this.parent.changeSubgroup(this, this.data.subgroup, data.subgroup);
   }
 
   this.data = data;

--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -146,15 +146,25 @@ Item.prototype.repositionY = function() {
 Item.prototype._repaintDragCenter = function () {
   if (this.selected && this.options.editable.updateTime && !this.dom.dragCenter) {
     var me = this;
-
     // create and show drag area
     var dragCenter = document.createElement('div');
     dragCenter.className = 'vis-drag-center';
     dragCenter.dragCenterItem = this;
+    var hammer = new Hammer(dragCenter);
 
-    new Hammer(dragCenter).on('doubletap', function (event) {
+    hammer.on('tap', function (event) {
+      me.parent.itemSet.body.emitter.emit('click',  {
+        event: event,
+        item: me.id
+      });
+    });
+    hammer.on('doubletap', function (event) {
       event.stopPropagation();
       me.parent.itemSet._onUpdateItem(me);
+      me.parent.itemSet.body.emitter.emit('doubleClick', {
+        event: event,
+        item: me.id 
+      });
     });
 
     if (this.dom.box) {
@@ -370,7 +380,6 @@ Item.prototype._updateContents = function (element) {
           throw new Error('Property "content" missing in item ' + this.id);
         }
       }
-
       this.content = content;
     }
   }

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -26,7 +26,11 @@ let allOptions = {
   //globals :
   align: {string},
   rtl: { 'boolean': bool, 'undefined': 'undefined'},
-  rollingMode: { 'boolean': bool, 'undefined': 'undefined'},
+  rollingMode: {
+    follow: { 'boolean': bool },
+    offset: {number,'undefined': 'undefined'},
+    __type__: {object}
+  },
   verticalScroll: { 'boolean': bool, 'undefined': 'undefined'},
   horizontalScroll: { 'boolean': bool, 'undefined': 'undefined'},
   autoResize: { 'boolean': bool},

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -54,6 +54,7 @@ let allOptions = {
       hour: {string,'undefined': 'undefined'},
       weekday: {string,'undefined': 'undefined'},
       day: {string,'undefined': 'undefined'},
+      week: {string,'undefined': 'undefined'},
       month: {string,'undefined': 'undefined'},
       year: {string,'undefined': 'undefined'},
       __type__: {object, 'function': 'function'}
@@ -65,6 +66,7 @@ let allOptions = {
       hour: {string,'undefined': 'undefined'},
       weekday: {string,'undefined': 'undefined'},
       day: {string,'undefined': 'undefined'},
+      week: {string,'undefined': 'undefined'},
       month: {string,'undefined': 'undefined'},
       year: {string,'undefined': 'undefined'},
       __type__: {object, 'function': 'function'}
@@ -181,6 +183,7 @@ let configureOptions = {
         hour:       'HH:mm',
         weekday:    'ddd D',
         day:        'D',
+        week:       'w',
         month:      'MMM',
         year:       'YYYY'
       },
@@ -191,6 +194,7 @@ let configureOptions = {
         hour:       'ddd D MMMM',
         weekday:    'MMMM YYYY',
         day:        'MMMM YYYY',
+        week:       'MMMM YYYY',
         month:      'YYYY',
         year:       ''
       }
@@ -236,7 +240,7 @@ let configureOptions = {
     start: '',
     //template: {'function': 'function'},
     //timeAxis: {
-    //  scale: ['millisecond', 'second', 'minute', 'hour', 'weekday', 'day', 'month', 'year'],
+    //  scale: ['millisecond', 'second', 'minute', 'hour', 'weekday', 'day', 'week', 'month', 'year'],
     //  step: [1, 1, 10, 1]
     //},
     tooltip: {

--- a/lib/util.js
+++ b/lib/util.js
@@ -188,7 +188,7 @@ exports.selectiveExtend = function (props, a, b) {
 
     for (var p = 0; p < props.length; p++) {
       var prop = props[p];
-      if (other.hasOwnProperty(prop)) {
+      if (other && other.hasOwnProperty(prop)) {
         a[prop] = other[prop];
       }
     }

--- a/misc/labels.md
+++ b/misc/labels.md
@@ -1,0 +1,106 @@
+# How we use Github labels
+
+*Because only team members can add and change labels this document is mainly for maintainers, but also for users to understand how we use labels.*
+
+*It is important to also label old and closed issues uniformly in order to export them later e.g. if the project gets separated into multiple components.*
+
+
+## Issue Types
+If an issue was created it MUST always be labeled as one of the following issue types:
+
+### `Question`
+The author has a general or very specific question.<br>
+If it is a general question on how to use vis.js the issues should be closed immediately with a reference to [stackoverflow](https://stackoverflow.com/questions/tagged/vis.js).<br>
+Specific question or hard problems should stay open.<br>
+Questions should be closed within 3 months.
+
+### `Problem`
+This issues points to a potential bug that needs to be confirmed.<br>
+If the problem most likely originates from the user's code it should be labeled as [`Question`](#question) instead.<br>
+The support team should try to reproduce this issue and then close it or mark it as [`Confirmed Bug`](#confirmed-bug).
+
+### `Confirmed Bug`
+This issue was reported as [`Problem`](#problem), but the issue is reproducible and is now a confirmed bug.
+
+### `Feature-Request`
+This issue proposes a new feature or a change of existing functionality. Issues that are unlikely to get implemented should be closed.
+
+### `wontfix`
+This issues is e.g. for discussing a topic or for project management purposes, and is not handled in the usual issue process.
+
+
+## Graph type
+All issues MUST have one of the following type labels. These labels are usually mutually exclusive:
+
+### `DataSet`
+Concerns the DataSet implementation.
+
+### `Graph2D`
+Concerns the 2D-Graph implementation.
+
+### `Graph3D`
+Concerns the 3D-Graph implementation.
+
+### `Network`
+Concerns the Network-Graph implementation.
+
+### `source/non-public API`
+This issues is just for discussion or is concerning the build-process, the code-style or something similar.
+
+### `Timeline`
+Concerns the Timeline-Graph implementation.
+
+
+## Additional labels
+
+### `Docs`
+This issue concerns only the documentation.<br>
+If an existing issue is documented wrongly this is a [`Problem`](#problem) in the component and not a [`docs`](#docs) issue.<br>
+This can be used for typos or requests for an improvement of the docs.
+
+### `Duplicate`
+This issues is a duplicate of an existing issue. The duplicate should be closed. In addition, add a reference to the original issue with a comment.
+
+### `Fixed awaiting release`
+This Issue is fixed or implemented in the "develop" branch but is not released yet and therefore should be still open.<br>
+This issues should be closed after the changes are merged into the "master" branch.
+
+### `For everyone!`
+This is a good issue to start working on if you are new to vis.js and want to help.<br>
+This label is also used for labels that may concern a lot of vis.js users.
+
+### `IE / Edge`
+These issues concern a problem with the Microsoft Internet Explorer or Edge browser.<br>
+
+### `invalid`
+This is not a valid issue.<br>
+Someone just created an empty issue, picked the wrong project or something similar.<br>
+This can also be used for pull-request to a non-develop branch or something similar.<br>
+This issue or pull request should be closed immediately.
+
+### `Issue Inactive`
+Issues marked as [`Question`](#question) or [`Problem`](#problem) get marked as inactive when the author is not responsive or the topic is old.<br>
+If an issue is marked as inactive for about 2 weeks it can be closed without any hesitation.
+
+### `PRIORITY`
+In general this is used for major bugs. There should only exist a few issues marked as PRIORITY at the same time.<br>
+These issues need to be handled before all others.
+
+### `Requires breaking change`
+A lot of code needs to be changed to implement this. This is maybe something for a major release or something for someone with a lot of time on their hands :-)
+
+### `waiting for answer/improvement`
+This is mostly used for pull requests were a reviewer requested some changes and the owner has not responded yet.
+
+### `Work In Progress`
+Someone is working on this issue or a pull request already exists and needs to be reviewed.<br>
+
+## Example Workflows
+
+### Bug
+
+[`Problem`](#Problem) ⟶ [`Confirmed Bug`](#confirmed-bug) ⟶ [`Work In Progress`](#work-in-progress) ⟶ [`Fixed awaiting release`](#fixed-awaiting-release)
+
+### Feature-Request
+
+[`Feature-Request`](#feature-request) ⟶ [`Work In Progress`](#work-in-progress) ⟶ [`Fixed awaiting release`](#fixed-awaiting-release)

--- a/misc/we_need_help.md
+++ b/misc/we_need_help.md
@@ -16,3 +16,4 @@ If you have shown some commitment to the project you can ask [@ludost](//github.
 * [@Tooa](//github.com/Tooa)
 * [@eymiha](//github.com/eymiha)
 * [@bradh](//github.com/bradh)
+* [@wimrijnders](//github.com/wimrijnders)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vis",
-  "version": "4.19.1",
+  "version": "4.19.1-SNAPSHOT",
   "description": "A dynamic, browser-based visualization library.",
   "homepage": "http://visjs.org/",
   "license": "(Apache-2.0 OR MIT)",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "emitter-component": "^1.1.1",
-    "moment": "^2.17.1",
+    "moment": "^2.18.1",
     "propagating-hammerjs": "^1.4.6",
     "hammerjs": "^2.0.8",
     "keycharm": "^0.2.0"

--- a/test/TimeStep.test.js
+++ b/test/TimeStep.test.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var vis = require('../dist/vis');
+var jsdom = require('mocha-jsdom')
+var moment = vis.moment;
+var timeline = vis.timeline;
+var TimeStep = timeline.TimeStep;
+var TestSupport = require('./TestSupport');
+
+describe('TimeStep', function () {
+  
+  jsdom();
+
+  it('should work with just start and end dates', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5));
+    assert.equal(timestep.autoScale, true, "should autoscale if scale not specified");
+    assert.equal(timestep.scale, "day", "should default to day scale if scale not specified");
+    assert.equal(timestep.step, 1, "should default to 1 day step if scale not specified");
+  });
+
+  it('should work with specified scale (just under 1 second)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5), 999);
+    assert.equal(timestep.scale, "second", "should have right scale");
+    assert.equal(timestep.step, 1, "should have right step size");
+  });
+
+  // TODO: check this - maybe should work for 1000?
+  it('should work with specified scale (1 second)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5), 1001);
+    assert.equal(timestep.scale, "second", "should have right scale");
+    assert.equal(timestep.step, 5, "should have right step size");
+  });
+
+  it('should work with specified scale (2 seconds)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5), 2000);
+    assert.equal(timestep.scale, "second", "should have right scale");
+    assert.equal(timestep.step, 5, "should have right step size");
+  });
+
+  it('should work with specified scale (5 seconds)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5), 5001);
+    assert.equal(timestep.scale, "second", "should have right scale");
+    assert.equal(timestep.step, 10, "should have right step size");
+  });
+});


### PR DESCRIPTION
Fix for #3057.

`NodesHandler.refresh()` accesses member `_data` directly from the nodes. This is an internal structure of `DataSet` and will not work with `DataView`.

Replaced usage of `_data[nodeId]` with `get(nodeId)`, which works for both `DataSet` and `DataView`.