### PR TITLE
Fix on call to `fontOptions.chooser()` in module Label

### DIFF
--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -778,17 +778,13 @@ class Label {
       strokeWidth: this.fontOptions.strokeWidth,
       strokeColor: this.fontOptions.strokeColor
     };
-    if (mod === "normal") {
-      if (selected || hover) {
-        if ((this.fontOptions.chooser === true) && (this.elementOptions.labelHighlightBold)) {
+    if (selected || hover) {
+      if (mod === "normal" && (this.fontOptions.chooser === true) && (this.elementOptions.labelHighlightBold)) {
           values.mod = 'bold';
-        } else if (typeof this.fontOptions.chooser === 'function') {
-          this.fontOptions.chooser(ctx, values, this.elementOptions.id, selected, hover);
+      } else {
+        if (typeof this.fontOptions.chooser === 'function') {
+          this.fontOptions.chooser(values, this.elementOptions.id, selected, hover);
         }
-      }
-    } else {
-      if ((selected || hover) && (typeof this.fontOptions.chooser === 'function')) {
-        this.fontOptions.chooser(ctx, values, this.elementOptions.id, selected, hover);
       }
     }
     ctx.font = (values.mod + " " + values.size + "px " + values.face).replace(/"/g, "");


### PR DESCRIPTION
Call on issue brought to light by #2990.

`ctx` should not be passed as a parameter to the call - not needed and not conform to documentation.
Also cleaned up the calling code to remove the double `fontOptions.chooser()` call.