### PR TITLE
Fix option handling label selection of edges

### DIFF
--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -528,7 +528,7 @@ class Edge {
       // set style
       var node1 = this.from;
       var node2 = this.to;
-      var selected = (this.from.selected || this.to.selected || this.selected);
+      var selected = this.selected;
 
       if (this.labelModule.differentState(selected, this.hover)) {
         this.labelModule.getTextSize(ctx, selected, this.hover);

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -528,10 +528,9 @@ class Edge {
       // set style
       var node1 = this.from;
       var node2 = this.to;
-      var selected = this.selected;
 
-      if (this.labelModule.differentState(selected, this.hover)) {
-        this.labelModule.getTextSize(ctx, selected, this.hover);
+      if (this.labelModule.differentState(this.selected, this.hover)) {
+        this.labelModule.getTextSize(ctx, this.selected, this.hover);
       }
 
       if (node1.id != node2.id) {
@@ -541,13 +540,13 @@ class Edge {
 
         // if the label has to be rotated:
         if (this.options.font.align !== "horizontal") {
-          this.labelModule.calculateLabelSize(ctx, selected, this.hover, point.x, point.y);
+          this.labelModule.calculateLabelSize(ctx, this.selected, this.hover, point.x, point.y);
           ctx.translate(point.x, this.labelModule.size.yLine);
           this._rotateForLabelAlignment(ctx);
         }
 
         // draw the label
-        this.labelModule.draw(ctx, point.x, point.y, selected, this.hover);
+        this.labelModule.draw(ctx, point.x, point.y, this.selected, this.hover);
         ctx.restore();
       }
       else {
@@ -564,7 +563,7 @@ class Edge {
           y = node1.y - node1.shape.height * 0.5;
         }
         point = this._pointOnCircle(x, y, radius, 0.125);
-        this.labelModule.draw(ctx, point.x, point.y, selected, this.hover);
+        this.labelModule.draw(ctx, point.x, point.y, this.selected, this.hover);
       }
     }
   }


### PR DESCRIPTION
Additional fix for #2990.

Option `interaction.selectConnectedEdges` was not working as expected. Adjusted selection determination in `Edge.drawlabel()` to fix this. The working of all options under `interaction` except `toolTipDelay` have been verified to work correctly.

**Update:** This PR needs expansion. There are more options related to labels which need to be considered: notably, `edge.chosen.label` and `edge.labelHighlightBold`.