### PR TITLE
Allow DOM elements for node titles

### DIFF
--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -329,7 +329,7 @@ let allOptions = {
       __type__: { object }
     },
     size: { number },
-    title: { string, 'undefined': 'undefined' },
+    title: { string, dom, 'undefined': 'undefined' },
     value: { number, 'undefined': 'undefined' },
     widthConstraint: {
       minimum: { number },

--- a/lib/util.js
+++ b/lib/util.js
@@ -1238,10 +1238,16 @@ exports.selectiveBridgeObject = function (fields, referenceObject) {
 exports.bridgeObject = function (referenceObject) {
   if (typeof referenceObject == "object") {
     var objectTo = Object.create(referenceObject);
-    for (var i in referenceObject) {
-      if (referenceObject.hasOwnProperty(i)) {
-        if (typeof referenceObject[i] == "object") {
-          objectTo[i] = exports.bridgeObject(referenceObject[i]);
+    if (referenceObject instanceof Element) {
+      // Avoid bridging DOM objects
+      objectTo = referenceObject;
+    } else {
+      objectTo = Object.create(referenceObject);
+      for (var i in referenceObject) {
+        if (referenceObject.hasOwnProperty(i)) {
+          if (typeof referenceObject[i] == "object") {
+            objectTo[i] = exports.bridgeObject(referenceObject[i]);
+          }
         }
       }
     }


### PR DESCRIPTION
**Note:** This is a small fix and should be easy to review.

Fix for #2579

- Adjusted node title definition in `options.js` to allow DOM elements
- Changed `BridgeObject()` in `util.js` so that DOM elements are *not* bridged.
