### PR TITLE
Fix setting of edge color options via Network.setOptions()

### DIFF
--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -128,9 +128,9 @@ class EdgesHandler {
           // only forcibly remove the smooth curve if the data has been set of the edge has the smooth curves defined.
           // this is because a change in the global would not affect these curves.
           if (edgeData !== undefined) {
-            let edgeOptions = edgeData.smooth;
-            if (edgeOptions !== undefined) {
-              if (edgeOptions.enabled === true && edgeOptions.type === 'dynamic') {
+            let smoothOptions = edgeData.smooth;
+            if (smoothOptions !== undefined) {
+              if (smoothOptions.enabled === true && smoothOptions.type === 'dynamic') {
                 if (type === undefined) {
                   edge.setOptions({smooth: false});
                 }
@@ -367,6 +367,16 @@ class EdgesHandler {
   }
 
   create(properties) {
+    // It is not at all clear why all these separate options should be passed:
+    //
+    // - this.edgeOptions is set in setOptions()
+    //   the value of which is also added to this.options with parseOptions() 
+    // - this.defaultOptions has been added to this.options with util.extend() in ctor
+    //
+    // So, in theory, this.options should be enough.
+    // The only reason I can think of for this, is that precedence is important.
+    // TODO: make unit tests for this, to check if edgeOptions and defaultOptions are redundant
+    //
     return new Edge(properties, this.body, this.options, this.defaultOptions, this.edgeOptions)
   }
 

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -108,7 +108,7 @@ class EdgesHandler {
       value: undefined
     };
 
-    util.extend(this.options, this.defaultOptions);
+    util.deepExtend(this.options, this.defaultOptions);
 
     this.bindEventListeners();
   }
@@ -181,7 +181,7 @@ class EdgesHandler {
     this.edgeOptions = options;
     if (options !== undefined) {
       // use the parser from the Edge class to fill in all shorthand notations
-      Edge.parseOptions(this.options, options);
+      Edge.parseOptions(this.options, options, true, this.defaultOptions, true);
 
       // update smooth settings in all edges
       let dataChanged = false;

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -111,7 +111,8 @@ class Edge {
     return dataChanged;
   }
 
-  static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}) {
+
+  static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}, copyFromGlobals = false) {
     var fields = [
       'arrowStrikethrough',
       'id',
@@ -182,12 +183,17 @@ class Edge {
       let fromColor = newOptions.color;
       let toColor   = parentOptions.color;
 
-      // Clear local properties - need to do it like this in order to retain prototype bridges
-      for (var i in toColor) {
-        if (toColor.hasOwnProperty(i)) {
-          delete toColor[i];
-        }
-      } 
+      // If passed, fill in values from default options - required in the case of no prototype bridging
+      if (copyFromGlobals) {
+        util.deepExtend(toColor, globalOptions.color, false, allowDeletion);
+      } else {
+        // Clear local properties - need to do it like this in order to retain prototype bridges
+        for (var i in toColor) {
+          if (toColor.hasOwnProperty(i)) {
+            delete toColor[i];
+          }
+        } 
+      }
 
       if (util.isString(toColor)) {
         toColor.color     = toColor;
@@ -206,10 +212,10 @@ class Edge {
         if (fromColor.inherit   !== undefined) {toColor.inherit   = fromColor.inherit;}
         if (fromColor.opacity   !== undefined) {toColor.opacity   = Math.min(1,Math.max(0,fromColor.opacity));}
 
-        if (toColor.inherit === undefined) {
-          if (colorsDefined === true) {
-            toColor.inherit = false;
-          } else {
+        if (colorsDefined === true) {
+          toColor.inherit = false;
+        } else {
+          if (toColor.inherit === undefined) {
             toColor.inherit = 'from';  // Set default
           }
         }

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -1,30 +1,37 @@
 var util = require('../../../util');
 
 var Label = require('./shared/Label').default;
+var ComponentUtil = require('./shared/ComponentUtil').default;
 var CubicBezierEdge = require('./edges/CubicBezierEdge').default;
 var BezierEdgeDynamic = require('./edges/BezierEdgeDynamic').default;
 var BezierEdgeStatic = require('./edges/BezierEdgeStatic').default;
 var StraightEdge = require('./edges/StraightEdge').default;
 
 /**
- * A edge connects two nodes
- * @param {Object} properties     Object with options. Must contain
- *                                At least options from and to.
- *                                Available options: from (number),
- *                                to (number), label (string, color (string),
- *                                width (number), style (string),
- *                                length (number), title (string)
- * @param {Network} network       A Network object, used to find and edge to
- *                                nodes.
- * @param {Object} constants      An object with default values for
- *                                example for the color
- * @class Edge
+ * An edge connects two nodes and has a specific direction.
+ *
+ * @class
  */
 class Edge {
+
+  /**
+   * @constructor
+   *
+   * @param {Object} options        values specific to this edge, must contain at least 'from' and 'to'
+   * @param {Object} body           shared state from Network instance 
+   * @param {Object} globalOptions  options from the EdgesHandler instance
+   * @param {Object} defaultOptions default options from the EdgeHandler instance. Value and reference are constant
+   * @param {Object} edgeOptions    option values specific for edges.
+   */
   constructor(options, body, globalOptions, defaultOptions, edgeOptions) {
     if (body === undefined) {
       throw "No body provided";
     }
+
+    // Since globalOptions is constant in values as well as reference,
+    // Following needs to be done only once.
+
+
     this.options = util.bridgeObject(globalOptions);
     this.globalOptions = globalOptions;
     this.defaultOptions = defaultOptions;
@@ -82,7 +89,8 @@ class Edge {
       options.value = parseFloat(options.value);
     }
 
-    this.choosify(options);
+    let pile = [options, this.options, this.edgeOptions, this.defaultOptions];
+    this.chooser = ComponentUtil.choosify('edge', pile);
 
     // update label Module
     this.updateLabelModule(options);
@@ -205,21 +213,6 @@ class Edge {
     }
   }
 
-  choosify(options) {
-    this.chooser = true;
-
-    let pile = [options, this.options, this.edgeOptions, this.defaultOptions];
-
-    let chosen = util.topMost(pile, 'chosen');
-    if (typeof chosen === 'boolean') {
-      this.chooser = chosen;
-    } else if (typeof chosen === 'object') {
-      let chosenEdge = util.topMost(pile, ['chosen', 'edge']);
-      if ((typeof chosenEdge === 'boolean') || (typeof chosenEdge === 'function')) {
-        this.chooser = chosenEdge;
-      }
-    }
-  }
 
   getFormattingValues() {
     let toArrow = (this.options.arrows.to === true) || (this.options.arrows.to.enabled === true)
@@ -305,7 +298,9 @@ class Edge {
       this.baseFontSize = this.labelModule.baseSize;
     }
     this.labelModule.constrain(this.edgeOptions, options, this.defaultOptions);
-    this.labelModule.choosify(this.edgeOptions, options, this.defaultOptions);
+
+    let pile = [options, this.edgeOptions, this.defaultOptions];
+    this.labelModule.fontOptions.chooser = ComponentUtil.choosify('label', pile);
   }
 
   /**

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -293,14 +293,12 @@ class Edge {
    * @param {Object} options
    */
   updateLabelModule(options) {
-    this.labelModule.setOptions(this.options, true);
+    let pile = [options, this.edgeOptions, this.defaultOptions];
+    this.labelModule.update(this.options, pile);
+
     if (this.labelModule.baseSize !== undefined) {
       this.baseFontSize = this.labelModule.baseSize;
     }
-    this.labelModule.constrain(this.edgeOptions, options, this.defaultOptions);
-
-    let pile = [options, this.edgeOptions, this.defaultOptions];
-    this.labelModule.fontOptions.chooser = ComponentUtil.choosify('label', pile);
   }
 
   /**

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -114,8 +114,9 @@ class Edge {
    * @param {Object} newOptions
    * @param {boolean} [allowDeletion=false]
    * @param {Object} [globalOptions={}]
+   * @param {boolean} [copyFromGlobals=false]
    */
-  static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}) {
+  static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}, copyFromGlobals = false) {
     var fields = [
       'arrowStrikethrough',
       'id',

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -179,24 +179,39 @@ class Edge {
 
     // handle multiple input cases for color
     if (newOptions.color !== undefined && newOptions.color !== null) {
-      // make a copy of the parent object in case this is referring to the global one (due to object create once, then update)
-      parentOptions.color = util.deepExtend({}, parentOptions.color, true);
-      if (util.isString(newOptions.color)) {
-        parentOptions.color.color     = newOptions.color;
-        parentOptions.color.highlight = newOptions.color;
-        parentOptions.color.hover     = newOptions.color;
-        parentOptions.color.inherit   = false;
+      let fromColor = newOptions.color;
+      let toColor   = parentOptions.color;
+
+      // Clear local properties - need to do it like this in order to retain prototype bridges
+      for (var i in toColor) {
+        if (toColor.hasOwnProperty(i)) {
+          delete toColor[i];
+        }
+      } 
+
+      if (util.isString(toColor)) {
+        toColor.color     = toColor;
+        toColor.highlight = toColor;
+        toColor.hover     = toColor;
+        toColor.inherit   = false;
+        if (fromColor.opacity === undefined) {
+          toColor.opacity = 1.0;  // set default
+        }
       }
       else {
         let colorsDefined = false;
-        if (newOptions.color.color     !== undefined) {parentOptions.color.color     = newOptions.color.color;     colorsDefined = true;}
-        if (newOptions.color.highlight !== undefined) {parentOptions.color.highlight = newOptions.color.highlight; colorsDefined = true;}
-        if (newOptions.color.hover     !== undefined) {parentOptions.color.hover     = newOptions.color.hover;     colorsDefined = true;}
-        if (newOptions.color.inherit   !== undefined) {parentOptions.color.inherit   = newOptions.color.inherit;}
-        if (newOptions.color.opacity   !== undefined) {parentOptions.color.opacity   = Math.min(1,Math.max(0,newOptions.color.opacity));}
+        if (fromColor.color     !== undefined) {toColor.color     = fromColor.color;     colorsDefined = true;}
+        if (fromColor.highlight !== undefined) {toColor.highlight = fromColor.highlight; colorsDefined = true;}
+        if (fromColor.hover     !== undefined) {toColor.hover     = fromColor.hover;     colorsDefined = true;}
+        if (fromColor.inherit   !== undefined) {toColor.inherit   = fromColor.inherit;}
+        if (fromColor.opacity   !== undefined) {toColor.opacity   = Math.min(1,Math.max(0,fromColor.opacity));}
 
-        if (newOptions.color.inherit === undefined && colorsDefined === true) {
-          parentOptions.color.inherit = false;
+        if (toColor.inherit === undefined) {
+          if (colorsDefined === true) {
+            toColor.inherit = false;
+          } else {
+            toColor.inherit = 'from';  // Set default
+          }
         }
       }
     }

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -304,14 +304,12 @@ class Node {
     if (this.options.label === undefined || this.options.label === null) {
       this.options.label = '';
     }
-    this.labelModule.setOptions(this.options, true);
+    let pile = [options, this.nodeOptions, this.defaultOptions];
+    this.labelModule.update(this.options, pile);
+
     if (this.labelModule.baseSize !== undefined) {
       this.baseFontSize = this.labelModule.baseSize;
     }
-    this.labelModule.constrain(this.nodeOptions, options, this.defaultOptions);
-
-    let pile = [options, this.nodeOptions, this.defaultOptions];
-    this.labelModule.fontOptions.chooser = ComponentUtil.choosify('label', pile);
   }
 
 

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -1,7 +1,7 @@
 var util = require('../../../util');
 
 var Label = require('./shared/Label').default;
-
+var ComponentUtil = require('./shared/ComponentUtil').default;
 var Box = require('./nodes/shapes/Box').default;
 var Circle = require('./nodes/shapes/Circle').default;
 var CircularImage = require('./nodes/shapes/CircularImage').default;
@@ -141,7 +141,8 @@ class Node {
     // this transforms all shorthands into fully defined options
     Node.parseOptions(this.options, options, true, this.globalOptions);
 
-    this.choosify(options);
+    let pile = [options, this.options, this.defaultOptions];
+    this.chooser = ComponentUtil.choosify('node', pile);
 
     this._load_images();
     this.updateLabelModule(options);
@@ -254,21 +255,6 @@ class Node {
     }
   }
 
-  choosify(options) {
-    this.chooser = true;
-
-    let pile = [options, this.options, this.defaultOptions];
-
-    let chosen = util.topMost(pile, 'chosen');
-    if (typeof chosen === 'boolean') {
-      this.chooser = chosen;
-    } else if (typeof chosen === 'object') {
-      let chosenNode = util.topMost(pile, ['chosen', 'node']);
-      if ((typeof chosenNode === 'boolean') || (typeof chosenNode === 'function')) {
-        this.chooser = chosenNode;
-      }
-    }
-  }
 
   getFormattingValues() {
     let values = {
@@ -323,8 +309,11 @@ class Node {
       this.baseFontSize = this.labelModule.baseSize;
     }
     this.labelModule.constrain(this.nodeOptions, options, this.defaultOptions);
-    this.labelModule.choosify(this.nodeOptions, options, this.defaultOptions);
+
+    let pile = [options, this.nodeOptions, this.defaultOptions];
+    this.labelModule.fontOptions.chooser = ComponentUtil.choosify('label', pile);
   }
+
 
   updateShape(currentShape) {
     if (currentShape === this.options.shape && this.shape) {

--- a/lib/network/modules/components/shared/ComponentUtil.js
+++ b/lib/network/modules/components/shared/ComponentUtil.js
@@ -5,8 +5,6 @@ let util = require("../../../../util");
  * @class
  */
 class ComponentUtil {
-  constructor() {}
-
   /**
    * Determine values to use for (sub)options of 'chosen'.
    *

--- a/lib/network/modules/components/shared/ComponentUtil.js
+++ b/lib/network/modules/components/shared/ComponentUtil.js
@@ -1,0 +1,56 @@
+let util = require("../../../../util");
+
+/**
+ * Helper functions for components
+ * @class
+ */
+class ComponentUtil {
+  constructor() {}
+
+  /**
+   * Determine values to use for (sub)options of 'chosen'.
+   *
+   * This option is either a boolean or an object whose values should be examined further.
+   * The relevant structures are:
+   *
+   * - chosen: <boolean value>
+   * - chosen: { subOption: <boolean or function> }
+   *
+   * Where subOption is 'node', 'edge' or 'label'.
+   *
+   * The intention of this method appears to be to set a specific priority to the options;
+   * Since most properties are either bridged or merged into the local options objects, there
+   * is not much point in handling them separately.
+   * TODO: examine if 'most' in previous sentence can be replaced with 'all'. In that case, we
+   *       should be able to get rid of this method.
+   *
+   * @param {String}  subOption  option within object 'chosen' to consider; either 'node', 'edge' or 'label'
+   * @param {Object}  pile       array of options objects to consider
+   * 
+   * @return {boolean|function}  value for passed subOption of 'chosen' to use
+   */
+  static choosify(subOption, pile) {
+    // allowed values for subOption
+    let allowed = [ 'node', 'edge', 'label'];
+    let value = true;
+
+    let chosen = util.topMost(pile, 'chosen');
+    if (typeof chosen === 'boolean') {
+      value = chosen;
+    } else if (typeof chosen === 'object') {
+      if (allowed.indexOf(subOption) === -1 ) {
+        throw new Error('choosify: subOption \'' + subOption + '\' should be one of '
+          + "'" + allowed.join("', '") +  "'");
+      }
+
+      let chosenEdge = util.topMost(pile, ['chosen', subOption]);
+      if ((typeof chosenEdge === 'boolean') || (typeof chosenEdge === 'function')) {
+        value = chosenEdge;
+      }
+    }
+
+    return value;
+  }
+}
+
+export default ComponentUtil;

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -1,4 +1,5 @@
 let util = require('../../../../util');
+let ComponentUtil = require('./ComponentUtil').default;
 
 
 /**
@@ -207,13 +208,16 @@ class Label {
   }
 
 
-  // set the width and height constraints based on 'nearest' value
-  constrain(elementOptions, options, defaultOptions) {
+  /**
+   * Set the width and height constraints based on 'nearest' value
+
+   * @param {Array} pile array of option objects to consider
+   * @private
+   */
+  constrain(pile) {
     this.fontOptions.constrainWidth = false;
     this.fontOptions.maxWdt = -1;
     this.fontOptions.minWdt = -1;
-
-    let pile = [options, elementOptions, defaultOptions];
 
     let widthConstraint = util.topMost(pile, 'widthConstraint');
     if (typeof widthConstraint === 'number') {
@@ -249,6 +253,19 @@ class Label {
         }
       }
     }
+  }
+
+
+  /**
+   * Set options and update internal state
+   *
+   * @param {Object} options  options to set
+   * @param {Array}  pile     array of option objects to consider for option 'chosen'
+   */
+  update(options, pile) {
+    this.setOptions(options, true);
+    this.constrain(pile);
+    this.fontOptions.chooser = ComponentUtil.choosify('label', pile);
   }
 
 

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -251,22 +251,6 @@ class Label {
     }
   }
 
-  // set the selected functions based on 'nearest' value
-  choosify(elementOptions, options, defaultOptions) {
-    this.fontOptions.chooser = true;
-
-    let pile = [options, elementOptions, defaultOptions];
-
-    let chosen = util.topMost(pile, 'chosen');
-    if (typeof chosen === 'boolean') {
-      this.fontOptions.chooser = chosen;
-    } else if (typeof chosen === 'object') {
-      let chosenLabel = util.topMost(pile, ['chosen', 'label']);
-      if ((typeof chosenLabel === 'boolean') || (typeof chosenLabel === 'function')) {
-        this.fontOptions.chooser = chosenLabel;
-      }
-    }
-  }
 
   // When margins are set in an element, adjust sizes is called to remove them
   // from the width/height constraints. This must be done prior to label sizing.

--- a/lib/util.js
+++ b/lib/util.js
@@ -305,7 +305,7 @@ exports.selectiveNotDeepExtend = function (props, a, b, allowDeletion = false) {
  * @param {Object} b
  * @param {Boolean} [protoExtend]   --> optional parameter. If true, the prototype values will also be extended.
  *                                    (ie. the options objects that inherit from others will also get the inherited options)
- * @param {Boolean} [allowDeletion] --> optional parameter. If true, the values of fields that are null will not deleted
+ * @param {Boolean} [allowDeletion] --> optional parameter. If true, the values of fields that are null will be deleted
  * @returns {Object}
  */
 exports.deepExtend = function (a, b, protoExtend, allowDeletion) {


### PR DESCRIPTION
Fix for #3350

- Options for colors of edges where only set on initialization of `Network`; if `Network.setOptions()` was called after initialization, any color options directly affecting Edge instances were not set.
- Added several unit tests for edge colors in order to ensure proper working.
- The option handling for edges is pretty obscure; for this reason cleanup has been done and extensive commenting has been added.

Further changes:

- **Consolidated choosify()**. There where near-identical versions in `Node`, `Edge` and `Label`. This has been reduced to a single instance. Unit tests for this have been added for this.
- **Refactored updateLabelModule()** - common parts of this method in `Node` and `Edge` have been moved to `Label`.
