### PR TITLE
Changed order of (de)select events for network

### DIFF
--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -194,26 +194,27 @@ class InteractionHandler {
     }
     let currentSelection = this.selectionHandler.getSelection();
 
+    // See NOTE in method comment for the reason to do it like this
     let deselectedItems = this._determineDifference(previousSelection, currentSelection);
     let selectedItems   = this._determineDifference(currentSelection , previousSelection);
 
     if (deselectedItems.edges.length > 0) {
-      this.selectionHandler._generateClickEvent('deselectEdge', event, pointer, deselectedItems);
+      this.selectionHandler._generateClickEvent('deselectEdge', event, pointer, previousSelection);
       selected = true;
     }
 
     if (deselectedItems.nodes.length > 0) {
-      this.selectionHandler._generateClickEvent('deselectNode', event, pointer, deselectedItems);
+      this.selectionHandler._generateClickEvent('deselectNode', event, pointer, previousSelection);
       selected = true;
     }
 
     if (selectedItems.nodes.length > 0) {
-      this.selectionHandler._generateClickEvent('selectNode', event, pointer, selectedItems);
+      this.selectionHandler._generateClickEvent('selectNode', event, pointer);
       selected = true;
     }
 
     if (selectedItems.edges.length > 0) {
-      this.selectionHandler._generateClickEvent('selectEdge', event, pointer, selectedItems);
+      this.selectionHandler._generateClickEvent('selectEdge', event, pointer);
       selected = true;
     }
 

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -170,60 +170,52 @@ class InteractionHandler {
 
 
   /**
+   * Select and deselect nodes depending current selection change.
+   *
+   * For changing nodes, select/deselect events are fired.
+   *
+   * NOTE: For a given edge, if one connecting node is deselected and with the same
+   *       click the other node is selected, no events for the edge will fire.
+   *       It was selected and it will remain selected.
+   *
+   * TODO: This is all SelectionHandler calls; the method should be moved to there.
    *
    * @param pointer
    * @param add
    */
   checkSelectionChanges(pointer, event, add = false) {
-    let previouslySelectedEdgeCount = this.selectionHandler._getSelectedEdgeCount();
-    let previouslySelectedNodeCount = this.selectionHandler._getSelectedNodeCount();
     let previousSelection = this.selectionHandler.getSelection();
-    let selected;
+    let selected = false;
     if (add === true) {
       selected = this.selectionHandler.selectAdditionalOnPoint(pointer);
     }
     else {
       selected = this.selectionHandler.selectOnPoint(pointer);
     }
-    let selectedEdgesCount = this.selectionHandler._getSelectedEdgeCount();
-    let selectedNodesCount = this.selectionHandler._getSelectedNodeCount();
     let currentSelection = this.selectionHandler.getSelection();
 
-    let {nodesChanged, edgesChanged} = this._determineIfDifferent(previousSelection, currentSelection);
-    let nodeSelected = false;
+    let deselectedItems = this._determineDifference(previousSelection, currentSelection);
+    let selectedItems   = this._determineDifference(currentSelection , previousSelection);
 
-    if (selectedNodesCount - previouslySelectedNodeCount > 0) { // node was selected
-      this.selectionHandler._generateClickEvent('selectNode', event, pointer);
-      selected = true;
-      nodeSelected = true;
-    }
-    else if (nodesChanged === true && selectedNodesCount > 0) {
-      this.selectionHandler._generateClickEvent('deselectNode', event, pointer, previousSelection);
-      this.selectionHandler._generateClickEvent('selectNode', event, pointer);
-      nodeSelected = true;
-      selected = true;
-    }
-    else if (selectedNodesCount - previouslySelectedNodeCount < 0) { // node was deselected
-      this.selectionHandler._generateClickEvent('deselectNode', event, pointer, previousSelection);
+    if (deselectedItems.edges.length > 0) {
+      this.selectionHandler._generateClickEvent('deselectEdge', event, pointer, deselectedItems);
       selected = true;
     }
 
-
-    // handle the selected edges
-    if (selectedEdgesCount - previouslySelectedEdgeCount > 0 && nodeSelected === false) { // edge was selected
-      this.selectionHandler._generateClickEvent('selectEdge', event, pointer);
-      selected = true;
-    }
-    else if (selectedEdgesCount > 0 && edgesChanged === true) {
-      this.selectionHandler._generateClickEvent('deselectEdge', event, pointer, previousSelection);
-      this.selectionHandler._generateClickEvent('selectEdge', event, pointer);
-      selected = true;
-    }
-    else if (selectedEdgesCount - previouslySelectedEdgeCount < 0) { // edge was deselected
-      this.selectionHandler._generateClickEvent('deselectEdge', event, pointer, previousSelection);
+    if (deselectedItems.nodes.length > 0) {
+      this.selectionHandler._generateClickEvent('deselectNode', event, pointer, deselectedItems);
       selected = true;
     }
 
+    if (selectedItems.nodes.length > 0) {
+      this.selectionHandler._generateClickEvent('selectNode', event, pointer, selectedItems);
+      selected = true;
+    }
+
+    if (selectedItems.edges.length > 0) {
+      this.selectionHandler._generateClickEvent('selectEdge', event, pointer, selectedItems);
+      selected = true;
+    }
 
     // fire the select event if anything has been selected or deselected
     if (selected === true) { // select or unselect
@@ -233,38 +225,31 @@ class InteractionHandler {
 
 
   /**
-   * This function checks if the nodes and edges previously selected have changed.
-   * @param previousSelection
-   * @param currentSelection
-   * @returns {{nodesChanged: boolean, edgesChanged: boolean}}
+   * Remove all node and edge id's from the first set that are present in the second one.
+   *
+   * @param firstSet
+   * @param secondSet
+   * @returns {{nodes: array, edges: array}}
    * @private
    */
-  _determineIfDifferent(previousSelection,currentSelection) {
-    let nodesChanged = false;
-    let edgesChanged = false;
+  _determineDifference(firstSet, secondSet) {
+    let arrayDiff = function(firstArr, secondArr) {
+      let result = [];
 
-    for (let i = 0; i < previousSelection.nodes.length; i++) {
-      if (currentSelection.nodes.indexOf(previousSelection.nodes[i]) === -1) {
-        nodesChanged = true;
+      for (let i = 0; i < firstArr.length; i++) {
+        let value = firstArr[i];
+        if (secondArr.indexOf(value) === -1) {
+          result.push(value);
+        }
       }
-    }
-    for (let i = 0; i < currentSelection.nodes.length; i++) {
-      if (previousSelection.nodes.indexOf(previousSelection.nodes[i]) === -1) {
-        nodesChanged = true;
-      }
-    }
-    for (let i = 0; i < previousSelection.edges.length; i++) {
-      if (currentSelection.edges.indexOf(previousSelection.edges[i]) === -1) {
-        edgesChanged = true;
-      }
-    }
-    for (let i = 0; i < currentSelection.edges.length; i++) {
-      if (previousSelection.edges.indexOf(previousSelection.edges[i]) === -1) {
-        edgesChanged = true;
-      }
-    }
 
-    return {nodesChanged, edgesChanged};
+      return result;
+    };
+
+    return {
+      nodes: arrayDiff(firstSet.nodes, secondSet.nodes),
+      edges: arrayDiff(firstSet.edges, secondSet.edges)
+    };
   }
 
 


### PR DESCRIPTION
Fix for #2959. Changed the order in which select/deselect events are fired, on change of selection of nodes and edges.

The old event order is:
1. `deselectNode`
2. `selectNode`
3. `deselectEdge`
4. `selectEdge`

The new event order will become:
1. `deselectEdge`
2. `deselectNode`
3. `selectNode`
4. `selectEdge`
