### PR TITLE
LineGraph: Remove array pre-fill since unchanged items are skipped anyways

### DIFF
--- a/lib/timeline/component/LineGraph.js
+++ b/lib/timeline/component/LineGraph.js
@@ -452,25 +452,6 @@ LineGraph.prototype._updateAllGroupData = function (ids, groupIds) {
       groupCounts.hasOwnProperty(groupId) ? groupCounts[groupId]++ : groupCounts[groupId] = 1;
     }
 
-    //Pre-load arrays from existing groups if items are not changed (not in ids)
-    if (!groupIds && ids) {
-      for (var groupId in this.groups) {
-        if (this.groups.hasOwnProperty(groupId)) {
-          var group = this.groups[groupId];
-          var existing_items = group.getItems();
-
-          groupsContent[groupId] = existing_items.filter(function (item) {
-            return (item[fieldId] !== idMap[item[fieldId]]);
-          });
-          var newLength = groupCounts[groupId];
-          groupCounts[groupId] -= groupsContent[groupId].length;
-          if (groupsContent[groupId].length < newLength) {
-            groupsContent[groupId][newLength - 1] = {};
-          }
-        }
-      }
-    }
-
     //Now insert data into the arrays.
     for (var i = 0; i < items.length; i++) {
       var item = items[i];


### PR DESCRIPTION
Fix for #2818 .

Not sure if the desired solution was removing the 
```
if (!groupIds && ids && item[fieldId] !== idMap[item[fieldId]]) {
        continue;
}
```
or the array pre-fill but this seemed more performant. 

As mentioned in the https://github.com/almende/vis/issues/2818

Since items not changed are being skipped already, the item count is being thrown off causing the empty object to not be overwritten.