### PR TITLE
Fixes #3183

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1342,6 +1342,12 @@ ItemSet.prototype._onDragStart = function (event) {
       this.touchParams.itemProps = [props];
     }
     else {
+      if(this.groupIds.length < 1) {
+        // Mitigates a race condition if _onDragStart() is
+        // called after markDirty() without redraw() being called between.
+        this.redraw();
+      }
+      
       var baseGroupIndex = this._getGroupIndex(item.data.group);
 
       var itemsToDrag = (this.options.itemsAlwaysDraggable.item && !item.selected) ? [item.id] : this.getSelection();


### PR DESCRIPTION
Fixes a race condition that set an item's group to be set to undefined
if it was dropped and then dragged again without a redraw happening in
between.