### PR TITLE
Edge labels turn bold on select and hover

### DIFF
--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -529,6 +529,11 @@ class Edge {
       var node1 = this.from;
       var node2 = this.to;
       var selected = (this.from.selected || this.to.selected || this.selected);
+
+      if (this.labelModule.differentState(selected, this.hover)) {
+        this.labelModule.getTextSize(ctx, selected, this.hover);
+      }
+
       if (node1.id != node2.id) {
         this.labelModule.pointToSelf = false;
         var point = this.edgeType.getPoint(0.5, viaNode);


### PR DESCRIPTION
Fix for #2990. Edge labels turn bold on select and hover, just like node labels.