### PR TITLE
Avoid overriding standard context method ellipse()

### DIFF
--- a/lib/network/modules/components/nodes/shapes/Ellipse.js
+++ b/lib/network/modules/components/nodes/shapes/Ellipse.js
@@ -28,7 +28,7 @@ class Ellipse extends NodeBase {
     ctx.strokeStyle = values.borderColor;
 
     ctx.fillStyle = values.color;
-    ctx.ellipse(this.left, this.top, this.width, this.height);
+    ctx.ellipse_vis(this.left, this.top, this.width, this.height);
 
     // draw shadow if enabled
     this.enableShadow(ctx, values);

--- a/lib/network/shapes.js
+++ b/lib/network/shapes.js
@@ -149,8 +149,10 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
 
   /**
    * http://stackoverflow.com/questions/2172798/how-to-draw-an-oval-in-html5-canvas
+   *
+   * Postfix '_vis' added to discern it from standard method ellipse().
    */
-  CanvasRenderingContext2D.prototype.ellipse = function (x, y, w, h) {
+  CanvasRenderingContext2D.prototype.ellipse_vis = function (x, y, w, h) {
     var kappa = .5522848,
       ox = (w / 2) * kappa, // control point offset horizontal
       oy = (h / 2) * kappa, // control point offset vertical


### PR DESCRIPTION
Fix for #3065.

Definition of method `ellipse()` in `lib/network/shapes.js` overrides the existing member of the same name in 2D context. Renamed the local method to avoid the naming conflict.