### PR TITLE
Fix missing comment end in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "complexity": [2, 55],
     "max-statements": [2, 115],
     "no-unreachable": 1,
+    "no-useless-escape": 0,
 /*
     // some disabled options which might be useful
     "no-console": 0,
@@ -26,8 +27,8 @@
     "no-mixed-spaces-and-tabs": 0,
     "no-redeclare": 0,
     "no-unused-vars": 0,
-     "no-useless-escape": 0,
     // following will flag presence of console.log as error.
     "no-console": ["error", { allow: ["warn", "error"] }],
+*/
   }
 }


### PR DESCRIPTION
Fix typo in #3262, ending `*/` of a block comment was missing.
Also disabled new test `no-useless-escape` for linting, because this triggers a bit too often for comfort.
