### PR TITLE
Fix check on missing reference in mergeOptions()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1295,7 +1295,7 @@ exports.mergeOptions = function (mergeTarget, options, option, allowDeletion = f
       }
       else {
         if (options[option].enabled === undefined) {
-          if (globalOptions[option].enabled !== undefined) {
+          if (globalOptions[option] !== undefined  && globalOptions[option].enabled !== undefined) {
             mergeTarget[option].enabled = globalOptions[option].enabled;
           } else {
             // assume this is the correct value


### PR DESCRIPTION
**Note:** This is a small fix and should be easy to debug.

This is a fix on the bug that triggered #3280. Added here separately, because #3280 might take a long time to review, and this is a pretty irritating bug. Please give this PR priority over #3280.

Added extra check in `util.mergeOptions() on presence of value in `globalOptions`. It was possible to get an exception due to this, e.g. when changing certain options.