### PR TITLE
Ensure first and last of stabilization progress events are sent

### DIFF
--- a/lib/network/modules/PhysicsEngine.js
+++ b/lib/network/modules/PhysicsEngine.js
@@ -638,20 +638,31 @@ class PhysicsEngine {
    * @private
    */
   _stabilizationBatch() {
+    var self = this;
+    var running = () => (self.stabilized === false && self.stabilizationIterations < self.targetIterations);
+    var sendProgress = () => {
+      self.body.emitter.emit('stabilizationProgress', {
+        iterations: self.stabilizationIterations,
+        total: self.targetIterations
+      });
+    };
+
     // this is here to ensure that there is at least one start event.
     if (this.startedStabilization === false) {
       this.body.emitter.emit('startStabilizing');
       this.startedStabilization = true;
+      sendProgress();
     }
 
     var count = 0;
-    while (this.stabilized === false && count < this.options.stabilization.updateInterval && this.stabilizationIterations < this.targetIterations) {
+    while (running() && count < this.options.stabilization.updateInterval) {
       this.physicsTick();
       count++;
     }
 
-    if (this.stabilized === false && this.stabilizationIterations < this.targetIterations) {
-      this.body.emitter.emit('stabilizationProgress', {iterations: this.stabilizationIterations, total: this.targetIterations});
+    sendProgress();
+
+    if (running()) {
       setTimeout(this._stabilizationBatch.bind(this),0);
     }
     else {


### PR DESCRIPTION
Fix for #3160

Event `stabilizationProgress` is now always sent for iteration 0 and for the very last stabilization iteration.
