### PR TITLE
Add prefix 'window.'  to cancelAnimationFrame()

### DIFF
--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -61,7 +61,7 @@ class CanvasRenderer {
         clearTimeout(this.renderTimer);
       }
       else {
-        cancelAnimationFrame(this.renderTimer);
+        window.cancelAnimationFrame(this.renderTimer);
       }
       this.body.emitter.off();
     });


### PR DESCRIPTION
One-liner fix for #3085.