### PR TITLE
timeline - items always draggable upgrade for range

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -729,11 +729,23 @@ function (option, path) {
       </td>
     </tr>
 
-    <tr>
-      <td>itemsAlwaysDraggable</td>
+    <tr class='toggle collapsible' onclick="toggleTable('optionTable','itemsAlwaysDraggable', this);">
+      <td><span parent="itemsAlwaysDraggable" class="right-caret"></span> itemsAlwaysDraggable</td>
+      <td>boolean or Object</td>
+      <td>Object</td>
+      <td>When a boolean, applies the value only to <code>itemsAlwaysDraggable.item</code>.</td>
+    </tr>
+    <tr parent="itemsAlwaysDraggable" class="hidden">
+      <td class="indent">itemsAlwaysDraggable.item</td>
       <td>boolean</td>
       <td><code>false</code></td>
       <td>If true, all items in the Timeline are draggable without being selected. If false, only the selected item(s) are draggable.</td>
+    </tr>
+    <tr parent="itemsAlwaysDraggable" class="hidden">
+      <td class="indent">itemsAlwaysDraggable.range</td>
+      <td>boolean</td>
+      <td><code>false</code></td>
+      <td>If true, range of all items in the Timeline is draggable without being selected. If false, range is only draggable for the selected item(s). Only applicable when option <code>itemsAlwaysDraggable.item</code> is set <code>true</code>. </td>
     </tr>
 
     <tr>

--- a/examples/timeline/editing/itemsAlwaysDraggable.html
+++ b/examples/timeline/editing/itemsAlwaysDraggable.html
@@ -1,0 +1,38 @@
+<html>
+    <head>
+        <title>Timeline | itemsAlwaysDraggable Option</title>
+        <meta charset="utf-8">
+        <script src="../../../dist/vis.js"></script>
+        <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
+    </head>
+    <body>
+        <p>The <code>itemsAlwaysDraggable</code> option allows to drag items around without first selecting them. When <code>itemsAlwaysDraggable.range</code> is set to <code>true</code>, the range can be changed without selection as well.</p>
+        <div id="mytimeline"></div>
+
+        <script>
+            var container = document.getElementById('mytimeline'),
+                items = new vis.DataSet();
+
+            for (var i = 10; i >= 0; i--) {
+                var start = new Date(new Date().getTime() + i * 100000);
+                items.add({
+                    id: i,
+                    content: "item " + i,
+                    start: start,
+                    end: new Date(start.getTime() + 100000)
+                });
+            }
+
+            var options = {
+                start: new Date(),
+                end: new Date(new Date().getTime() + 1000000),
+                editable: true,
+                itemsAlwaysDraggable: {
+                    item: true,
+                    range: true
+                }
+            };
+            var timeline = new vis.Timeline(container, items, null, options);
+        </script>
+    </body>
+</html>

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -44,7 +44,10 @@ function ItemSet(body, options) {
 
     selectable: true,
     multiselect: false,
-    itemsAlwaysDraggable: false,
+    itemsAlwaysDraggable: {
+      item: false,
+      range: false,
+    },
 
     editable: {
       updateTime: false,
@@ -335,11 +338,25 @@ ItemSet.prototype.setOptions = function(options) {
   if (options) {
     // copy all options that we know
     var fields = [
-      'type', 'rtl', 'align', 'order', 'stack', 'stackSubgroups', 'selectable', 'multiselect', 'itemsAlwaysDraggable', 
+      'type', 'rtl', 'align', 'order', 'stack', 'stackSubgroups', 'selectable', 'multiselect',
       'multiselectPerGroup', 'groupOrder', 'dataAttributes', 'template', 'groupTemplate', 'visibleFrameTemplate',
       'hide', 'snap', 'groupOrderSwap', 'tooltip', 'tooltipOnItemUpdateTime'
     ];
     util.selectiveExtend(fields, this.options, options);
+
+    if ('itemsAlwaysDraggable' in options) {
+      if (typeof options.itemsAlwaysDraggable === 'boolean') {
+        this.options.itemsAlwaysDraggable.item = options.itemsAlwaysDraggable;
+        this.options.itemsAlwaysDraggable.range = false;
+      }
+      else if (typeof options.itemsAlwaysDraggable === 'object') {
+        util.selectiveExtend(['item', 'range'], this.options.itemsAlwaysDraggable, options.itemsAlwaysDraggable);
+        // only allow range always draggable when item is always draggable as well
+        if (! this.options.itemsAlwaysDraggable.item) {
+          this.options.itemsAlwaysDraggable.range = false;
+        }
+      }
+    }
 
     if ('orientation' in options) {
       if (typeof options.orientation === 'string') {
@@ -1289,7 +1306,7 @@ ItemSet.prototype._onDragStart = function (event) {
   var me = this;
   var props;
 
-  if (item && (item.selected || this.options.itemsAlwaysDraggable)) {
+  if (item && (item.selected || this.options.itemsAlwaysDraggable.item)) {
 
     if (this.options.editable.overrideItems &&
         !this.options.editable.updateTime &&
@@ -1331,7 +1348,7 @@ ItemSet.prototype._onDragStart = function (event) {
     else {
       var baseGroupIndex = this._getGroupIndex(item.data.group);
 
-      var itemsToDrag = (this.options.itemsAlwaysDraggable && !item.selected) ? [item.id] : this.getSelection();
+      var itemsToDrag = (this.options.itemsAlwaysDraggable.item && !item.selected) ? [item.id] : this.getSelection();
 
       this.touchParams.itemProps = itemsToDrag.map(function (id) {
         var item = me.items[id];

--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -168,8 +168,13 @@ Item.prototype._repaintDragCenter = function () {
     });
 
     if (this.dom.box) {
-      this.dom.box.appendChild(dragCenter);
-    } 
+      if (this.dom.dragLeft) {
+        this.dom.box.insertBefore(dragCenter, this.dom.dragLeft);
+      }
+      else {
+        this.dom.box.appendChild(dragCenter);
+      }
+    }
     else if (this.dom.point) {
       this.dom.point.appendChild(dragCenter);
     }

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -291,7 +291,7 @@ RangeItem.prototype.repositionY = function() {
  * @protected
  */
 RangeItem.prototype._repaintDragLeft = function () {
-  if (this.selected && this.options.editable.updateTime && !this.dom.dragLeft) {
+  if ((this.selected || this.options.itemsAlwaysDraggable.range) && this.options.editable.updateTime && !this.dom.dragLeft) {
     // create and show drag area
     var dragLeft = document.createElement('div');
     dragLeft.className = 'vis-drag-left';
@@ -300,7 +300,7 @@ RangeItem.prototype._repaintDragLeft = function () {
     this.dom.box.appendChild(dragLeft);
     this.dom.dragLeft = dragLeft;
   }
-  else if (!this.selected && this.dom.dragLeft) {
+  else if (!this.selected && !this.options.itemsAlwaysDraggable.range && this.dom.dragLeft) {
     // delete drag area
     if (this.dom.dragLeft.parentNode) {
       this.dom.dragLeft.parentNode.removeChild(this.dom.dragLeft);
@@ -314,7 +314,7 @@ RangeItem.prototype._repaintDragLeft = function () {
  * @protected
  */
 RangeItem.prototype._repaintDragRight = function () {
-  if (this.selected && this.options.editable.updateTime && !this.dom.dragRight) {
+  if ((this.selected || this.options.itemsAlwaysDraggable.range) && this.options.editable.updateTime && !this.dom.dragRight) {
     // create and show drag area
     var dragRight = document.createElement('div');
     dragRight.className = 'vis-drag-right';
@@ -323,7 +323,7 @@ RangeItem.prototype._repaintDragRight = function () {
     this.dom.box.appendChild(dragRight);
     this.dom.dragRight = dragRight;
   }
-  else if (!this.selected && this.dom.dragRight) {
+  else if (!this.selected && !this.options.itemsAlwaysDraggable.range && this.dom.dragRight) {
     // delete drag area
     if (this.dom.dragRight.parentNode) {
       this.dom.dragRight.parentNode.removeChild(this.dom.dragRight);

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -89,7 +89,11 @@ let allOptions = {
     repeat: {string},
     __type__: {object, array}
   },
-  itemsAlwaysDraggable: { 'boolean': bool},
+  itemsAlwaysDraggable: {
+	 item: { 'boolean': bool, 'undefined': 'undefined'},
+	 range: { 'boolean': bool, 'undefined': 'undefined'},
+	 __type__: { 'boolean': bool, object}
+  },
   locale:{string},
   locales:{
     __any__: {any},


### PR DESCRIPTION
Added new suboption to the itemsAlwaysDraggable option of timeline.

When activated dragLeft and dragRight elements are always added to range items, thus supporting changing of range without the need to select first.