### PR TITLE
Prevent crashes from invalid id's in `Clustering.findNode()`

### DIFF
--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -611,13 +611,18 @@ var locales = {
             </tr>
             <tr class="collapsible toggle" onclick="toggleTable('methodTable','findNode', this);">
                 <td colspan="2"><span parent="findNode" class="right-caret" id="method_findNode"></span> findNode(
-                    <code>String nodeId</code>)
+                    <code>String/Number nodeId</code>)
             </tr>
             <tr class="hidden" parent="findNode">
                 <td class="midMethods">Returns: Array</td>
                 <td>Nodes can be in clusters. Clusters can also be in clusters. This function returns and array of
-                    nodeIds
-                    showing where the node is. <br><br> Example:
+                    nodeIds showing where the node is.
+
+                    <br><br>
+                    If any nodeId in the chain, especially the first passed in as a parameter, is not present in
+                    the current nodes list, an empty array is returned.
+
+                    <br><br> Example:
                     cluster 'A' contains cluster 'B',
                     cluster 'B' contains cluster 'C',
                     cluster 'C' contains node 'fred'.

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -689,22 +689,32 @@ class ClusterEngine {
 
   /**
   * Get the stack clusterId's that a certain node resides in. cluster A -> cluster B -> cluster C -> node
-  * @param nodeId
+  *
+  * If a node can't be found in the chain, return an empty array.
+  *
+  * @param {string|number} nodeId
   * @returns {Array}
   */
   findNode(nodeId) {
     let stack = [];
     let max = 100;
     let counter = 0;
+    let node;
 
     while (this.clusteredNodes[nodeId] !== undefined && counter < max) {
-      stack.push(this.body.nodes[nodeId].id);
+      node = this.body.nodes[nodeId]
+      if (node === undefined) return [];
+      stack.push(node.id);
+
       nodeId = this.clusteredNodes[nodeId].clusterId;
       counter++;
     }
-    stack.push(this.body.nodes[nodeId].id);
-    stack.reverse();
 
+    node = this.body.nodes[nodeId]
+    if (node === undefined) return [];
+    stack.push(node.id);
+
+    stack.reverse();
     return stack;
   }
 
@@ -726,6 +736,8 @@ class ClusterEngine {
   * Using a base edgeId, update all related clustered edges with the new options
   * @param startEdgeId
   * @param {object} newOptions
+  *
+  * NOTE: never ever called!
   */
   updateEdge(startEdgeId, newOptions) {
     if (startEdgeId === undefined) {throw new Error("No startEdgeId supplied to updateEdge.");}
@@ -744,6 +756,8 @@ class ClusterEngine {
   * Get a stack of clusterEdgeId's (+base edgeid) that a base edge is the same as. cluster edge C -> cluster edge B -> cluster edge A -> base edge(edgeId)
   * @param edgeId
   * @returns {Array}
+  *
+  * NOTE: Only called in `updateEdge()`, which is never used!
   */
   getClusteredEdges(edgeId) {
     let stack = [];

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -736,8 +736,6 @@ class ClusterEngine {
   * Using a base edgeId, update all related clustered edges with the new options
   * @param startEdgeId
   * @param {object} newOptions
-  *
-  * NOTE: never ever called!
   */
   updateEdge(startEdgeId, newOptions) {
     if (startEdgeId === undefined) {throw new Error("No startEdgeId supplied to updateEdge.");}
@@ -756,8 +754,6 @@ class ClusterEngine {
   * Get a stack of clusterEdgeId's (+base edgeid) that a base edge is the same as. cluster edge C -> cluster edge B -> cluster edge A -> base edge(edgeId)
   * @param edgeId
   * @returns {Array}
-  *
-  * NOTE: Only called in `updateEdge()`, which is never used!
   */
   getClusteredEdges(edgeId) {
     let stack = [];


### PR DESCRIPTION
Fix for #3163

- Added safeguards in said method, to prevent exceptions happening when invalid id's are passed in.
- Adjusted documentation for said method