### PR TITLE
Adding caching to Range getMillisecondsPerPixel function

### DIFF
--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -16,7 +16,8 @@ function Range(body, options) {
   var now = moment().hours(0).minutes(0).seconds(0).milliseconds(0);
   var start = now.clone().add(-3, 'days').valueOf();
   var end = now.clone().add(3, 'days').valueOf(); 
-
+  this.millisecondsPerPixelCache = undefined;
+  
   if(options === undefined) {
     this.start = start;
     this.end = end;
@@ -200,6 +201,7 @@ Range.prototype.setRange = function(start, end, options, callback) {
   var finalStart = start != undefined ? util.convert(start, 'Date').valueOf() : null;
   var finalEnd   = end != undefined   ? util.convert(end, 'Date').valueOf()   : null;
   this._cancelAnimation();
+  this.millisecondsPerPixelCache = undefined;
 
   if (options.animation) { // true or an Object
     var initStart = this.start;
@@ -280,7 +282,10 @@ Range.prototype.setRange = function(start, end, options, callback) {
  * Get the number of milliseconds per pixel.
  */
 Range.prototype.getMillisecondsPerPixel = function() {
-  return (this.end - this.start) / this.body.dom.center.clientWidth;
+  if (this.millisecondsPerPixelCache === undefined) {
+    this.millisecondsPerPixelCache = (this.end - this.start) / this.body.dom.center.clientWidth;
+  }
+  return this.millisecondsPerPixelCache;
 }
 
 /**


### PR DESCRIPTION
Adding some caching (a better name would be _memoization_) to Range.prototype.getMillisecondsPerPixel.

In my case, this function was responsible for quite some time (see attached chrome profiling), and from what I could understand, I could cache the results quite easily (as the results only changes after a "setRange").

Some bench marking, while adding some points to the timeline:

```
#items	4.20.1-snapshot		withCache
500	5.147s			2.844s
1000	19.879s			11.635s
2000	76.248s			48.438s
```
We can see some clear improvements (and the quadratic behavior!)

![getmillisecondsperpixel](https://user-images.githubusercontent.com/1238919/26980765-120cac4e-4d01-11e7-9286-62db2b2b22c5.PNG)

