### PR TITLE
Fix manipulation examples for Network

### DIFF
--- a/examples/network/other/manipulationEditEdgeNoDrag.html
+++ b/examples/network/other/manipulationEditEdgeNoDrag.html
@@ -113,12 +113,12 @@
           addNode: function (data, callback) {
             // filling in the popup DOM elements
             document.getElementById('node-operation').innerHTML = "Add Node";
-            editNode(data, callback);
+            editNode(data, clearNodePopUp, callback);
           },
           editNode: function (data, callback) {
             // filling in the popup DOM elements
             document.getElementById('node-operation').innerHTML = "Edit Node";
-            editNode(data, callback);
+            editNode(data, cancelNodeEdit, callback);
           },
           addEdge: function (data, callback) {
             if (data.from == data.to) {
@@ -142,13 +142,14 @@
       network = new vis.Network(container, data, options);
     }
 
-    function editNode(data, callback) {
+    function editNode(data, cancelAction, callback) {
       document.getElementById('node-label').value = data.label;
       document.getElementById('node-saveButton').onclick = saveNodeData.bind(this, data, callback);
-      document.getElementById('node-cancelButton').onclick = clearNodePopUp.bind();
+      document.getElementById('node-cancelButton').onclick = cancelAction.bind(this, callback);
       document.getElementById('node-popUp').style.display = 'block';
     }
 
+    // Callback passed as parameter is ignored
     function clearNodePopUp() {
       document.getElementById('node-saveButton').onclick = null;
       document.getElementById('node-cancelButton').onclick = null;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1289,7 +1289,12 @@ exports.mergeOptions = function (mergeTarget, options, option, allowDeletion = f
       }
       else {
         if (options[option].enabled === undefined) {
-          mergeTarget[option].enabled = true;
+          if (globalOptions[option].enabled !== undefined) {
+            mergeTarget[option].enabled = globalOptions[option].enabled;
+          } else {
+            // assume this is the correct value
+            mergeTarget[option].enabled = true;
+          }
         }
         for (var prop in options[option]) {
           if (options[option].hasOwnProperty(prop)) {


### PR DESCRIPTION
**Note:** This is a small fix, should be easily reviewable.

Fix for #2856

- Toolbar gets reshown when cancelling edit node dialog
- No shadow displayed upon save in edit node dialog

The latter is actually a more general problem. Function `mergeOptions()` in `util.js`
made an assumption as to the correct value of field `enabled`. It now takes the value
from `globalOptions`, if present.