### PR TITLE
Set dimensions properly of images on initialization.

### DIFF
--- a/lib/network/CachedImage.js
+++ b/lib/network/CachedImage.js
@@ -23,6 +23,7 @@ class CachedImage {
   init() {
     if (this.initialized()) return;
 
+    this.src = this.image.src;  // For same interface with Image
     var w = this.image.width;
     var h = this.image.height;
 

--- a/lib/network/modules/components/nodes/shapes/Image.js
+++ b/lib/network/modules/components/nodes/shapes/Image.js
@@ -10,6 +10,17 @@ class Image extends CircleImageBase {
   }
 
   resize(ctx, selected = this.selected, hover = this.hover) {
+    var imageAbsent = (this.imageObj.src === undefined) ||
+        (this.imageObj.width === undefined) ||
+        (this.imageObj.height === undefined);
+
+    if (imageAbsent) {
+      var side = this.options.size * 2;
+      this.width = side;
+      this.height = side;
+			return;
+    }
+
     if (this.needsRefresh(selected, hover)) {
       this._resizeImage();
     }

--- a/lib/network/modules/components/nodes/shapes/Image.js
+++ b/lib/network/modules/components/nodes/shapes/Image.js
@@ -18,7 +18,7 @@ class Image extends CircleImageBase {
       var side = this.options.size * 2;
       this.width = side;
       this.height = side;
-			return;
+      return;
     }
 
     if (this.needsRefresh(selected, hover)) {


### PR DESCRIPTION
Fix for #3203

Image nodes were assigned the default size on initialization, leading to very compressed images.
This fix adjusts the default size as soon as the images used have been loaded.

The approach for dealing with this has been adapted from `CircularImage`.
