### PR TITLE
Enable 'eslint'

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,13 +6,17 @@
     "mocha": true
   },
 
-  "parser": "babel-eslint",
+  "parserOptions": {
+    "sourceType": "module",
+  },
 
   "extends": "eslint:recommended",
 
   "rules": {
     "complexity": [2, 55],
     "max-statements": [2, 115],
+    "no-unreachable": 1,
+/*
     "no-console": 0,
     "no-empty": 0,
     "no-extra-semi": 0,
@@ -20,7 +24,10 @@
     "no-inner-declarations": 0,
     "no-mixed-spaces-and-tabs": 0,
     "no-redeclare": 0,
-    "no-unreachable": 1,
     "no-unused-vars": 0,
+
+// new:
+    "no-console": ["error", { allow: ["warn", "error"] }],
+*/
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "max-statements": [2, 115],
     "no-unreachable": 1,
 /*
+    // some disabled options which might be useful
     "no-console": 0,
     "no-empty": 0,
     "no-extra-semi": 0,
@@ -26,7 +27,7 @@
     "no-redeclare": 0,
     "no-unused-vars": 0,
 
-// new:
+    // following will flag presence of console.log as error.
     "no-console": ["error", { allow: ["warn", "error"] }],
 */
   }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: "6"
 before_script:
-  - npm run lint
+#  - npm run lint
   - npm install -g gulp
 script:
   - gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js: "6"
 before_script:
 #  - npm run lint
-  - npm install -g gulp
+  - npm install gulp
 script:
   - gulp
   - npm test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var async = require('async');
 var gulp = require('gulp');
+var eslint = require('gulp-eslint');
 var gutil = require('gulp-util');
 var concat = require('gulp-concat');
 var cleanCSS = require('gulp-clean-css');
@@ -217,3 +218,11 @@ gulp.task('watch', watchTasks, function () {
 
 // The default task (called when you run `gulp`)
 gulp.task('default', ['clean', 'bundle', 'minify']);
+
+gulp.task('lint', function () {
+  //return gulp.src(['lib/**/*.js', '!node_modules/**'])
+  return gulp.src(['lib/graph3d/**/*.js', '!node_modules/**'])
+    .pipe(eslint())
+    .pipe(eslint.format())
+    .pipe(eslint.failAfterError());
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -216,13 +216,39 @@ gulp.task('watch', watchTasks, function () {
   gulp.watch(['index.js', 'lib/**/*'], watchTasks);
 });
 
-// The default task (called when you run `gulp`)
-gulp.task('default', ['clean', 'bundle', 'minify']);
 
-gulp.task('lint', function () {
-  //return gulp.src(['lib/**/*.js', '!node_modules/**'])
-  return gulp.src(['lib/graph3d/**/*.js', '!node_modules/**'])
+////////////////////////////////////////////////////////////////////////////////////////
+// Linting
+//
+// Linting has intentionally NOT been added yet to the default task; there are simply
+// too many errors at the moment to make this comfortable. Run it separately with:
+//
+//    > gulp lint    or   > gulp lint-<module name>
+//
+// This is set up so that 'gulp lint' runs the linting over the complete lib directory.
+// You can also run linting on the separate modules, e.g. 'gulp lint-network' for just
+// the network module. Scan the tasks below for the available lint commands.
+//
+// Note that currently a separate lint is missing for Graph2d,  DataSet and DataGroup.
+////////////////////////////////////////////////////////////////////////////////////////
+
+
+function runLintTask(pathPrefix) {
+  return gulp.src([ pathPrefix + '/**/*.js', '!node_modules/**'])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());
-});
+}
+
+gulp.task('lint',          function () {return runLintTask('lib');});
+gulp.task('lint-timeline', function () {return runLintTask('lib/timeline');});
+gulp.task('lint-network',  function () {return runLintTask('lib/network');});
+gulp.task('lint-graph3d',  function () {return runLintTask('lib/graph3d');});
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// End Linting
+////////////////////////////////////////////////////////////////////////////////////////
+
+// The default task (called when you run `gulp`)
+gulp.task('default', ['clean', 'bundle', 'minify']);

--- a/lib/graph3d/Camera.js
+++ b/lib/graph3d/Camera.js
@@ -47,11 +47,11 @@ Camera.prototype.setOffset = function(x, y) {
   this.calculateCameraOrientation();
 };
 
+
 /**
  * Get camera offset by horizontal and vertical
- * @return {Point3d} x - horizontal offset, y - vertical offset, z - not used
  */
-Camera.prototype.getOffset = function(x, y) {
+Camera.prototype.getOffset = function() {
   return this.cameraOffset;
 };
 
@@ -165,7 +165,6 @@ Camera.prototype.calculateCameraOrientation = function() {
   this.cameraRotation.z = -this.armRotation.horizontal;
 
   var xa = this.cameraRotation.x;
-  var ya = this.cameraRotation.y;
   var za = this.cameraRotation.z;
   var dx = this.cameraOffset.x;
   var dy = this.cameraOffset.y;

--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -1,6 +1,5 @@
 var DataSet  = require('../DataSet');
 var DataView = require('../DataView');
-var Point3d  = require('./Point3d');
 var Range    = require('./Range');
 
 

--- a/lib/graph3d/Filter.js
+++ b/lib/graph3d/Filter.js
@@ -35,7 +35,7 @@ function Filter (dataGroup, column, graph) {
   else {
     this.loaded = true;
   }
-};
+}
 
 
 /**
@@ -176,9 +176,6 @@ Filter.prototype.loadInBackground = function(index) {
   var frame = this.graph.frame;
 
   if (index < this.values.length) {
-    var dataPointsTemp = this._getDataPoints(index);
-    //this.graph.redrawInfo(); // TODO: not neat
-
     // create a progress box
     if (frame.progress === undefined) {
       frame.progress = document.createElement('DIV');

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1,14 +1,10 @@
 var Emitter = require('emitter-component');
-var DataSet = require('../DataSet');
-var DataView = require('../DataView');
 var util = require('../util');
 var Point3d = require('./Point3d');
 var Point2d = require('./Point2d');
-var Camera = require('./Camera');
 var Filter = require('./Filter');
 var Slider = require('./Slider');
 var StepNumber = require('./StepNumber');
-var Range = require('./Range');
 var Settings = require('./Settings');
 var DataGroup = require('./DataGroup');
 
@@ -1126,6 +1122,7 @@ Graph3d.prototype._redrawAxis = function() {
   var xRange = this.xRange;
   var yRange = this.yRange;
   var zRange = this.zRange;
+  var point3d;
 
   // draw x-grid lines
   ctx.lineWidth = 1;
@@ -1153,8 +1150,8 @@ Graph3d.prototype._redrawAxis = function() {
 
     if (this.showXAxis) {
       yText       = (armVector.x > 0) ? yRange.min : yRange.max;
-      var point3d = new Point3d(x, yText, zRange.min);
-      var msg     = '  ' + this.xValueLabel(x) + '  ';
+      point3d = new Point3d(x, yText, zRange.min);
+      let msg     = '  ' + this.xValueLabel(x) + '  ';
       this.drawAxisLabelX(ctx, point3d, msg, armAngle, textMargin);
     }
 
@@ -1188,7 +1185,7 @@ Graph3d.prototype._redrawAxis = function() {
     if (this.showYAxis) {
       xText   = (armVector.y > 0) ? xRange.min : xRange.max;
       point3d = new Point3d(xText, y, zRange.min);
-      var msg = '  ' + this.yValueLabel(y) + '  ';
+      let msg = '  ' + this.yValueLabel(y) + '  ';
       this.drawAxisLabelY(ctx, point3d, msg, armAngle, textMargin);
     }
 
@@ -1214,7 +1211,7 @@ Graph3d.prototype._redrawAxis = function() {
       to = new Point2d(from2d.x - textMargin, from2d.y);
       this._line(ctx, from2d, to, this.axisColor);
 
-      var msg = this.zValueLabel(z) + ' ';
+      let msg = this.zValueLabel(z) + ' ';
       this.drawAxisLabelZ(ctx, from3d, msg, 5);
 
       step.next();
@@ -1340,7 +1337,7 @@ Graph3d.prototype._getStrokeWidth = function(point) {
  * Draw a bar element in the view with the given properties.
  */
 Graph3d.prototype._redrawBar = function(ctx, point, xWidth, yWidth, color, borderColor) {
-  var i, j, surface;
+  var surface;
 
   // calculate all corner points
   var me = this;
@@ -1378,7 +1375,7 @@ Graph3d.prototype._redrawBar = function(ctx, point, xWidth, yWidth, color, borde
   point.surfaces = surfaces;
 
   // calculate the distance of each of the surface centers to the camera
-  for (j = 0; j < surfaces.length; j++) {
+  for (let j = 0; j < surfaces.length; j++) {
     surface = surfaces[j];
     var transCenter = this._convertPointToTranslation(surface.center);
     surface.dist = this.showPerspective ? transCenter.length() : -transCenter.z;
@@ -1405,7 +1402,7 @@ Graph3d.prototype._redrawBar = function(ctx, point, xWidth, yWidth, color, borde
   ctx.strokeStyle = borderColor;
   ctx.fillStyle = color;
   // NOTE: we start at j=2 instead of j=0 as we don't need to draw the two surfaces at the backside
-  for (j = 2; j < surfaces.length; j++) {
+  for (let j = 2; j < surfaces.length; j++) {
     surface = surfaces[j];
     this._polygon(ctx, surface.corners);
   }

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -437,7 +437,7 @@ Graph3d.prototype.getDataPoints = function(data) {
 Graph3d.prototype._getDataPoints = function (data) {
   // TODO: store the created matrix dataPoints in the filters instead of
   //       reloading each time.
-  var x, y, i, z, obj, point;
+  var x, y, i, obj;
 
   var dataPoints = [];
 
@@ -490,7 +490,7 @@ Graph3d.prototype._getDataPoints = function (data) {
       // Add next member points for line drawing
       for (i = 0; i < dataPoints.length; i++) {
         if (i > 0) {
-          dataPoints[i - 1].pointNext = dataPoints[i];;
+          dataPoints[i - 1].pointNext = dataPoints[i];
         }
       }
     }
@@ -688,8 +688,6 @@ Graph3d.prototype.setData = function (data) {
  * @param {Object} options
  */
 Graph3d.prototype.setOptions = function (options) {
-  var cameraPosition = undefined;
-
   this.animationStop();
 
   Settings.setOptions(options, this);
@@ -910,7 +908,6 @@ Graph3d.prototype._redrawLegend = function() {
   var step = new StepNumber(legendMin, legendMax, (legendMax-legendMin)/5, true);
   step.start(true);
 
-  var y;
   var from;
   var to;
   while (!step.end()) {
@@ -1650,7 +1647,6 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
   var topSideVisible = true;
   var fillStyle;
   var strokeStyle;
-  var lineWidth;
 
   if (this.showGrayBottom || this.showShadow) {
     // calculate the cross product of the two vectors from center

--- a/lib/graph3d/Point3d.js
+++ b/lib/graph3d/Point3d.js
@@ -8,7 +8,7 @@ function Point3d(x, y, z) {
   this.x = x !== undefined ? x : 0;
   this.y = y !== undefined ? y : 0;
   this.z = z !== undefined ? z : 0;
-};
+}
 
 /**
  * Subtract the two provided points, returns a-b

--- a/lib/graph3d/Slider.js
+++ b/lib/graph3d/Slider.js
@@ -184,7 +184,7 @@ Slider.prototype.setPlayInterval = function(interval) {
  * Retrieve the current play interval
  * @return {Number} interval   The interval in milliseconds
  */
-Slider.prototype.getPlayInterval = function(interval) {
+Slider.prototype.getPlayInterval = function() {
   return this.playInterval;
 };
 
@@ -333,7 +333,7 @@ Slider.prototype._onMouseMove = function (event) {
 };
 
 
-Slider.prototype._onMouseUp = function (event) {
+Slider.prototype._onMouseUp = function (event) {  // eslint-disable-line no-unused-vars
   this.frame.style.cursor = 'auto';
 
   // remove event listeners

--- a/lib/graph3d/StepNumber.js
+++ b/lib/graph3d/StepNumber.js
@@ -33,7 +33,7 @@ function StepNumber(start, end, step, prettyStep) {
 
   this._current = 0;
   this.setRange(start, end, step, prettyStep);
-};
+}
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "async": "^2.1.4",
     "babel-core": "^6.6.5",
-    "babel-eslint": "^7.1.1",
     "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.22.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
@@ -50,7 +49,8 @@
     "babelify": "^7.3.0",
     "clean-css": "^4.0.2",
     "eslint": "^3.15.0",
-    "gulp": "^3.9.1",
+    "gulp-eslint": "^4.0.0",
+    "gulp-clean-css": "^2.3.2",
     "gulp-clean-css": "^2.3.2",
     "gulp-concat": "^2.6.1",
     "gulp-rename": "^1.2.2",


### PR DESCRIPTION
This enables linting for `vis.js`.

- Replaces the `babel-eslint` (has issues) with `gulp-eslint`
- Has been added to `package.json`, so it should be automatically installed.
-  Linting has intentionally **not** been added yet to the default task; there are simply  too many errors at the moment to make this comfortable
- Can be run as follows:

```
 > gulp lint            # Run over all of vis.js
 > gulp lint-graph3d
 > gulp lint-network
 > gulp lint-timeline
```

The linting has been run over `Graph3d`, results are added here for reference of what changes this brings.

On the whole, I'm pretty happy with `eslint`; I hope it comes in regular use.
