### PR TITLE
Small fix on ref usage in DataGroup

### DIFF
--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -36,8 +36,6 @@ function DataGroup() {
  * @param {Number}   style   Style Number
  */
 DataGroup.prototype.initializeData = function(graph3d, rawData, style) {
-  var me = this;
-
   // unsubscribe from the dataTable
   if (this.dataSet) {
     this.dataSet.off('*', this._onChange);
@@ -65,8 +63,9 @@ DataGroup.prototype.initializeData = function(graph3d, rawData, style) {
   this.dataTable = data;
 
   // subscribe to changes in the dataset
+  var me = this;
   this._onChange = function () {
-    me.setData(me.dataSet);
+    graph3d.setData(me.dataSet);
   };
   this.dataSet.on('*', this._onChange);
 


### PR DESCRIPTION
Fix on something I stumbled upon when updating the  `DataSet` instance connected to a `Graph3D`.

Ref `me` in a callback should be a ref to a `Graph3d` instance.