### PR TITLE
Update hierarchy when node level changes

### DIFF
--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -17,7 +17,7 @@ class NodesHandler {
 
     this.nodesListeners = {
       add: (event, params) => { this.add(params.items); },
-      update: (event, params) => { this.update(params.items, params.data); },
+      update: (event, params) => { this.update(params.items, params.data, params.oldData); },
       remove: (event, params) => { this.remove(params.items); }
     };
 
@@ -273,10 +273,12 @@ class NodesHandler {
 
   /**
    * Update existing nodes, or create them when not yet existing
-   * @param {Number[] | String[]} ids
+   * @param {Number[] | String[]} ids id's of changed nodes
+   * @param {Array} changedData array with changed data
+   * @param {Array|undefined} oldData optional; array with previous data
    * @private
    */
-  update(ids, changedData) {
+  update(ids, changedData, oldData) {
     let nodes = this.body.nodes;
     let dataChanged = false;
     for (let i = 0; i < ids.length; i++) {
@@ -285,7 +287,9 @@ class NodesHandler {
       let data = changedData[i];
       if (node !== undefined) {
         // update node
-        dataChanged = node.setOptions(data);
+        if (node.setOptions(data) === true) {  // explicit test because setOptions() can return undefined
+          dataChanged = true;
+        }
       }
       else {
         dataChanged = true;
@@ -294,6 +298,24 @@ class NodesHandler {
         nodes[id] = node;
       }
     }
+
+    if (!dataChanged && oldData !== undefined) {
+      // Check for any changes which should trigger a layout recalculation
+      // For now, this is just 'level' for hierarchical layout
+      // Assumption: old and new data arranged in same order; at time of writing, this holds.
+      for (let i = 0; i < changedData.length; i++) {
+        let oldValue = oldData[i];
+        let newValue = changedData[i];
+
+        if (oldValue  !== undefined && newValue !== undefined) {  // paranoia
+          if (oldValue.level !== newValue.level) {
+            dataChanged = true;
+            break;  // One change is enough to trigger recalc
+          }
+        }
+      }
+    }
+
     if (dataChanged === true) {
       this.body.emitter.emit("_dataChanged");
     }

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -287,7 +287,7 @@ class NodesHandler {
       let data = changedData[i];
       if (node !== undefined) {
         // update node
-        if (node.setOptions(data) === true) {  // explicit test because setOptions() can return undefined
+        if (node.setOptions(data)) {
           dataChanged = true;
         }
       }
@@ -303,17 +303,10 @@ class NodesHandler {
       // Check for any changes which should trigger a layout recalculation
       // For now, this is just 'level' for hierarchical layout
       // Assumption: old and new data arranged in same order; at time of writing, this holds.
-      for (let i = 0; i < changedData.length; i++) {
-        let oldValue = oldData[i];
-        let newValue = changedData[i];
-
-        if (oldValue  !== undefined && newValue !== undefined) {  // paranoia
-          if (oldValue.level !== newValue.level) {
-            dataChanged = true;
-            break;  // One change is enough to trigger recalc
-          }
-        }
-      }
+      dataChanged = changedData.some(function(newValue, index) {
+        let oldValue = oldData[index];
+        return (oldValue && oldValue.level !== newValue.level);
+      });
     }
 
     if (dataChanged === true) {

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -105,7 +105,7 @@ class Node {
   setOptions(options) {
     let currentShape = this.options.shape;
     if (!options) {
-      return;
+      return;  // Note that the return value will be 'undefined'! This is OK.
     }
 
     // basic options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vis",
-  "version": "4.20.1",
+  "version": "4.20.1-SNAPSHOT",
   "description": "A dynamic, browser-based visualization library.",
   "homepage": "http://visjs.org/",
   "license": "(Apache-2.0 OR MIT)",


### PR DESCRIPTION
Fix for #3220

On change of data of an existing node, field `level` is checked for change.
If changed, force a recalculation of the hierarchical layout.

- The fix does not explicitly check for hierarchical layout; this should not be a problem.
- The added code can be used to add further node fields which may trigger recalculation of layout.
