### PR TITLE
Refactoring of `BezierEdgeStatic._getViaCoordinates()`

### DIFF
--- a/lib/network/modules/components/edges/BezierEdgeStatic.js
+++ b/lib/network/modules/components/edges/BezierEdgeStatic.js
@@ -39,6 +39,7 @@ class BezierEdgeStatic extends BezierEdgeBase {
    * @private
    */
   _getViaCoordinates() {
+    // Assumption: x/y coordinates in from/to always defined
     let xVia = undefined;
     let yVia = undefined;
     let factor = this.options.smooth.roundness;
@@ -46,94 +47,55 @@ class BezierEdgeStatic extends BezierEdgeBase {
     let dx = Math.abs(this.from.x - this.to.x);
     let dy = Math.abs(this.from.y - this.to.y);
     if (type === 'discrete' || type === 'diagonalCross') {
-      if (Math.abs(this.from.x - this.to.x) <= Math.abs(this.from.y - this.to.y)) {
-        if (this.from.y >= this.to.y) {
-          if (this.from.x <= this.to.x) {
-            xVia = this.from.x + factor * dy;
-            yVia = this.from.y - factor * dy;
-          }
-          else if (this.from.x > this.to.x) {
-            xVia = this.from.x - factor * dy;
-            yVia = this.from.y - factor * dy;
-          }
-        }
-        else if (this.from.y < this.to.y) {
-          if (this.from.x <= this.to.x) {
-            xVia = this.from.x + factor * dy;
-            yVia = this.from.y + factor * dy;
-          }
-          else if (this.from.x > this.to.x) {
-            xVia = this.from.x - factor * dy;
-            yVia = this.from.y + factor * dy;
-          }
-        }
-        if (type === "discrete") {
-          xVia = dx < factor * dy ? this.from.x : xVia;
-        }
+      let stepX;
+      let stepY;
+
+      if (dx <= dy) {
+        stepX = stepY = factor * dy;
+      } else {
+        stepX = stepY = factor * dx;
       }
-      else if (Math.abs(this.from.x - this.to.x) > Math.abs(this.from.y - this.to.y)) {
-        if (this.from.y >= this.to.y) {
-          if (this.from.x <= this.to.x) {
-            xVia = this.from.x + factor * dx;
-            yVia = this.from.y - factor * dx;
-          }
-          else if (this.from.x > this.to.x) {
-            xVia = this.from.x - factor * dx;
-            yVia = this.from.y - factor * dx;
-          }
-        }
-        else if (this.from.y < this.to.y) {
-          if (this.from.x <= this.to.x) {
-            xVia = this.from.x + factor * dx;
-            yVia = this.from.y + factor * dx;
-          }
-          else if (this.from.x > this.to.x) {
-            xVia = this.from.x - factor * dx;
-            yVia = this.from.y + factor * dx;
-          }
-        }
-        if (type === "discrete") {
+
+      if (this.from.x >  this.to.x) stepX = -stepX;
+      if (this.from.y >= this.to.y) stepY = -stepY;
+
+      xVia = this.from.x + stepX;
+      yVia = this.from.y + stepY;
+
+      if (type === "discrete") {
+        if (dx <= dy) {
+          xVia = dx < factor * dy ? this.from.x : xVia;
+        } else {
           yVia = dy < factor * dx ? this.from.y : yVia;
         }
       }
     }
     else if (type === "straightCross") {
-      if (Math.abs(this.from.x - this.to.x) <= Math.abs(this.from.y - this.to.y)) {  // up - down
-        xVia = this.from.x;
-        if (this.from.y < this.to.y) {
-          yVia = this.to.y - (1 - factor) * dy;
-        }
-        else {
-          yVia = this.to.y + (1 - factor) * dy;
-        }
+      let stepX = (1 - factor) * dx;
+      let stepY = (1 - factor) * dy;
+
+      if (dx <= dy) {  // up - down
+        stepX = 0;
+        if (this.from.y < this.to.y) stepY = -stepY;
       }
-      else if (Math.abs(this.from.x - this.to.x) > Math.abs(this.from.y - this.to.y)) { // left - right
-        if (this.from.x < this.to.x) {
-          xVia = this.to.x - (1 - factor) * dx;
-        }
-        else {
-          xVia = this.to.x + (1 - factor) * dx;
-        }
-        yVia = this.from.y;
+      else { // left - right
+        if (this.from.x < this.to.x) stepX = -stepX;
+        stepY = 0;
       }
+      xVia = this.to.x + stepX;
+      yVia = this.to.y + stepY;
     }
     else if (type === 'horizontal') {
-      if (this.from.x < this.to.x) {
-        xVia = this.to.x - (1 - factor) * dx;
-      }
-      else {
-        xVia = this.to.x + (1 - factor) * dx;
-      }
+      let stepX = (1 - factor) * dx;
+      if (this.from.x < this.to.x) stepX = -stepX;
+      xVia = this.to.x + stepX;
       yVia = this.from.y;
     }
     else if (type === 'vertical') {
+      let stepY = (1 - factor) * dy;
+      if (this.from.y < this.to.y) stepY = -stepY;
       xVia = this.from.x;
-      if (this.from.y < this.to.y) {
-        yVia = this.to.y - (1 - factor) * dy;
-      }
-      else {
-        yVia = this.to.y + (1 - factor) * dy;
-      }
+      yVia = this.to.y + stepY;
     }
     else if (type === 'curvedCW') {
       dx = this.to.x - this.from.x;
@@ -160,56 +122,34 @@ class BezierEdgeStatic extends BezierEdgeBase {
       yVia = this.from.y + (factor * 0.5 + 0.5) * radius * Math.cos(myAngle);
     }
     else { // continuous
-      if (Math.abs(this.from.x - this.to.x) <= Math.abs(this.from.y - this.to.y)) {
-        if (this.from.y >= this.to.y) {
-          if (this.from.x <= this.to.x) {
-            xVia = this.from.x + factor * dy;
-            yVia = this.from.y - factor * dy;
-            xVia = this.to.x < xVia ? this.to.x : xVia;
-          }
-          else if (this.from.x > this.to.x) {
-            xVia = this.from.x - factor * dy;
-            yVia = this.from.y - factor * dy;
-            xVia = this.to.x > xVia ? this.to.x : xVia;
-          }
+      let stepX;
+      let stepY;
+
+      if (dx <= dy) {
+        stepX = stepY = factor * dy;
+      } else {
+        stepX = stepY = factor * dx;
+      }
+
+      if (this.from.x >  this.to.x) stepX = -stepX;
+      if (this.from.y >= this.to.y) stepY = -stepY;
+
+      xVia = this.from.x + stepX;
+      yVia = this.from.y + stepY;
+
+      if (dx <= dy) {
+        if (this.from.x <= this.to.x) {
+          xVia = this.to.x < xVia ? this.to.x : xVia;
         }
-        else if (this.from.y < this.to.y) {
-          if (this.from.x <= this.to.x) {
-            xVia = this.from.x + factor * dy;
-            yVia = this.from.y + factor * dy;
-            xVia = this.to.x < xVia ? this.to.x : xVia;
-          }
-          else if (this.from.x > this.to.x) {
-            xVia = this.from.x - factor * dy;
-            yVia = this.from.y + factor * dy;
-            xVia = this.to.x > xVia ? this.to.x : xVia;
-          }
+        else {
+          xVia = this.to.x > xVia ? this.to.x : xVia;
         }
       }
-      else if (Math.abs(this.from.x - this.to.x) > Math.abs(this.from.y - this.to.y)) {
+      else {
         if (this.from.y >= this.to.y) {
-          if (this.from.x <= this.to.x) {
-            xVia = this.from.x + factor * dx;
-            yVia = this.from.y - factor * dx;
-            yVia = this.to.y > yVia ? this.to.y : yVia;
-          }
-          else if (this.from.x > this.to.x) {
-            xVia = this.from.x - factor * dx;
-            yVia = this.from.y - factor * dx;
-            yVia = this.to.y > yVia ? this.to.y : yVia;
-          }
-        }
-        else if (this.from.y < this.to.y) {
-          if (this.from.x <= this.to.x) {
-            xVia = this.from.x + factor * dx;
-            yVia = this.from.y + factor * dx;
-            yVia = this.to.y < yVia ? this.to.y : yVia;
-          }
-          else if (this.from.x > this.to.x) {
-            xVia = this.from.x - factor * dx;
-            yVia = this.from.y + factor * dx;
-            yVia = this.to.y < yVia ? this.to.y : yVia;
-          }
+          yVia = this.to.y > yVia ? this.to.y : yVia;
+        } else {
+          yVia = this.to.y < yVia ? this.to.y : yVia;
         }
       }
     }


### PR DESCRIPTION
This method is needlessly complicated. Code has been adjusted to better show the intent.

In addition:
- reuse of variables already present, notably `dx` and `dy`
- put recurring code fragments into local variables
- removed second conditions in constructs of the form `if (condition) ... else if (!condition) ...`

The refactoring can be taken further, but it would change the conditional flow, which would complicate reviewing. The current changes highlight the similarities between the code blocks.