### PR TITLE
Add item with ctrlKey/metaKey when dagging on a selected item

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1358,8 +1358,7 @@ ItemSet.prototype._onDragStart = function (event) {
       };
 
       this.touchParams.itemProps = [props];
-    }
-    else if (dragRightItem) {
+    } else if (dragRightItem) {
       props = {
         item: dragRightItem,
         initialX: event.center.x,
@@ -1368,8 +1367,10 @@ ItemSet.prototype._onDragStart = function (event) {
       };
 
       this.touchParams.itemProps = [props];
-    }
-    else {
+    } else if (this.options.editable.add && (event.srcEvent.ctrlKey || event.srcEvent.metaKey)) {
+      // create a new range item when dragging with ctrl key down
+      this._onDragStartAddItem(event);
+    } else {
       if(this.groupIds.length < 1) {
         // Mitigates a race condition if _onDragStart() is
         // called after markDirty() without redraw() being called between.
@@ -1393,8 +1394,7 @@ ItemSet.prototype._onDragStart = function (event) {
     }
 
     event.stopPropagation();
-  }
-  else if (this.options.editable.add && (event.srcEvent.ctrlKey || event.srcEvent.metaKey)) {
+  } else if (this.options.editable.add && (event.srcEvent.ctrlKey || event.srcEvent.metaKey)) {
     // create a new range item when dragging with ctrl key down
     this._onDragStartAddItem(event);
   }


### PR DESCRIPTION
I encountered this annoying behavior in my own app. When trying to add an item (with the ctrlKey) on a selected item, it would move the selected item instead of adding an item over the selected item. 
This is annoying to say the least...

This fixes it: solves #3378