### PR TITLE
Adds missing @extends/@constructor to jsdoc

### DIFF
--- a/lib/Queue.js
+++ b/lib/Queue.js
@@ -9,7 +9,7 @@
  *            - max: number      When the queue exceeds the given maximum number
  *                               of entries, the queue is flushed automatically.
  *                               Default value of max is Infinity.
- * @constructor
+ * @constructor Queue
  */
 function Queue(options) {
   // options

--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -16,7 +16,7 @@ var Point3d = require('./Point3d');
  *
  *     Error: Array, DataSet, or DataView expected
  *
- * @constructor
+ * @constructor DataGroup
  */
 function DataGroup() {
   this.dataTable = null;  // The original data table

--- a/lib/shared/Activator.js
+++ b/lib/shared/Activator.js
@@ -11,7 +11,7 @@ var util = require('../util');
  * the interactive contents of the element can be used. When clicked outside
  * the element, the elements mode is changed to inactive.
  * @param {Element} container
- * @constructor
+ * @constructor Activator
  */
 function Activator(container) {
   this.active = false;

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -9,7 +9,7 @@ var CustomTime = require('./component/CustomTime');
 
 /**
  * Create a timeline visualization
- * @constructor
+ * @constructor Core
  */
 function Core () {}
 

--- a/lib/timeline/Graph2d.js
+++ b/lib/timeline/Graph2d.js
@@ -22,7 +22,7 @@ var Validator = require('../shared/Validator').default;
  * @param {vis.DataSet | Array} [items]
  * @param {vis.DataSet | Array | vis.DataView | Object} [groups]
  * @param {Object} [options]  See Graph2d.setOptions for the available options.
- * @constructor
+ * @constructor Graph2d
  * @extends Core
  */
 function Graph2d (container, items, groups, options) {

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -10,6 +10,7 @@ var DateUtil = require('./DateUtil');
  * @param {{dom: Object, domProps: Object, emitter: Emitter}} body
  * @param {Object} [options]    See description at Range.setOptions
  * @constructor Range
+ * @extends Component
  */
 function Range(body, options) {
   var now = moment().hours(0).minutes(0).seconds(0).milliseconds(0);

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -23,7 +23,7 @@ var Validator = require('../shared/Validator').default;
  * @param {vis.DataSet | vis.DataView | Array} [items]
  * @param {vis.DataSet | vis.DataView | Array} [groups]
  * @param {Object} [options]  See Timeline.setOptions for the available options.
- * @constructor
+ * @constructor Timeline
  * @extends Core
  */
 function Timeline (container, items, groups, options) {

--- a/lib/timeline/component/BackgroundGroup.js
+++ b/lib/timeline/component/BackgroundGroup.js
@@ -5,6 +5,7 @@ var Group = require('./Group');
  * @param {Number | String} groupId
  * @param {Object} data
  * @param {ItemSet} itemSet
+ * @extends Group
  */
 function BackgroundGroup (groupId, data, itemSet) {
   Group.call(this, groupId, data, itemSet);

--- a/lib/timeline/component/DataScale.js
+++ b/lib/timeline/component/DataScale.js
@@ -8,7 +8,7 @@
  * @param {number} majorCharHeight
  * @param {boolean} zeroAlign
  * @param {function} formattingFunction
- * @constructor
+ * @constructor DataScale
  */
 function DataScale(start, end, autoScaleStart, autoScaleEnd, containerHeight, majorCharHeight, zeroAlign = false, formattingFunction=false) {
   this.majorSteps = [1, 2, 5, 10];

--- a/lib/timeline/component/GraphGroup.js
+++ b/lib/timeline/component/GraphGroup.js
@@ -11,7 +11,7 @@ var Points = require('./graph2d_types/points');
  * @param {array} groupsUsingDefaultStyles  | this array has one entree.
  *                                            It is passed as an array so it is passed by reference.
  *                                            It enumerates through the default styles
- * @constructor
+ * @constructor GraphGroup
  */
 function GraphGroup(group, groupId, options, groupsUsingDefaultStyles) {
   this.id = groupId;

--- a/lib/timeline/component/Legend.js
+++ b/lib/timeline/component/Legend.js
@@ -10,6 +10,7 @@ var Component = require('./Component');
  * @param {number} side
  * @param {vis.LineGraph.options} linegraphOptions
  * @constructor
+ * @extends Component
  */
 function Legend(body, options, side, linegraphOptions) {
   this.body = body;

--- a/lib/timeline/component/Legend.js
+++ b/lib/timeline/component/Legend.js
@@ -9,7 +9,7 @@ var Component = require('./Component');
  * @param {vis.Graph2d.options} options
  * @param {number} side
  * @param {vis.LineGraph.options} linegraphOptions
- * @constructor
+ * @constructor Legend
  * @extends Component
  */
 function Legend(body, options, side, linegraphOptions) {

--- a/lib/timeline/component/LineGraph.js
+++ b/lib/timeline/component/LineGraph.js
@@ -18,6 +18,7 @@ var UNGROUPED = '__ungrouped__'; // reserved group id for ungrouped items
  * @param {vis.Timeline.body} body
  * @param {Object} options
  * @constructor
+ * @extends Component
  */
 function LineGraph(body, options) {
   this.id = util.randomUUID();

--- a/lib/timeline/component/LineGraph.js
+++ b/lib/timeline/component/LineGraph.js
@@ -17,7 +17,7 @@ var UNGROUPED = '__ungrouped__'; // reserved group id for ungrouped items
  *
  * @param {vis.Timeline.body} body
  * @param {Object} options
- * @constructor
+ * @constructor LineGraph
  * @extends Component
  */
 function LineGraph(body, options) {

--- a/lib/timeline/component/graph2d_types/bar.js
+++ b/lib/timeline/component/graph2d_types/bar.js
@@ -5,7 +5,7 @@ var Points = require('./points');
  *
  * @param {vis.GraphGroup.id} groupId
  * @param {Object} options   // TODO: Describe options
- * @constructor
+ * @constructor Bargraph
  */
 function Bargraph(groupId, options) {  // eslint-disable-line no-unused-vars
 }

--- a/lib/timeline/component/graph2d_types/line.js
+++ b/lib/timeline/component/graph2d_types/line.js
@@ -4,7 +4,7 @@ var DOMutil = require('../../../DOMutil');
  *
  * @param {vis.GraphGroup.id} groupId
  * @param {Object} options   // TODO: Describe options
- * @constructor
+ * @constructor Line
  */
 function Line(groupId, options) {  // eslint-disable-line no-unused-vars
 }

--- a/lib/timeline/component/graph2d_types/points.js
+++ b/lib/timeline/component/graph2d_types/points.js
@@ -5,7 +5,7 @@ var DOMutil = require('../../../DOMutil');
  * @param {Number | String} groupId
  * @param {Object} options   // TODO: Describe options
  *
- * @constructor
+ * @constructor Points
  */
 function Points(groupId, options) {  // eslint-disable-line no-unused-vars
 }


### PR DESCRIPTION
Some classes that extend from others are missing @extends documentation and/or names for @constructor documentation.

@yotamberk 