### PR TITLE
Protect Network from zero and negative mass values

### DIFF
--- a/docs/network/nodes.html
+++ b/docs/network/nodes.html
@@ -809,7 +809,10 @@ network.setOptions(options);
             <td>Number</td>
             <td><code>1</code></td>
             <td>The barnesHut physics model (which is enabled by default) is based on an inverted gravity model. By
-                increasing the mass of a node, you increase it's repulsion. Values lower than 1 are not recommended.
+                increasing the mass of a node, you increase it's repulsion.
+                <br><br>
+                Values between 0 and 1 are not recommended.<br>
+                Negative or zero values are not allowed. These will generate a console error and will be set to 1.
             </td>
         </tr>
         <tr>

--- a/examples/network/events/interactionEvents.html
+++ b/examples/network/events/interactionEvents.html
@@ -48,9 +48,7 @@
         nodes: nodes,
         edges: edges
     };
-
     var options = {interaction:{hover:true}};
-
     var network = new vis.Network(container, data, options);
 
     network.on("click", function (params) {

--- a/examples/network/events/interactionEvents.html
+++ b/examples/network/events/interactionEvents.html
@@ -48,7 +48,9 @@
         nodes: nodes,
         edges: edges
     };
+
     var options = {interaction:{hover:true}};
+
     var network = new vis.Network(container, data, options);
 
     network.on("click", function (params) {

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -130,7 +130,6 @@ class NodesHandler {
       y: undefined
     };
 
-
     // Protect from idiocy
     if (this.defaultOptions.mass <= 0) {
       throw 'Internal error: mass in defaultOptions of NodesHandler may not be zero or negative';

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -129,6 +129,13 @@ class NodesHandler {
       x: undefined,
       y: undefined
     };
+
+
+    // Protect from idiocy
+    if (this.defaultOptions.mass <= 0) {
+      throw 'Internal error: mass in defaultOptions of NodesHandler may not be zero or negative';
+    }
+
     util.extend(this.options, this.defaultOptions);
 
     this.bindEventListeners();

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -115,6 +115,8 @@ class Node {
       throw "Node must have an id";
     }
 
+    Node.checkMass(options, this.id);
+
     // set these options locally
     // clear x and y positions
     if (options.x !== undefined) {
@@ -209,6 +211,8 @@ class Node {
       'shadow'
     ];
     util.selectiveNotDeepExtend(fields, parentOptions, newOptions, allowDeletion);
+
+    Node.checkMass(newOptions);
 
     // merge the shadow options into the parent.
     util.mergeOptions(parentOptions, newOptions, 'shadow', allowDeletion, globalOptions);
@@ -538,6 +542,24 @@ class Node {
       this.shape.boundingBox.bottom > obj.top
     );
   }
+
+
+ /**
+  * Check valid values for mass
+  *
+  * The mass may not be negative or zero. If it is, reset to 1
+  */
+  static checkMass(options, id) {
+    if (options.mass !== undefined && options.mass <= 0) {
+      let strId = '';
+      if (id !== undefined) {
+        strId = ' in node id: ' + id;
+      }
+      console.log('%cNegative or zero mass disallowed' + strId +
+                  ', setting mass to 1.' , printStyle);
+      options.mass = 1;
+    }
+	}
 }
 
 export default Node;

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -559,7 +559,7 @@ class Node {
                   ', setting mass to 1.' , printStyle);
       options.mass = 1;
     }
-	}
+  }
 }
 
 export default Node;


### PR DESCRIPTION
Fix for #3133

Option-field `node.node.mass` must be >= 0.
Checks have been added at the nodes level, for both nodes-global and nodes specific options.
In addition, an internal check has been added for `NodeHandler.defaultOptions`.

The documentation has been adjusted for this change.