### PR TITLE
Graph3d put guards before unsubscription in DataGroup

### DIFF
--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -35,13 +35,7 @@ function DataGroup() {
  * @param {Number}   style   Style Number
  */
 DataGroup.prototype.initializeData = function(graph3d, rawData, style) {
-  // unsubscribe from the dataTable
-  if (this.dataSet) {
-    this.dataSet.off('*', this._onChange);
-  }
-
-  if (rawData === undefined)
-    return;
+  if (rawData === undefined) return;
 
   if (Array.isArray(rawData)) {
     rawData = new DataSet(rawData);
@@ -55,8 +49,12 @@ DataGroup.prototype.initializeData = function(graph3d, rawData, style) {
     throw new Error('Array, DataSet, or DataView expected');
   }
 
-  if (data.length == 0)
-    return;
+  if (data.length == 0) return;
+
+  // unsubscribe from the dataTable
+  if (this.dataSet) {
+    this.dataSet.off('*', this._onChange);
+  }
 
   this.dataSet = rawData;
   this.dataTable = data;


### PR DESCRIPTION
**Note:** This is a small fix and should be easy to review.

Second fix for #3251.

In method `DataGroup.initializeData()`, if the passed `rawData` is bad for some reason,
it was possible to lose the subscriptions due to early return from the method.

This fix changes the order in the method so that the guard clauses execute *before* the
subscription is changed.
