### PR TITLE
Reverse nodes returned with 'from' and 'to' directions

### DIFF
--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -425,13 +425,13 @@ class NodesHandler {
       let nodeObj = {}; // used to quickly check if node already exists
       for (let i = 0; i < node.edges.length; i++) {
         let edge = node.edges[i];
-        if (direction !== 'from' && edge.toId == node.id) { // these are double equals since ids can be numeric or string
+        if (direction !== 'to' && edge.toId == node.id) { // these are double equals since ids can be numeric or string
           if (nodeObj[edge.fromId] === undefined) {
             nodeList.push(edge.fromId);
             nodeObj[edge.fromId] = true;
           }
         }
-        else if (direction !== 'to' && edge.fromId == node.id) { // these are double equals since ids can be numeric or string
+        else if (direction !== 'from' && edge.fromId == node.id) { // these are double equals since ids can be numeric or string
           if (nodeObj[edge.toId] === undefined) {
             nodeList.push(edge.toId);
             nodeObj[edge.toId] = true;


### PR DESCRIPTION
Fix for PR #3108.

The returned node id's were exactly the wrong way around;
'to' returned the parents, 'from' returned the children.

This fix swaps the tests for determining which to return.