### PR TITLE
Adjusting timeline TimeStep.roundToMinor - fixes #3105

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -148,6 +148,10 @@ TimeStep.prototype.start = function() {
  */
 TimeStep.prototype.roundToMinor = function() {
   // round to floor
+  // to prevent year & month scales rounding down to the first day of week we perform this separately
+  if (this.scale == 'week') {
+    this.current.weekday(0);
+  }
   // IMPORTANT: we have no breaks in this switch! (this is no bug)
   // noinspection FallThroughInSwitchStatementJS
   switch (this.scale) {
@@ -155,7 +159,7 @@ TimeStep.prototype.roundToMinor = function() {
       this.current.year(this.step * Math.floor(this.current.year() / this.step));
       this.current.month(0);
     case 'month':        this.current.date(1);
-    case 'week':         this.current.weekday(0);
+    case 'week':         // intentional fall through
     case 'day':          // intentional fall through
     case 'weekday':      this.current.hours(0);
     case 'hour':         this.current.minutes(0);

--- a/test/TimeStep.test.js
+++ b/test/TimeStep.test.js
@@ -41,4 +41,50 @@ describe('TimeStep', function () {
     assert.equal(timestep.scale, "second", "should have right scale");
     assert.equal(timestep.step, 10, "should have right step size");
   });
+
+  it('should perform the step with a specified scale (1 year)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5));
+    timestep.setScale({ scale: 'year', step: 1 });
+    timestep.start();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-01-01T00:00:00.000").unix(), "should have the right initial value");
+    timestep.next();
+    assert.equal(timestep.getCurrent().unix(), moment("2018-01-01T00:00:00.000").unix(), "should have the right value after a step");
+  });
+
+  it('should perform the step with a specified scale (1 month)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5));
+    timestep.setScale({ scale: 'month', step: 1 });
+    timestep.start();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-04-01T00:00:00.000").unix(), "should have the right initial value");
+    timestep.next();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-05-01T00:00:00.000").unix(), "should have the right value after a step");
+  });
+
+  it('should perform the step with a specified scale (1 week)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5));
+    timestep.setScale({ scale: 'week', step: 1 });
+    timestep.start();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-04-02T00:00:00.000").unix(), "should have the right initial value");
+    timestep.next();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-04-09T00:00:00.000").unix(), "should have the right value after a step");
+  });
+
+  it('should perform the step with a specified scale (1 day)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5));
+    timestep.setScale({ scale: 'day', step: 1 });
+    timestep.start();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-04-03T00:00:00.000").unix(), "should have the right initial value");
+    timestep.next();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-04-04T00:00:00.000").unix(), "should have the right value after a step");
+  });
+
+  it('should perform the step with a specified scale (1 hour)', function () {
+    var timestep = new TimeStep(new Date(2017, 3, 3), new Date(2017, 3, 5));
+    timestep.setScale({ scale: 'hour', step: 1 });
+    timestep.start();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-04-03T00:00:00.000").unix(), "should have the right initial value");
+    timestep.next();
+    assert.equal(timestep.getCurrent().unix(), moment("2017-04-03T01:00:00.000").unix(), "should have the right value after a step");
+  });
+
 });


### PR DESCRIPTION
- `TimeStep.roundToMinor` function was shifting year and month steps down to the first day of the week.
- Added tests for TimeStep to check the `step` is now working as expected.
- Should fix issue #3105 