### PR TITLE
Enable linting for Travis

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,23 +12,14 @@
 
   "extends": "eslint:recommended",
 
+  // For the full list of rules, see: http://eslint.org/docs/rules/
   "rules": {
     "complexity": [2, 55],
     "max-statements": [2, 115],
     "no-unreachable": 1,
+    "no-useless-escape": 0,
     "no-console": 0,
-    "no-useless-escape": 0
-/*
-    // some disabled options which might be useful
-    "no-empty": 0,
-    "no-extra-semi": 0,
-    "no-fallthrough": 0,
-    "no-inner-declarations": 0,
-    "no-mixed-spaces-and-tabs": 0,
-    "no-redeclare": 0,
-    "no-unused-vars": 0,
-    // following will flag presence of console.log as error.
-    "no-console": ["error", { allow: ["warn", "error"] }],
-*/
+    // To flag presence of console.log without breaking linting:
+    //"no-console": ["warn", { allow: ["warn", "error"] }],
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - libgif-dev
       - g++-4.8
 before_script:
-#  - npm run lint
+  - npm run lint
   - npm install gulp
 script:
   - gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -218,38 +218,19 @@ gulp.task('watch', watchTasks, function () {
 });
 
 
-////////////////////////////////////////////////////////////////////////////////////////
-// Linting
 //
-// Linting has intentionally NOT been added yet to the default task; there are simply
-// too many errors at the moment to make this comfortable. Run it separately with:
+// Linting usage:
 //
-//    > gulp lint    or   > gulp lint-<module name>
+//    > gulp lint
+// or > npm run lint
 //
-// This is set up so that 'gulp lint' runs the linting over the complete lib directory.
-// You can also run linting on the separate modules, e.g. 'gulp lint-network' for just
-// the network module. Scan the tasks below for the available lint commands.
-//
-// Note that currently a separate lint is missing for Graph2d,  DataSet and DataGroup.
-////////////////////////////////////////////////////////////////////////////////////////
-
-
-function runLintTask(pathPrefix) {
-  return gulp.src([ pathPrefix + '/**/*.js', '!node_modules/**'])
+gulp.task('lint', function () {
+  return gulp.src(['lib/**/*.js', '!node_modules/**'])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());
-}
+});
 
-gulp.task('lint',          function () {return runLintTask('lib');});
-gulp.task('lint-timeline', function () {return runLintTask('lib/timeline');});
-gulp.task('lint-network',  function () {return runLintTask('lib/network');});
-gulp.task('lint-graph3d',  function () {return runLintTask('lib/graph3d');});
-
-
-////////////////////////////////////////////////////////////////////////////////////////
-// End Linting
-////////////////////////////////////////////////////////////////////////////////////////
 
 // The default task (called when you run `gulp`)
 gulp.task('default', ['clean', 'bundle', 'minify']);

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -8,7 +8,7 @@ class ClusterEngine {
     this.clusteredNodes = {};  // Set of all nodes which are in a cluster
     this.clusteredEdges = {};  // Set of all edges replaced by a clustering edge
 
-    this.options = {};
+    this.options = {};;
     this.defaultOptions = {};
     util.extend(this.options, this.defaultOptions);
 

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -8,7 +8,7 @@ class ClusterEngine {
     this.clusteredNodes = {};  // Set of all nodes which are in a cluster
     this.clusteredEdges = {};  // Set of all edges replaced by a clustering edge
 
-    this.options = {};;
+    this.options = {};
     this.defaultOptions = {};
     util.extend(this.options, this.defaultOptions);
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "test": "mocha --compilers js:babel-core/register",
     "build": "gulp",
-    "lint": "eslint lib",
+    "lint": "gulp lint",
     "watch": "gulp watch",
     "watch-dev": "gulp watch --bundle"
   },


### PR DESCRIPTION
Fix for #2697.

Since all code has been linted (thanks @macleodbroad-wf!), it is now safe to enable linting for Travis.

Some cleanup actions have been performed; notably the additional `gulp` tasks for modules has
been removed. Since all code has been fixed for linting, these are not useful any more.
