### PR TITLE
Fix usage of clustering with hierarchical networks

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -55,13 +55,27 @@ function Network(container, data, options) {
   };
   util.extend(this.options, this.defaultOptions);
 
-  // containers for nodes and edges
+  /**
+   * Containers for nodes and edges.
+   *
+   * 'edges' and 'nodes' contain the full definitions of all the network elements.
+   * 'nodeIndices' and 'edgeIndices' contain the id's of the active elements.
+   *
+   * The distinction is important, because a defined node need not be active, i.e.
+   * visible on the canvas. This happens in particular when clusters are defined, in
+   * that case there will be nodes and edges not displayed.
+   * The bottom line is that all code with actions related to visibility, *must* use
+   * 'nodeIndices' and 'edgeIndices', not 'nodes' and 'edges' directly.
+   */
   this.body = {
     container: container,
+
+    // See comment above for following fields
     nodes: {},
     nodeIndices: [],
     edges: {},
     edgeIndices: [],
+
     emitter: {
       on:   this.on.bind(this),
       off:  this.off.bind(this),

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -1195,6 +1195,9 @@ class LayoutEngine {
 
   /**
    * Return the active (i.e. visible) edges for this node
+   *
+   * @returns {array} Array of edge instances
+   * @private
    */
   _getActiveEdges(node) {
     let result = [];
@@ -1243,7 +1246,6 @@ class LayoutEngine {
   /**
    * this function allocates nodes in levels based on the recursive branching from the largest hubs.
    *
-   * @param hubsize
    * @private
    */
   _determineLevelsByHubsize() {
@@ -1348,7 +1350,7 @@ class LayoutEngine {
 
   /**
    * Crawl over the entire network and use a callback on each node couple that is connected to each other.
-   * @param callback          | will receive nodeA nodeB and the connecting edge. A and B are unique.
+   * @param callback          | will receive nodeA, nodeB and the connecting edge. A and B are distinct.
    * @param startingNodeId
    * @private
    */
@@ -1367,12 +1369,9 @@ class LayoutEngine {
         progress[node.id] = true;
         let childNode;
         let edges = this._getActiveEdges(node);
-        //for (let i = 0; i < node.edges.length; i++) {
-        //  let edges = node.edges[i];
         for (let i = 0; i < edges.length; i++) {
           let edge = edges[i];
           if (edge.connected === true) {
-            //if (edge.toId === node.id) {
             if (edge.toId == node.id) {         // '==' because id's can be string and numeric
               childNode = edge.from;
             }
@@ -1380,7 +1379,6 @@ class LayoutEngine {
               childNode = edge.to;
             }
 
-            //if (node.id !== childNode.id) {
             if (node.id != childNode.id) {      // '!=' because id's can be string and numeric
               callback(node, childNode, edge);
               crawler(childNode, tree);
@@ -1589,44 +1587,6 @@ class LayoutEngine {
 
     return 0.5 * (minPos + maxPos);
   }
-
-
-  /**
-   * Get a list of node id's which are *not* part of a cluster.
-   *
-   * This will include the clusters themselves.
-   *
-   * @return {array} Array of node id's
-   * @private
-   * /
-  _getUnclusteredNodes() {
-    // Determine id's of all nodes in clusters
-    let clustered = [];
-
-    for (let id1 in this.body.nodes) {
-      if (this.body.nodes.hasOwnProperty(id1)) {
-        let node = this.body.nodes[id1];
-        if (node.isCluster === true) {
-          for (let id2 in node.containedNodes) {
-            clustered.push(id2);
-          }
-        }
-      }
-    }
-
-    // Determine the inverse of the list of clustered nodes
-    let unclustered = []
-    for (let id in this.body.nodes) {
-      if (this.body.nodes.hasOwnProperty(id)) {
-        if (clustered.indexOf(id) === -1) {
-          unclustered.push(id);
-        }
-      }
-    }
-
-    return unclustered;
-  }
-*/
 }
 
 export default LayoutEngine;

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -1194,22 +1194,49 @@ class LayoutEngine {
 
 
   /**
-   * Get the hubsize from all remaining unlevelled nodes.
+   * Return the active (i.e. visible) edges for this node
+   */
+  _getActiveEdges(node) {
+    let result = [];
+
+    for (let j in node.edges) {
+      let edge = node.edges[j];
+      if (this.body.edgeIndices.indexOf(edge.id) !== -1) {
+        result.push(edge);
+      }
+    }
+
+    return result;
+  }
+
+
+  /**
+   * Get the hubsizes for all active nodes.
    *
    * @returns {number}
    * @private
    */
-  _getHubSize() {
-    let hubSize = 0;
-    for (let nodeId in this.body.nodes) {
-      if (this.body.nodes.hasOwnProperty(nodeId)) {
-        let node = this.body.nodes[nodeId];
-        if (this.hierarchical.levels[nodeId] === undefined) {
-          hubSize = node.edges.length < hubSize ? hubSize : node.edges.length;
-        }
-      }
+  _getHubSizes() {
+    let hubSizes = {};
+    let nodeIds = this.body.nodeIndices;
+
+    for (let i in nodeIds) {
+      let nodeId = nodeIds[i];
+      let node = this.body.nodes[nodeId];
+      let hubSize = this._getActiveEdges(node).length;
+      hubSizes[hubSize] = true;
     }
-    return hubSize;
+
+    // Make an array of the size sorted descending
+    let result = [];
+    for (let size in hubSizes) {
+      result.push(Number(size));
+    }
+    result.sort(function(a, b) {
+      return b - a;
+    });
+
+    return result;
   }
 
 
@@ -1220,24 +1247,23 @@ class LayoutEngine {
    * @private
    */
   _determineLevelsByHubsize() {
-    let hubSize = 1;
-
     let levelDownstream = (nodeA, nodeB) => {
       this.hierarchical.levelDownstream(nodeA, nodeB);
     }
 
-    while (hubSize > 0) {
-      // determine hubs
-      hubSize = this._getHubSize();
-      if (hubSize === 0)
-        break;
+    let hubSizes = this._getHubSizes();
 
-      for (let nodeId in this.body.nodes) {
-        if (this.body.nodes.hasOwnProperty(nodeId)) {
-          let node = this.body.nodes[nodeId];
-          if (node.edges.length === hubSize) {
-            this._crawlNetwork(levelDownstream,nodeId);
-          }
+    for (let i = 0; i < hubSizes.length; ++i ) {
+      let hubSize = hubSizes[i];
+      if (hubSize === 0) break;
+
+      let nodeIds = this.body.nodeIndices;
+      for (let j in nodeIds) {
+        let nodeId = nodeIds[j];
+        let node = this.body.nodes[nodeId];
+
+        if (hubSize === this._getActiveEdges(node).length) {
+          this._crawlNetwork(levelDownstream, nodeId);
         }
       }
     }
@@ -1340,18 +1366,23 @@ class LayoutEngine {
 
         progress[node.id] = true;
         let childNode;
-        for (let i = 0; i < node.edges.length; i++) {
-          let edges = node.edges[i];
-          if (edges.connected === true) {
-            if (edges.toId === node.id) {
-              childNode = edges.from;
+        let edges = this._getActiveEdges(node);
+        //for (let i = 0; i < node.edges.length; i++) {
+        //  let edges = node.edges[i];
+        for (let i = 0; i < edges.length; i++) {
+          let edge = edges[i];
+          if (edge.connected === true) {
+            //if (edge.toId === node.id) {
+            if (edge.toId == node.id) {         // '==' because id's can be string and numeric
+              childNode = edge.from;
             }
             else {
-              childNode = edges.to;
+              childNode = edge.to;
             }
 
-            if (node.id !== childNode.id) {
-              callback(node, childNode, edges);
+            //if (node.id !== childNode.id) {
+            if (node.id != childNode.id) {      // '!=' because id's can be string and numeric
+              callback(node, childNode, edge);
               crawler(childNode, tree);
             }
           }
@@ -1558,6 +1589,44 @@ class LayoutEngine {
 
     return 0.5 * (minPos + maxPos);
   }
+
+
+  /**
+   * Get a list of node id's which are *not* part of a cluster.
+   *
+   * This will include the clusters themselves.
+   *
+   * @return {array} Array of node id's
+   * @private
+   * /
+  _getUnclusteredNodes() {
+    // Determine id's of all nodes in clusters
+    let clustered = [];
+
+    for (let id1 in this.body.nodes) {
+      if (this.body.nodes.hasOwnProperty(id1)) {
+        let node = this.body.nodes[id1];
+        if (node.isCluster === true) {
+          for (let id2 in node.containedNodes) {
+            clustered.push(id2);
+          }
+        }
+      }
+    }
+
+    // Determine the inverse of the list of clustered nodes
+    let unclustered = []
+    for (let id in this.body.nodes) {
+      if (this.body.nodes.hasOwnProperty(id)) {
+        if (clustered.indexOf(id) === -1) {
+          unclustered.push(id);
+        }
+      }
+    }
+
+    return unclustered;
+  }
+*/
 }
 
 export default LayoutEngine;


### PR DESCRIPTION
Fix for #1105.

Clustering actually works with hierarchical layouts; however, the *initialization* of a clustered network with hierarchical layout had issues. This PR fixes this particular case.

The problem was that the hierarchical initialization used **all of the nodes and edges** to set up the layout, **including the nodes and edges hidden within clusters**. This has been fixed by only dealing with the nodes and edges *active (or visible)* in the clustering layout.

In addition, the following changes:
- Added the above insight as a comment at the initialization of `Network.body`, where the node and edge data is stored, for posterity.
- For initialization by `hubsize`, adjusted the retrieval of hubsizes so that it is done with a single call for all hubsizes. This is contrast to the original method of determining the largest hubsize whenever it was needed.


----
Here is a [jsbin demo](http://jsbin.com/kulega/edit?html,output) of the fix.

Compare this with the [original demo](http://jsbin.com/rukevih/edit?html,output). You will need to change the reference to the used `vis.js` to:

```
<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.20.0/vis.js"></script>
```
