### PR TITLE
LineGraph: Add an existingItemsMap to check if items are new or not before skipping

### DIFF
--- a/lib/timeline/component/LineGraph.js
+++ b/lib/timeline/component/LineGraph.js
@@ -453,6 +453,7 @@ LineGraph.prototype._updateAllGroupData = function (ids, groupIds) {
     }
 
     //Pre-load arrays from existing groups if items are not changed (not in ids)
+    var existingItemsMap = {};
     if (!groupIds && ids) {
       for (var groupId in this.groups) {
         if (this.groups.hasOwnProperty(groupId)) {
@@ -460,6 +461,7 @@ LineGraph.prototype._updateAllGroupData = function (ids, groupIds) {
           var existing_items = group.getItems();
 
           groupsContent[groupId] = existing_items.filter(function (item) {
+            existingItemsMap[item[fieldId]] = item[fieldId];
             return (item[fieldId] !== idMap[item[fieldId]]);
           });
           var newLength = groupCounts[groupId];
@@ -478,7 +480,7 @@ LineGraph.prototype._updateAllGroupData = function (ids, groupIds) {
       if (groupId === null || groupId === undefined) {
         groupId = UNGROUPED;
       }
-      if (!groupIds && ids && (item[fieldId] !== idMap[item[fieldId]])) {
+      if (!groupIds && ids && (item[fieldId] !== idMap[item[fieldId]]) && existingItemsMap.hasOwnProperty(item[fieldId])) {
         continue;
       }
       if (!groupsContent.hasOwnProperty(groupId)) {


### PR DESCRIPTION
Fix for #2818 .

Added a existingItemMap to check if item is new before skipping. Previous implementation assumed only existing items were updated with setItems.