### PR TITLE
NodesHandler: get() instead of _data[] for nodes access

### DIFF
--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -330,7 +330,7 @@ class NodesHandler {
       if (nodes.hasOwnProperty(nodeId)) {
         node = nodes[nodeId];
       }
-      let data = this.body.data.nodes._data[nodeId];
+      let data = this.body.data.nodes.get(nodeId);
       if (node !== undefined && data !== undefined) {
         if (clearPositions === true) {
           node.setOptions({x:null, y:null});


### PR DESCRIPTION
Fix for #3057.

NodesHandler.refresh() accesses member _data directly from the nodes. This is an internal structure of DataSet and will not work with DataView.

Replaced usage of _data[nodeId] with get(nodeId), which works for both DataSet and DataView.