### PR TITLE
Fix missing reference to Graph3D instance in DataGroup

### DIFF
--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -293,14 +293,4 @@ DataGroup.prototype.getDataSet = function() {
 };
 
 
-/**
- * Reload the data
- */
-DataGroup.prototype.reload = function() {
-  if (this.dataTable) {
-    this.setData(this.dataTable);
-  }
-};
-
-
 module.exports = DataGroup;

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -171,9 +171,7 @@ function Graph3d(container, data, options) {
   this.setOptions(options);
 
   // apply data
-  if (data) {
-    this.setData(data);
-  }
+  this.setData(data);
 }
 
 // Extend Graph3d with an Emitter mixin
@@ -677,6 +675,8 @@ Graph3d.prototype._readData = function(data) {
  * @param {Array | DataSet | DataView} data
  */
 Graph3d.prototype.setData = function (data) {
+  if (data === undefined || data === null) return;
+
   this._readData(data);
   this.redraw();
 
@@ -702,7 +702,7 @@ Graph3d.prototype.setOptions = function (options) {
   this._setSize(this.width, this.height);
 
   // re-load the data
-  this.dataGroup.reload();
+	this.setData(this.dataGroup.getDataTable());
 
   // start animation when option is true
   if (this.animationAutoStart && this.dataFilter) {

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -701,8 +701,7 @@ Graph3d.prototype.setOptions = function (options) {
   this.setPointDrawingMethod();
   this._setSize(this.width, this.height);
 
-  // re-load the data
-	this.setData(this.dataGroup.getDataTable());
+  this.setData(this.dataGroup.getDataTable());
 
   // start animation when option is true
   if (this.animationAutoStart && this.dataFilter) {


### PR DESCRIPTION
Fix for #3251.

A reference was missed in `DataGroup.reload()` during refactoring.
Rather than fix this method, it has been removed and the logic moved to `Graph3d`.
This makes for somewhat cleaner code.
