### PR TITLE
Added param 'direction' to Network.getConnectedNodes()

### DIFF
--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -866,13 +866,19 @@ function releaseFunction (clusterPosition, containedNodesPositions) {
             </tr>
             <tr class="collapsible toggle" onclick="toggleTable('methodTable','getConnectedNodes', this);">
                 <td colspan="2"><span parent="getConnectedNodes" class="right-caret" id="method_getConnectedNodes"></span> getConnectedNodes(<code><i>String
-                    nodeId or edgeId</i></code>)
+                    nodeId or edgeId, [String direction]</i></code>)
                 </td>
             </tr>
             <tr class="hidden" parent="getConnectedNodes">
                 <td class="midMethods">Returns: Array</td>
-                <td>Returns an array of nodeIds of the all the nodes that are directly connected to this node. If you supply an edgeId,
-                vis will first match the id to nodes. If no match is found, it will search in the edgelist and return an array: <code>[fromId, toId]</code>.</td>
+                <td>Returns an array of nodeIds of all the nodes that are directly connected to this node or edge.<br><br>
+                For a node id, returns an array with the id's of the connected nodes.<br>
+                If optional parameter <code>direction</code> is set to string <i>'from'</i>, only parent nodes are returned.<br>
+                If <code>direction</code> is set to <i>'to'</i>, only child nodes are returned.<br>
+                Any other value or <code>undefined</code> returns both parent and child nodes.
+                <br><br>
+                For an edge id, returns an array: <code>[fromId, toId]</code>.
+                Parameter <i>direction</i> is ignored for edges.</td>
             </tr>
             <tr class="collapsible toggle" onclick="toggleTable('methodTable','getConnectedEdges', this);">
                 <td colspan="2"><span parent="getConnectedEdges" class="right-caret" id="method_getConnectedEdges"></span> getConnectedEdges(<code><i>String

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -61,7 +61,7 @@ class CanvasRenderer {
         clearTimeout(this.renderTimer);
       }
       else {
-        cancelAnimationFrame(this.renderTimer);
+        window.cancelAnimationFrame(this.renderTimer);
       }
       this.body.emitter.off();
     });

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -408,22 +408,24 @@ class NodesHandler {
   /**
    * Get the Ids of nodes connected to this node.
    * @param nodeId
+   * @param direction {String|undefined} values 'from' and 'to' select respectively parent and child nodes only.
+   *                                     Any other value returns both parent and child nodes.
    * @returns {Array}
    */
-  getConnectedNodes(nodeId) {
+  getConnectedNodes(nodeId, direction) {
     let nodeList = [];
     if (this.body.nodes[nodeId] !== undefined) {
       let node = this.body.nodes[nodeId];
       let nodeObj = {}; // used to quickly check if node already exists
       for (let i = 0; i < node.edges.length; i++) {
         let edge = node.edges[i];
-        if (edge.toId == node.id) { // these are double equals since ids can be numeric or string
+        if (direction !== 'from' && edge.toId == node.id) { // these are double equals since ids can be numeric or string
           if (nodeObj[edge.fromId] === undefined) {
             nodeList.push(edge.fromId);
             nodeObj[edge.fromId] = true;
           }
         }
-        else if (edge.fromId == node.id) { // these are double equals since ids can be numeric or string
+        else if (direction !== 'to' && edge.fromId == node.id) { // these are double equals since ids can be numeric or string
           if (nodeObj[edge.toId] === undefined) {
             nodeList.push(edge.toId);
             nodeObj[edge.toId] = true;


### PR DESCRIPTION
This is a better resolution for #3091. The question of getting parents or children only gets asked regularly, so I think it's good to offer the option.

- Added parameter `direction` to `Network.getConnectedNodes()`. Parent-only and child-only nodes can be selected with values `from` and `to` respectively.
- Adjusted the documentation for this change.

*This changes the API, so it presumably will be a MINOR version change.*