### PR TITLE
Update jsdoc to address feedback from #3382

### DIFF
--- a/examples/graph3d/playground/playground.js
+++ b/examples/graph3d/playground/playground.js
@@ -304,7 +304,7 @@ function getDataType() {
 /**
  * Retrieve the datatable from the entered contents of the csv text
  * @param {boolean} [skipValue] | if true, the 4th element is a filter value
- * @return {vis DataSet}
+ * @return {vis.DataSet}
  */
 function getDataCsv() {
   var csv = document.getElementById("csvTextarea").value;
@@ -366,7 +366,7 @@ function trim(text) {
 
 /**
  * Retrieve the datatable from the entered contents of the javascript text
- * @return {vis Dataset}
+ * @return {vis.DataSet}
  */
 function getDataJson() {
   var json = document.getElementById("jsonTextarea").value;
@@ -378,7 +378,7 @@ function getDataJson() {
 
 /**
  * Retrieve the datatable from the entered contents of the javascript text
- * @return {vis Dataset}
+ * @return {vis.DataSet}
  */
 function getDataJavascript() {
   var js = document.getElementById("javascriptTextarea").value;
@@ -391,7 +391,7 @@ function getDataJavascript() {
 
 /**
  * Retrieve the datatable from the entered contents of the datasource text
- * @return {vis Dataset}
+ * @return {vis.DataSet}
  */
 function getDataDatasource() {
 }

--- a/lib/DOMutil.js
+++ b/lib/DOMutil.js
@@ -50,7 +50,7 @@ exports.resetElements = function(JSONcontainer) {
  * Allocate or generate an SVG element if needed. Store a reference to it in the JSON container and draw it in the svgContainer
  * the JSON container and the SVG container have to be supplied so other svg containers (like the legend) can use this.
  *
- * @param {String} elementType
+ * @param {string} elementType
  * @param {Object} JSONcontainer
  * @param {Object} svgContainer
  * @returns {Element}
@@ -86,7 +86,7 @@ exports.getSVGElement = function (elementType, JSONcontainer, svgContainer) {
  * Allocate or generate an SVG element if needed. Store a reference to it in the JSON container and draw it in the svgContainer
  * the JSON container and the SVG container have to be supplied so other svg containers (like the legend) can use this.
  *
- * @param {String} elementType
+ * @param {string} elementType
  * @param {Object} JSONcontainer
  * @param {Element} DOMContainer
  * @param {Element} insertBefore
@@ -135,8 +135,8 @@ exports.getDOMElement = function (elementType, JSONcontainer, DOMContainer, inse
  * The reason the JSONcontainer and the target SVG svgContainer have to be supplied is so the legend can use these functions
  * as well.
  *
- * @param {Number} x
- * @param {Number} y
+ * @param {number} x
+ * @param {number} y
  * @param {Object} groupTemplate: A template containing the necessary information to draw the datapoint e.g., {style: 'circle', size: 5, className: 'className' }
  * @param {Object} JSONcontainer
  * @param {Object} svgContainer
@@ -192,11 +192,11 @@ exports.drawPoint = function(x, y, groupTemplate, JSONcontainer, svgContainer, l
 /**
  * draw a bar SVG element centered on the X coordinate
  *
- * @param {Number} x
- * @param {Number} y
- * @param {Number} width
- * @param {Number} height
- * @param {String} className
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ * @param {string} className
  * @param {Object} JSONcontainer
  * @param {Object} svgContainer
  * @param {string} style

--- a/lib/DataSet.js
+++ b/lib/DataSet.js
@@ -32,9 +32,9 @@ var Queue = require('./Queue');
  *
  * @param {Array} [data]    Optional array with initial data
  * @param {Object} [options]   Available options:
- *                             {String} fieldId Field name of the id in the
+ *                             {string} fieldId Field name of the id in the
  *                                              items, 'id' by default.
- *                             {Object.<String, String} type
+ *                             {Object.<string, string} type
  *                                              A map with field names as key,
  *                                              and the field type as value.
  *                             {Object} queue   Queue changes to the DataSet,
@@ -122,12 +122,12 @@ DataSet.prototype.setOptions = function(options) {
 
 /**
  * Subscribe to an event, add an event listener
- * @param {String} event        Event name. Available events: 'put', 'update',
+ * @param {string} event        Event name. Available events: 'put', 'update',
  *                              'remove'
  * @param {function} callback   Callback method. Called with three parameters:
- *                                  {String} event
+ *                                  {string} event
  *                                  {Object | null} params
- *                                  {String | Number} senderId
+ *                                  {string | number} senderId
  */
 DataSet.prototype.on = function(event, callback) {
   var subscribers = this._subscribers[event];
@@ -151,7 +151,7 @@ DataSet.prototype.subscribe = function () {
 
 /**
  * Unsubscribe from an event, remove an event listener
- * @param {String} event
+ * @param {string} event
  * @param {function} callback
  */
 DataSet.prototype.off = function(event, callback) {
@@ -168,9 +168,9 @@ DataSet.prototype.unsubscribe = function () {
 
 /**
  * Trigger an event
- * @param {String} event
+ * @param {string} event
  * @param {Object | null} params
- * @param {String} [senderId]       Optional id of the sender.
+ * @param {string} [senderId]       Optional id of the sender.
  * @private
  */
 DataSet.prototype._trigger = function (event, params, senderId) {
@@ -198,8 +198,8 @@ DataSet.prototype._trigger = function (event, params, senderId) {
  * Add data.
  * Adding an item will fail when there already is an item with the same id.
  * @param {Object | Array} data
- * @param {String} [senderId] Optional sender id
- * @return {Array} addedIds      Array with the ids of the added items
+ * @param {string} [senderId] Optional sender id
+ * @return {Array.<string|number>} addedIds      Array with the ids of the added items
  */
 DataSet.prototype.add = function (data, senderId) {
   var addedIds = [],
@@ -232,8 +232,8 @@ DataSet.prototype.add = function (data, senderId) {
 /**
  * Update existing items. When an item does not exist, it will be created
  * @param {Object | Array} data
- * @param {String} [senderId] Optional sender id
- * @return {Array} updatedIds     The ids of the added or updated items
+ * @param {string} [senderId] Optional sender id
+ * @return {Array.<string|number>} updatedIds     The ids of the added or updated items
  */
 DataSet.prototype.update = function (data, senderId) {
   var addedIds = [];
@@ -304,23 +304,23 @@ DataSet.prototype.update = function (data, senderId) {
  *     get()
  *     get(options: Object)
  *
- *     get(id: Number | String)
- *     get(id: Number | String, options: Object)
+ *     get(id: number | string)
+ *     get(id: number | string, options: Object)
  *
- *     get(ids: Number[] | String[])
- *     get(ids: Number[] | String[], options: Object)
+ *     get(ids: number[] | string[])
+ *     get(ids: number[] | string[], options: Object)
  *
  * Where:
  *
- * {Number | String} id         The id of an item
- * {Number[] | String{}} ids    An array with ids of items
+ * {number | string} id         The id of an item
+ * {number[] | string{}} ids    An array with ids of items
  * {Object} options             An Object with options. Available options:
- * {String} [returnType]        Type of data to be returned.
+ * {string} [returnType]        Type of data to be returned.
  *                              Can be 'Array' (default) or 'Object'.
- * {Object.<String, String>} [type]
- * {String[]} [fields]          field names to be returned
+ * {Object.<string, string>} [type]
+ * {string[]} [fields]          field names to be returned
  * {function} [filter]          filter items
- * {String | function} [order]  Order the items by a field name or custom sort function.
+ * {string | function} [order]  Order the items by a field name or custom sort function.
  * @param {Array} args
  * @returns {DataSet}
  * @throws Error
@@ -331,7 +331,7 @@ DataSet.prototype.get = function (args) {  // eslint-disable-line no-unused-vars
   // parse the arguments
   var id, ids, options;
   var firstType = util.getType(arguments[0]);
-  if (firstType == 'String' || firstType == 'Number') {
+  if (firstType == 'String' || firstType == 'number') {
     // get(id [, options])
     id = arguments[0];
     options = arguments[1];
@@ -434,9 +434,9 @@ DataSet.prototype.get = function (args) {  // eslint-disable-line no-unused-vars
  * Get ids of all items or from a filtered set of items.
  * @param {Object} [options]    An Object with options. Available options:
  *                              {function} [filter] filter items
- *                              {String | function} [order] Order the items by
+ *                              {string | function} [order] Order the items by
  *                                  a field name or custom sort function.
- * @return {Array} ids
+ * @return {Array.<string|number>} ids
  */
 DataSet.prototype.getIds = function (options) {
   var data = this._data,
@@ -523,10 +523,10 @@ DataSet.prototype.getDataSet = function () {
  * Execute a callback function for every item in the dataset.
  * @param {function} callback
  * @param {Object} [options]    Available options:
- *                              {Object.<String, String>} [type]
- *                              {String[]} [fields] filter fields
+ *                              {Object.<string, string>} [type]
+ *                              {string[]} [fields] filter fields
  *                              {function} [filter] filter items
- *                              {String | function} [order] Order the items by
+ *                              {string | function} [order] Order the items by
  *                                  a field name or custom sort function.
  */
 DataSet.prototype.forEach = function (callback, options) {
@@ -565,10 +565,10 @@ DataSet.prototype.forEach = function (callback, options) {
  * Map every item in the dataset.
  * @param {function} callback
  * @param {Object} [options]    Available options:
- *                              {Object.<String, String>} [type]
- *                              {String[]} [fields] filter fields
+ *                              {Object.<string, string>} [type]
+ *                              {string[]} [fields] filter fields
  *                              {function} [filter] filter items
- *                              {String | function} [order] Order the items by
+ *                              {string | function} [order] Order the items by
  *                                  a field name or custom sort function.
  * @return {Object[]} mappedItems
  */
@@ -603,7 +603,7 @@ DataSet.prototype.map = function (callback, options) {
 /**
  * Filter the fields of an item
  * @param {Object | null} item
- * @param {String[]} fields     Field names
+ * @param {string[]} fields     Field names
  * @return {Object | null} filteredItem or null if no item is provided
  * @private
  */
@@ -640,7 +640,7 @@ DataSet.prototype._filterFields = function (item, fields) {
 /**
  * Sort the provided array with items
  * @param {Object[]} items
- * @param {String | function} order      A field name or custom sort function.
+ * @param {string | function} order      A field name or custom sort function.
  * @private
  */
 DataSet.prototype._sort = function (items, order) {
@@ -657,7 +657,7 @@ DataSet.prototype._sort = function (items, order) {
     // order by sort function
     items.sort(order);
   }
-  // TODO: extend order by an Object {field:String, direction:String}
+  // TODO: extend order by an Object {field:string, direction:string}
   //       where direction can be 'asc' or 'desc'
   else {
     throw new TypeError('Order must be a function or a string');
@@ -666,10 +666,10 @@ DataSet.prototype._sort = function (items, order) {
 
 /**
  * Remove an object by pointer or by id
- * @param {String | Number | Object | Array} id Object or id, or an array with
+ * @param {string | number | Object | Array.<string|number>} id Object or id, or an array with
  *                                              objects or ids to be removed
- * @param {String} [senderId] Optional sender id
- * @return {Array} removedIds
+ * @param {string} [senderId] Optional sender id
+ * @return {Array.<string|number>} removedIds
  */
 DataSet.prototype.remove = function (id, senderId) {
   var removedIds = [],
@@ -700,8 +700,8 @@ DataSet.prototype.remove = function (id, senderId) {
 
 /**
  * Remove an item by its id
- * @param {Number | String | Object} id   id or item
- * @returns {Number | String | null} id
+ * @param {number | string | Object} id   id or item
+ * @returns {number | string | null} id
  * @private
  */
 DataSet.prototype._remove = function (id) {
@@ -728,8 +728,8 @@ DataSet.prototype._remove = function (id) {
 
 /**
  * Clear the data
- * @param {String} [senderId] Optional sender id
- * @return {Array} removedIds    The ids of all removed items
+ * @param {string} [senderId] Optional sender id
+ * @return {Array.<string|number>} removedIds    The ids of all removed items
  */
 DataSet.prototype.clear = function (senderId) {
   var i, len;
@@ -750,7 +750,7 @@ DataSet.prototype.clear = function (senderId) {
 
 /**
  * Find the item with maximum value of a specified field
- * @param {String} field
+ * @param {string} field
  * @return {Object | null} item  Item containing max value, or null if no items
  */
 DataSet.prototype.max = function (field) {
@@ -776,7 +776,7 @@ DataSet.prototype.max = function (field) {
 
 /**
  * Find the item with minimum value of a specified field
- * @param {String} field
+ * @param {string} field
  * @return {Object | null} item  Item containing max value, or null if no items
  */
 DataSet.prototype.min = function (field) {
@@ -802,7 +802,7 @@ DataSet.prototype.min = function (field) {
 
 /**
  * Find all distinct values of a specified field
- * @param {String} field
+ * @param {string} field
  * @return {Array} values  Array containing all distinct values. If data items
  *                         do not contain the specified field are ignored.
  *                         The returned array is unordered.
@@ -846,7 +846,7 @@ DataSet.prototype.distinct = function (field) {
 /**
  * Add a single item. Will fail when an item with the same id already exists.
  * @param {Object} item
- * @return {String} id
+ * @return {string} id
  * @private
  */
 DataSet.prototype._addItem = function (item) {
@@ -882,8 +882,8 @@ DataSet.prototype._addItem = function (item) {
 
 /**
  * Get an item. Fields can be converted to a specific type
- * @param {String} id
- * @param {Object.<String, String>} [types]  field types to convert
+ * @param {string} id
+ * @param {Object.<string, string>} [types]  field types to convert
  * @return {Object | null} item
  * @private
  */
@@ -928,7 +928,7 @@ DataSet.prototype._getItem = function (id, types) {
  * Will fail when the item has no id, or when there does not exist an item
  * with the same id.
  * @param {Object} item
- * @return {String} id
+ * @return {string} id
  * @private
  */
 DataSet.prototype._updateItem = function (item) {

--- a/lib/DataView.js
+++ b/lib/DataView.js
@@ -143,15 +143,15 @@ DataView.prototype.refresh = function () {
  *
  * Where:
  *
- * {Number | String} id         The id of an item
- * {Number[] | String{}} ids    An array with ids of items
+ * {number | string} id         The id of an item
+ * {number[] | string{}} ids    An array with ids of items
  * {Object} options             An Object with options. Available options:
- *                              {String} [type] Type of data to be returned. Can
+ *                              {string} [type] Type of data to be returned. Can
  *                                              be 'DataTable' or 'Array' (default)
- *                              {Object.<String, String>} [convert]
- *                              {String[]} [fields] field names to be returned
+ *                              {Object.<string, string>} [convert]
+ *                              {string[]} [fields] field names to be returned
  *                              {function} [filter] filter items
- *                              {String | function} [order] Order the items by
+ *                              {string | function} [order] Order the items by
  *                                  a field name or custom sort function.
  * {Array | DataTable} [data]   If provided, items will be appended to this
  *                              array or table. Required in case of Google
@@ -202,9 +202,9 @@ DataView.prototype.get = function (args) {  // eslint-disable-line no-unused-var
  * Get ids of all items or from a filtered set of items.
  * @param {Object} [options]    An Object with options. Available options:
  *                              {function} [filter] filter items
- *                              {String | function} [order] Order the items by
+ *                              {string | function} [order] Order the items by
  *                                  a field name or custom sort function.
- * @return {Array} ids
+ * @return {Array.<string|number>} ids
  */
 DataView.prototype.getIds = function (options) {
   var ids;
@@ -243,10 +243,10 @@ DataView.prototype.getIds = function (options) {
  * Map every item in the dataset.
  * @param {function} callback
  * @param {Object} [options]    Available options:
- *                              {Object.<String, String>} [type]
- *                              {String[]} [fields] filter fields
+ *                              {Object.<string, string>} [type]
+ *                              {string[]} [fields] filter fields
  *                              {function} [filter] filter items
- *                              {String | function} [order] Order the items by
+ *                              {string | function} [order] Order the items by
  *                                  a field name or custom sort function.
  * @return {Object[]} mappedItems
  */
@@ -299,9 +299,9 @@ DataView.prototype.getDataSet = function () {
  * Event listener. Will propagate all events from the connected data set to
  * the subscribers of the DataView, but will filter the items and only trigger
  * when there are changes in the filtered data set.
- * @param {String} event
+ * @param {string} event
  * @param {Object | null} params
- * @param {String} senderId
+ * @param {string} senderId
  * @private
  */
 DataView.prototype._onEvent = function (event, params, senderId) {

--- a/lib/graph3d/Camera.js
+++ b/lib/graph3d/Camera.js
@@ -27,8 +27,8 @@ function Camera() {
 
 /**
  * Set offset camera in camera coordinates
- * @param {Number} x offset by camera horisontal
- * @param {Number} y offset by camera vertical
+ * @param {number} x offset by camera horisontal
+ * @param {number} y offset by camera vertical
  */
 Camera.prototype.setOffset = function(x, y) {
   var abs = Math.abs,
@@ -58,9 +58,9 @@ Camera.prototype.getOffset = function() {
 
 /**
  * Set the location (origin) of the arm
- * @param {Number} x  Normalized value of x
- * @param {Number} y  Normalized value of y
- * @param {Number} z  Normalized value of z
+ * @param {number} x  Normalized value of x
+ * @param {number} y  Normalized value of y
+ * @param {number} z  Normalized value of z
  */
 Camera.prototype.setArmLocation = function(x, y, z) {
   this.armLocation.x = x;
@@ -72,9 +72,9 @@ Camera.prototype.setArmLocation = function(x, y, z) {
 
 /**
  * Set the rotation of the camera arm
- * @param {Number} horizontal   The horizontal rotation, between 0 and 2*PI.
+ * @param {number} horizontal   The horizontal rotation, between 0 and 2*PI.
  *                Optional, can be left undefined.
- * @param {Number} vertical   The vertical rotation, between 0 and 0.5*PI
+ * @param {number} vertical   The vertical rotation, between 0 and 0.5*PI
  *                if vertical=0.5*PI, the graph is shown from the
  *                top. Optional, can be left undefined.
  */
@@ -108,7 +108,7 @@ Camera.prototype.getArmRotation = function() {
 
 /**
  * Set the (normalized) length of the camera arm.
- * @param {Number} length A length between 0.71 and 5.0
+ * @param {number} length A length between 0.71 and 5.0
  */
 Camera.prototype.setArmLength = function(length) {
   if (length === undefined)
@@ -128,7 +128,7 @@ Camera.prototype.setArmLength = function(length) {
 
 /**
  * Retrieve the arm length
- * @return {Number} length
+ * @return {number} length
  */
 Camera.prototype.getArmLength = function() {
   return this.armLength;

--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -143,7 +143,7 @@ DataGroup.prototype.initializeData = function(graph3d, rawData, style) {
  * @private
  *
  * @param {'x'|'y'|'z'} column  The data column to process
- * @param {vis.Graph3d}     graph3d Reference to the calling Graph3D instance;
+ * @param {Graph3D}     graph3d Reference to the calling Graph3D instance;
  *                              required for access to settings
  * @returns {Object}
  */

--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -35,8 +35,8 @@ function DataGroup() {
  * @param {vis.Graph3d}  graph3d Reference to the calling Graph3D instance.
  * @param {Array | DataSet | DataView} rawData The data containing the items for
  *                                             the Graph.
- * @param {Number}   style   Style Number
- * @returns {Array<Object>}
+ * @param {number}   style   Style Number
+ * @returns {Array.<Object>}
  */
 DataGroup.prototype.initializeData = function(graph3d, rawData, style) {
   if (rawData === undefined) return;
@@ -178,7 +178,7 @@ DataGroup.prototype._collectRangeSettings = function(column, graph3d) {
  * @param {'x'|'y'|'z'}        column   The data column to process
  * @param {vis.Graph3d}        graph3d  Reference to the calling Graph3D instance;
  *                                      required for access to settings
- * @param {Boolean}            withBars True if initializing for bar graph
+ * @param {boolean}            withBars True if initializing for bar graph
  */
 DataGroup.prototype._initializeRange = function(data, column, graph3d, withBars) {
   var NUMSTEPS = 5;
@@ -230,7 +230,7 @@ DataGroup.prototype.getDistinctValues = function(column, data) {
  * @param {DataSet|DataView|undefined} data   The data containing the items for the Graph
  * @param {'x'|'y'|'z'}                column The data column to process
  *
- * @returns {Number|null} Smallest difference value or
+ * @returns {number|null} Smallest difference value or
  *                        null, if it can't be determined.
  */
 DataGroup.prototype.getSmallestDifference = function(data, column) {
@@ -276,7 +276,7 @@ DataGroup.prototype.getColumnRange = function(data, column) {
 /**
  * Determines the number of rows in the current data.
  *
- * @returns {Number}
+ * @returns {number}
  */
 DataGroup.prototype.getNumberOfRows = function() {
   return this.dataTable.length;
@@ -325,8 +325,8 @@ DataGroup.prototype.getDataSet = function() {
 
 /**
  * Return all data values as a list of Point3d objects
- * @param {Array<Object>} data
- * @returns {Array<Object>}
+ * @param {Array.<Object>} data
+ * @returns {Array.<Object>}
  */
 DataGroup.prototype.getDataPoints = function(data) {
   var dataPoints = [];
@@ -359,8 +359,8 @@ DataGroup.prototype.getDataPoints = function(data) {
  * Copy all values from the data table to a matrix.
  *
  * The provided values are supposed to form a grid of (x,y) positions.
- * @param {Array<Object>} data
- * @returns {Array<Object>}
+ * @param {Array.<Object>} data
+ * @returns {Array.<Object>}
  * @private
  */
 DataGroup.prototype.initDataAsMatrix = function(data) {
@@ -467,7 +467,7 @@ DataGroup.prototype._getDataPoints = function (data) {
  *
  * Throws if a problem is detected.
  *
- * @param {Array<Object>} data
+ * @param {Array.<Object>} data
  * @private
  */
 DataGroup.prototype._checkValueField = function (data) {

--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -143,7 +143,7 @@ DataGroup.prototype.initializeData = function(graph3d, rawData, style) {
  * @private
  *
  * @param {'x'|'y'|'z'} column  The data column to process
- * @param {Graph3D}     graph3d Reference to the calling Graph3D instance;
+ * @param {vis.Graph3d} graph3d Reference to the calling Graph3D instance;
  *                              required for access to settings
  * @returns {Object}
  */
@@ -176,7 +176,7 @@ DataGroup.prototype._collectRangeSettings = function(column, graph3d) {
  *
  * @param {DataSet | DataView} data     The data containing the items for the Graph
  * @param {'x'|'y'|'z'}        column   The data column to process
- * @param {Graph3D}            graph3d  Reference to the calling Graph3D instance;
+ * @param {vis.Graph3d}        graph3d  Reference to the calling Graph3D instance;
  *                                      required for access to settings
  * @param {Boolean}            withBars True if initializing for bar graph
  */

--- a/lib/graph3d/DataGroup.js
+++ b/lib/graph3d/DataGroup.js
@@ -32,7 +32,7 @@ function DataGroup() {
  * the given instance.
  * TODO: Pass settings only instead.
  *
- * @param {vis.Graph3D}  graph3d Reference to the calling Graph3D instance.
+ * @param {vis.Graph3d}  graph3d Reference to the calling Graph3D instance.
  * @param {Array | DataSet | DataView} rawData The data containing the items for
  *                                             the Graph.
  * @param {Number}   style   Style Number
@@ -143,7 +143,7 @@ DataGroup.prototype.initializeData = function(graph3d, rawData, style) {
  * @private
  *
  * @param {'x'|'y'|'z'} column  The data column to process
- * @param {vis.Graph3D}     graph3d Reference to the calling Graph3D instance;
+ * @param {vis.Graph3d}     graph3d Reference to the calling Graph3D instance;
  *                              required for access to settings
  * @returns {Object}
  */

--- a/lib/graph3d/Filter.js
+++ b/lib/graph3d/Filter.js
@@ -4,7 +4,7 @@ var DataView = require('../DataView');
  * @class Filter
  *
  * @param {DataGroup} dataGroup the data group 
- * @param {Number}  column             The index of the column to be filtered
+ * @param {number}  column             The index of the column to be filtered
  * @param {Graph3d} graph              The graph
  */
 function Filter (dataGroup, column, graph) {
@@ -49,7 +49,7 @@ Filter.prototype.isLoaded = function() {
 
 /**
  * Return the loaded progress
- * @return {Number} percentage between 0 and 100
+ * @return {number} percentage between 0 and 100
  */
 Filter.prototype.getLoadedProgress = function() {
   var len = this.values.length;
@@ -74,7 +74,7 @@ Filter.prototype.getLabel = function() {
 
 /**
  * Return the columnIndex of the filter
- * @return {Number} columnIndex
+ * @return {number} columnIndex
  */
 Filter.prototype.getColumn = function() {
   return this.column;
@@ -101,7 +101,7 @@ Filter.prototype.getValues = function() {
 
 /**
  * Retrieve one value of the filter
- * @param {Number}  index
+ * @param {number}  index
  * @return {*} value
  */
 Filter.prototype.getValue = function(index) {
@@ -114,7 +114,7 @@ Filter.prototype.getValue = function(index) {
 
 /**
  * Retrieve the (filtered) dataPoints for the currently selected filter index
- * @param {Number} [index] (optional)
+ * @param {number} [index] (optional)
  * @return {Array} dataPoints
  */
 Filter.prototype._getDataPoints = function(index) {
@@ -157,7 +157,7 @@ Filter.prototype.setOnLoadCallback = function(callback) {
 /**
  * Add a value to the list with available values for this filter
  * No double entries will be created.
- * @param {Number} index
+ * @param {number} index
  */
 Filter.prototype.selectValue = function(index) {
   if (index >= this.values.length)

--- a/lib/graph3d/Filter.js
+++ b/lib/graph3d/Filter.js
@@ -5,7 +5,7 @@ var DataView = require('../DataView');
  *
  * @param {DataGroup} dataGroup the data group 
  * @param {Number}  column             The index of the column to be filtered
- * @param {Graph} graph           The graph
+ * @param {Graph3d} graph              The graph
  */
 function Filter (dataGroup, column, graph) {
   this.dataGroup = dataGroup;

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -24,7 +24,6 @@ Graph3d.STYLE = Settings.STYLE;
  */
 var autoByDefault = undefined;
 
-
 /**
  * Default values for option settings.
  *
@@ -93,7 +92,6 @@ Graph3d.DEFAULTS = {
       }
   },
 
-
   dataColor        : {
     fill       : '#7DC1FF',
     stroke     : '#3267D2',
@@ -105,7 +103,6 @@ Graph3d.DEFAULTS = {
      vertical  : 0.5,
      distance  : 1.7
   },
-
 
 /*
   The following fields are 'auto by default', see above.
@@ -551,7 +548,8 @@ Graph3d.prototype._resizeCanvas = function() {
 
 
 /**
- * Start animation, if requested and filter present
+ * Start playing the animation, if requested and filter present. Only applicable
+ * when animation data is available.
  */
 Graph3d.prototype.animationStart = function() {
   // start animation when option is true

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -302,7 +302,7 @@ Graph3d.prototype._convertTranslationToScreen = function(translation) {
 /**
  * Calculate the translations and screen positions of all points
  *
- * @param {Array<Point3d>} points
+ * @param {Array.<Point3d>} points
  * @private
  */
 Graph3d.prototype._calcTranslations = function(points) {
@@ -357,7 +357,7 @@ Graph3d.prototype._initializeRanges = function() {
  * Return all data values as a list of Point3d objects
  *
  * @param {vis.DataSet} data
- * @returns {Array<Object>}
+ * @returns {Array.<Object>}
  */
 Graph3d.prototype.getDataPoints = function(data) {
   var dataPoints = [];
@@ -1291,9 +1291,9 @@ Graph3d.prototype._redrawAxis = function() {
 
 /**
  * Calculate the color based on the given value.
- * @param {Number} H   Hue, a value be between 0 and 360
- * @param {Number} S   Saturation, a value between 0 and 1
- * @param {Number} V   Value, a value between 0 and 1
+ * @param {number} H   Hue, a value be between 0 and 360
+ * @param {number} S   Saturation, a value between 0 and 1
+ * @param {number} V   Value, a value between 0 and 1
  * @returns {string}
  * @private
  */
@@ -1432,7 +1432,7 @@ Graph3d.prototype._redrawBar = function(ctx, point, xWidth, yWidth, color, borde
  * Draw a polygon using the passed points and fill it with the passed style and stroke.
  *
  * @param {CanvasRenderingContext2D} ctx
- * @param {Array<vis.Point3d>} points      an array of points.
+ * @param {Array.<vis.Point3d>} points      an array of points.
  * @param {string} [fillStyle] the fill style to set
  * @param {string} [strokeStyle] the stroke style to set
  */
@@ -2143,8 +2143,8 @@ Graph3d.prototype._insideTriangle = function (point, triangle) {
 
   /**
    *
-   * @param {Number} x
-   * @returns {Number}
+   * @param {number} x
+   * @returns {number}
    */
   function sign (x) {
     return x > 0 ? 1 : x < 0 ? -1 : 0;
@@ -2163,8 +2163,8 @@ Graph3d.prototype._insideTriangle = function (point, triangle) {
 /**
  * Find a data point close to given screen position (x, y)
  *
- * @param   {Number} x
- * @param   {Number} y
+ * @param   {number} x
+ * @param   {number} y
  * @returns {Object | null} The closest data point or null if not close to any
  *                          data point
  * @private
@@ -2336,7 +2336,7 @@ Graph3d.prototype._hideTooltip = function () {
  * Get the horizontal mouse position from a mouse event
  *
  * @param   {Event}  event
- * @returns {Number} mouse x
+ * @returns {number} mouse x
  */
 function getMouseX (event) {
   if ('clientX' in event) return event.clientX;
@@ -2347,7 +2347,7 @@ function getMouseX (event) {
  * Get the vertical mouse position from a mouse event
  *
  * @param   {Event}  event
- * @returns {Number} mouse y
+ * @returns {number} mouse y
  */
 function getMouseY (event) {
   if ('clientY' in event) return event.clientY;
@@ -2363,12 +2363,12 @@ function getMouseY (event) {
  * Set the rotation and distance of the camera
  *
  * @param {Object}  pos            An object with the camera position
- * @param {?Number} pos.horizontal The horizontal rotation, between 0 and 2*PI.
+ * @param {number} [pos.horizontal] The horizontal rotation, between 0 and 2*PI.
  *                                 Optional, can be left undefined.
- * @param {?Number} pos.vertical   The vertical rotation, between 0 and 0.5*PI.
+ * @param {number} [pos.vertical]  The vertical rotation, between 0 and 0.5*PI.
  *                                 if vertical=0.5*PI, the graph is shown from
  *                                 the top. Optional, can be left undefined.
- * @param {?Number} pos.distance   The (normalized) distance of the camera to the
+ * @param {number} [pos.distance]  The (normalized) distance of the camera to the
  *                                 center of the graph, a value between 0.71 and
  *                                 5.0. Optional, can be left undefined.
  */

--- a/lib/graph3d/Point2d.js
+++ b/lib/graph3d/Point2d.js
@@ -1,7 +1,7 @@
 /**
  * @prototype Point2d
- * @param {Number} [x]
- * @param {Number} [y]
+ * @param {number} [x]
+ * @param {number} [y]
  */
 function Point2d (x, y) {
   this.x = x !== undefined ? x : 0;

--- a/lib/graph3d/Point3d.js
+++ b/lib/graph3d/Point3d.js
@@ -1,8 +1,8 @@
 /**
  * @prototype Point3d
- * @param {Number} [x]
- * @param {Number} [y]
- * @param {Number} [z]
+ * @param {number} [x]
+ * @param {number} [y]
+ * @param {number} [z]
  */
 function Point3d(x, y, z) {
   this.x = x !== undefined ? x : 0;
@@ -72,7 +72,7 @@ Point3d.crossProduct = function(a, b) {
 
 /**
  * Rtrieve the length of the vector (or the distance from this point to the origin
- * @return {Number}  length
+ * @return {number}  length
  */
 Point3d.prototype.length = function() {
   return Math.sqrt(

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -336,7 +336,7 @@ function setShowLegend(showLegend, dst) {
 /**
  * Retrieve the style index from given styleName
  * @param {string} styleName  Style name such as 'dot', 'grid', 'dot-line'
- * @return {Number} styleNumber Enumeration value representing the style, or -1
+ * @return {number} styleNumber Enumeration value representing the style, or -1
  *                when not found
  */
 function getStyleNumberByName(styleName) {
@@ -353,7 +353,7 @@ function getStyleNumberByName(styleName) {
 /**
  * Check if given number is a valid style number.
  *
- * @param {String | Number} style
+ * @param {string | number} style
  * @return {boolean} true if valid, false otherwise
  */
 function checkStyleNumber(style) {
@@ -371,7 +371,7 @@ function checkStyleNumber(style) {
 
 /**
  *
- * @param {String | Number} style
+ * @param {string | number} style
  * @param {Object} dst
  */
 function setStyle(style, dst) {
@@ -432,7 +432,7 @@ function setBackgroundColor(backgroundColor, dst) {
 
 /**
  *
- * @param {String | Object} dataColor
+ * @param {string | Object} dataColor
  * @param {Object} dst
  */
 function setDataColor(dataColor, dst) {

--- a/lib/graph3d/Slider.js
+++ b/lib/graph3d/Slider.js
@@ -176,7 +176,7 @@ Slider.prototype.setOnChangeCallback = function(callback) {
 
 /**
  * Set the interval for playing the list
- * @param {Number} interval   The interval in milliseconds
+ * @param {number} interval   The interval in milliseconds
  */
 Slider.prototype.setPlayInterval = function(interval) {
   this.playInterval = interval;
@@ -184,7 +184,7 @@ Slider.prototype.setPlayInterval = function(interval) {
 
 /**
  * Retrieve the current play interval
- * @return {Number} interval   The interval in milliseconds
+ * @return {number} interval   The interval in milliseconds
  */
 Slider.prototype.getPlayInterval = function() {
   return this.playInterval;
@@ -246,7 +246,7 @@ Slider.prototype.setValues = function(values) {
 
 /**
  * Select a value by its index
- * @param {Number} index
+ * @param {number} index
  */
 Slider.prototype.setIndex = function(index) {
   if (index < this.values.length) {
@@ -262,7 +262,7 @@ Slider.prototype.setIndex = function(index) {
 
 /**
  * retrieve the index of the currently selected vaue
- * @return {Number} index
+ * @return {number} index
  */
 Slider.prototype.getIndex = function() {
   return this.index;

--- a/lib/graph3d/StepNumber.js
+++ b/lib/graph3d/StepNumber.js
@@ -17,9 +17,9 @@
  *
  * Version: 1.0
  *
- * @param {Number} start     The start value
- * @param {Number} end     The end value
- * @param {Number} step    Optional. Step size. Must be a positive value.
+ * @param {number} start     The start value
+ * @param {number} end     The end value
+ * @param {number} step    Optional. Step size. Must be a positive value.
  * @param {boolean} prettyStep Optional. If true, the step size is rounded
  *               To a pretty step size (like 1, 2, 5, 10, 20, 50, ...)
  */
@@ -52,9 +52,9 @@ StepNumber.prototype.isNumeric = function(n) {
 /**
  * Set a new range: start, end and step.
  *
- * @param {Number} start     The start value
- * @param {Number} end     The end value
- * @param {Number} step    Optional. Step size. Must be a positive value.
+ * @param {number} start     The start value
+ * @param {number} end     The end value
+ * @param {number} step    Optional. Step size. Must be a positive value.
  * @param {boolean} prettyStep Optional. If true, the step size is rounded
  *               To a pretty step size (like 1, 2, 5, 10, 20, 50, ...)
  */
@@ -77,7 +77,7 @@ StepNumber.prototype.setRange = function(start, end, step, prettyStep) {
 
 /**
  * Set a new step size
- * @param {Number} step    New step size. Must be a positive value
+ * @param {number} step    New step size. Must be a positive value
  * @param {boolean} prettyStep Optional. If true, the provided step is rounded
  *               to a pretty step size (like 1, 2, 5, 10, 20, 50, ...)
  */
@@ -98,8 +98,8 @@ StepNumber.prototype.setStep = function(step, prettyStep) {
  * Calculate a nice step size, closest to the desired step size.
  * Returns a value in one of the ranges 1*10^n, 2*10^n, or 5*10^n, where n is an
  * integer Number. For example 1, 2, 5, 10, 20, 50, etc...
- * @param {Number}  step  Desired step size
- * @return {Number}     Nice step size
+ * @param {number}  step  Desired step size
+ * @return {number}     Nice step size
  */
 StepNumber.calculatePrettyStep = function (step) {
   var log10 = function (x) {return Math.log(x) / Math.LN10;};
@@ -124,7 +124,7 @@ StepNumber.calculatePrettyStep = function (step) {
 
 /**
  * returns the current value of the step
- * @return {Number} current value
+ * @return {number} current value
  */
 StepNumber.prototype.getCurrent = function () {
   return parseFloat(this._current.toPrecision(this.precision));
@@ -132,7 +132,7 @@ StepNumber.prototype.getCurrent = function () {
 
 /**
  * returns the current step size
- * @return {Number} current step size
+ * @return {number} current step size
  */
 StepNumber.prototype.getStep = function () {
   return this._step;

--- a/lib/network/CachedImage.js
+++ b/lib/network/CachedImage.js
@@ -8,13 +8,11 @@
  * NOTE: Images can also be of type 'data:svg+xml`. This code also works
  *       for svg, but the mipmapping may not be necessary.
  *
- * @class CachedImage
+ * @param {Image} image
  */
 class CachedImage {
   /**
-   * Create a CachedImage instance
-   * @param {Image} image
-   * @constructor
+   * @inheritDoc
    */
   constructor(image) {  // eslint-disable-line no-unused-vars
     this.NUM_ITERATIONS = 4;  // Number of items in the coordinates array

--- a/lib/network/CachedImage.js
+++ b/lib/network/CachedImage.js
@@ -12,7 +12,7 @@
  */
 class CachedImage {
   /**
-   * Create a Chached Image
+   * Create a CachedImage instance
    * @param {Image} image
    * @constructor
    */
@@ -25,7 +25,7 @@ class CachedImage {
 
 
   /**
-   * Called when the image has been succesfully loaded.
+   * Called when the image has been successfully loaded.
    */
   init() {
     if (this.initialized()) return;

--- a/lib/network/CachedImage.js
+++ b/lib/network/CachedImage.js
@@ -108,10 +108,10 @@ class CachedImage {
    *
    * @param {CanvasRenderingContext2D} ctx  context on which to draw zoomed image
    * @param {Float} factor scale factor at which to draw
-   * @param {Number} left
-   * @param {Number} top
-   * @param {Number} width
-   * @param {Number} height
+   * @param {number} left
+   * @param {number} top
+   * @param {number} width
+   * @param {number} height
    */
   drawImageAtPosition(ctx, factor, left, top, width, height) {
     if (factor > 2 && this.initialized()) {

--- a/lib/network/Images.js
+++ b/lib/network/Images.js
@@ -3,14 +3,12 @@ import CachedImage from './CachedImage';
 
 /**
  * This class loads images and keeps them stored.
- * @class Images
+ * @callback callback
+ * @param {function} callback
  */
 class Images {
   /**
-   * Create a Images
-   * @callback callback
-   * @param {function} callback
-   * @constructor Images
+   * @inheritDoc
    */
   constructor(callback){
         this.images = {};

--- a/lib/network/Images.js
+++ b/lib/network/Images.js
@@ -3,7 +3,7 @@ import CachedImage from './CachedImage';
 
 /**
  * This class loads images and keeps them stored.
- * class Images
+ * @class Images
  */
 class Images {
   /**

--- a/lib/network/NetworkUtil.js
+++ b/lib/network/NetworkUtil.js
@@ -1,19 +1,19 @@
 let util = require("../util");
 
 /**
- * @class NetworkUtil
+ * Utility Class
  */
 class NetworkUtil {
   /**
-   * @constructor NetworkUtil
+   * @inheritDoc
    */
   constructor() {}
 
   /**
    * Find the center position of the network considering the bounding boxes
    *
-   * @param {Array<vis.Node>} allNodes
-   * @param {Array<vis.Node>} [specificNodes=[]]
+   * @param {Array<Node>} allNodes
+   * @param {Array<Node>} [specificNodes=[]]
    * @returns {{minX: number, maxX: number, minY: number, maxY: number}}
    * @static
    */
@@ -46,8 +46,8 @@ class NetworkUtil {
   /**
    * Find the center position of the network
    *
-   * @param {Array<vis.Node>} allNodes
-   * @param {Array<vis.Node>} [specificNodes=[]]
+   * @param {Array<Node>} allNodes
+   * @param {Array<Node>} [specificNodes=[]]
    * @returns {{minX: number, maxX: number, minY: number, maxY: number}}
    * @static
    */

--- a/lib/network/NetworkUtil.js
+++ b/lib/network/NetworkUtil.js
@@ -15,6 +15,7 @@ class NetworkUtil {
    * @param {Array<vis.Node>} allNodes
    * @param {Array<vis.Node>} [specificNodes=[]]
    * @returns {{minX: number, maxX: number, minY: number, maxY: number}}
+   * @static
    */
   static getRange(allNodes, specificNodes = []) {
     var minY = 1e9, maxY = -1e9, minX = 1e9, maxX = -1e9, node;
@@ -48,6 +49,7 @@ class NetworkUtil {
    * @param {Array<vis.Node>} allNodes
    * @param {Array<vis.Node>} [specificNodes=[]]
    * @returns {{minX: number, maxX: number, minY: number, maxY: number}}
+   * @static
    */
   static getRangeCore(allNodes, specificNodes = []) {
     var minY = 1e9, maxY = -1e9, minX = 1e9, maxX = -1e9, node;
@@ -79,6 +81,7 @@ class NetworkUtil {
   /**
    * @param {object} range = {minX: minX, maxX: maxX, minY: minY, maxY: maxY};
    * @returns {{x: number, y: number}}
+   * @static
    */
   static findCenter(range) {
     return {x: (0.5 * (range.maxX + range.minX)),
@@ -91,6 +94,7 @@ class NetworkUtil {
    * @param {vis.Item} item
    * @param {'node'|undefined} type
    * @returns {{}}
+   * @static
    */
   static cloneOptions(item, type) {
     let clonedOptions = {};

--- a/lib/network/NetworkUtil.js
+++ b/lib/network/NetworkUtil.js
@@ -12,8 +12,8 @@ class NetworkUtil {
   /**
    * Find the center position of the network considering the bounding boxes
    *
-   * @param {Array<Node>} allNodes
-   * @param {Array<Node>} [specificNodes=[]]
+   * @param {Array.<Node>} allNodes
+   * @param {Array.<Node>} [specificNodes=[]]
    * @returns {{minX: number, maxX: number, minY: number, maxY: number}}
    * @static
    */
@@ -46,8 +46,8 @@ class NetworkUtil {
   /**
    * Find the center position of the network
    *
-   * @param {Array<Node>} allNodes
-   * @param {Array<Node>} [specificNodes=[]]
+   * @param {Array.<Node>} allNodes
+   * @param {Array.<Node>} [specificNodes=[]]
    * @returns {{minX: number, maxX: number, minY: number, maxY: number}}
    * @static
    */

--- a/lib/network/dotparser.js
+++ b/lib/network/dotparser.js
@@ -6,7 +6,7 @@
  *
  * DOT language attributes: http://graphviz.org/content/attrs
  *
- * @param {String} data     Text containing a graph in DOT-notation
+ * @param {string} data     Text containing a graph in DOT-notation
  * @return {Object} graph   An object containing two parameters:
  *                          {Object[]} nodes
  *                          {Object[]} edges
@@ -104,7 +104,7 @@ function next() {
 
 /**
  * Preview the next character from the dot file.
- * @return {String} cNext
+ * @return {string} cNext
  */
 function nextPreview() {
   return dot.charAt(index + 1);
@@ -113,7 +113,7 @@ function nextPreview() {
 var regexAlphaNumeric = /[a-zA-Z_0-9.:#]/;
 /**
  * Test whether given character is alphabetic or numeric
- * @param {String} c
+ * @param {string} c
  * @return {Boolean} isAlphaNumeric
  */
 function isAlphaNumeric(c) {
@@ -149,7 +149,7 @@ function merge (a, b) {
  *     setValue(obj, 'b.c', 3);     // obj = {a: 2, b: {c: 3}}
  *
  * @param {Object} obj
- * @param {String} path  A parameter name or dot-separated parameter path,
+ * @param {string} path  A parameter name or dot-separated parameter path,
  *                      like "color.highlight.border".
  * @param {*} value
  */
@@ -248,9 +248,9 @@ function addEdge(graph, edge) {
 /**
  * Create an edge to a graph object
  * @param {Object} graph
- * @param {String | Number | Object} from
- * @param {String | Number | Object} to
- * @param {String} type
+ * @param {string | number | Object} from
+ * @param {string | number | Object} to
+ * @param {string} type
  * @param {Object | null} attr
  * @return {Object} edge
  */
@@ -621,7 +621,7 @@ function parseAttributeStatement (graph) {
 /**
  * parse a node statement
  * @param {Object} graph
- * @param {String | Number} id
+ * @param {string | number} id
  */
 function parseNodeStatement(graph, id) {
   // node statement
@@ -641,7 +641,7 @@ function parseNodeStatement(graph, id) {
 /**
  * Parse an edge or a series of edges
  * @param {Object} graph
- * @param {String | Number} from        Id of the from node
+ * @param {string | number} from        Id of the from node
  */
 function parseEdge(graph, from) {
   while (token === '->' || token === '--') {
@@ -734,7 +734,7 @@ function parseAttributeList() {
 
 /**
  * Create a syntax error with extra information on current token and index.
- * @param {String} message
+ * @param {string} message
  * @returns {SyntaxError} err
  */
 function newSyntaxError(message) {
@@ -743,8 +743,8 @@ function newSyntaxError(message) {
 
 /**
  * Chop off text after a maximum length
- * @param {String} text
- * @param {Number} maxLength
+ * @param {string} text
+ * @param {number} maxLength
  * @returns {String}
  */
 function chop (text, maxLength) {
@@ -843,7 +843,7 @@ function convertAttr (attr, mapping) {
 /**
  * Convert a string containing a graph in DOT language into a map containing
  * with nodes and edges in the format of graph.
- * @param {String} data         Text containing a graph in DOT-notation
+ * @param {string} data         Text containing a graph in DOT-notation
  * @return {Object} graphData
  */
 function DOTToGraph (data) {

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -9,12 +9,11 @@ let util = require('../../util');
  * contains a canvas, and this canvas contains all objects like the axis and
  * nodes.
  *
- * @class Canvas
+ * @param {Object} body
  */
 class Canvas {
   /**
-   * @param {Object} body
-   * @constructor Canvas
+   * @inheritDoc
    */
   constructor(body) {
     this.body = body;

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -164,7 +164,6 @@ class Canvas {
    * @param {number|string} value
    * @returns {string}
    * @private
-   * @static
    */
   _prepareValue(value) {
     if (typeof value === 'number') {

--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -102,7 +102,7 @@ class Canvas {
   /**
    * Get and store the cameraState
    *
-   * @param {Number} [pixelRatio=this.pixelRatio]
+   * @param {number} [pixelRatio=this.pixelRatio]
    * @private
    */
   _getCameraState(pixelRatio = this.pixelRatio) {

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -288,7 +288,7 @@ class CanvasRenderer {
    * Redraw all nodes
    *
    * @param {CanvasRenderingContext2D}   ctx
-   * @param {Boolean} [alwaysShow]
+   * @param {boolean} [alwaysShow]
    * @private
    */
   _resizeNodes() {
@@ -318,7 +318,7 @@ class CanvasRenderer {
    * Redraw all nodes
    *
    * @param {CanvasRenderingContext2D} ctx  2D context of a HTML canvas
-   * @param {Boolean} [alwaysShow]
+   * @param {boolean} [alwaysShow]
    * @private
    */
   _drawNodes(ctx, alwaysShow = false) {

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -44,13 +44,12 @@ function _initRequestAnimationFrame() {
 let util = require('../../util');
 
 /**
- * @class CanvasRenderer
+ * @param {Object} body
+ * @param {Canvas} canvas
  */
 class CanvasRenderer {
   /**
-   * @param {Object} body
-   * @param {Canvas} canvas
-   * @constructor CanvasRenderer
+   * @inheritDoc
    */
   constructor(body, canvas) {
     _initRequestAnimationFrame();

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -99,12 +99,11 @@ var Edge = require('./components/Edge').default;  // Only needed for check on ty
 var Node = require('./components/Node').default;  // Only needed for check on type!
 
 /**
- * @class ClusterEngine
+ * @param {Object} body
  */
 class ClusterEngine {
   /**
-   * @param {Object} body
-   * @constructor ClusterEngine
+   * @inheritDoc
    */
   constructor(body) {
     this.body = body;
@@ -284,7 +283,7 @@ class ClusterEngine {
 
   /**
   * suck all connected nodes of a node into the node.
-  * @param {vis.Node.id} nodeId
+  * @param {Node.id} nodeId
   * @param {Object} options
   * @param {Boolean} [refreshData=true]
   */
@@ -360,7 +359,7 @@ class ClusterEngine {
   * This function creates the edges that will be attached to the cluster
   * It looks for edges that are connected to the nodes from the "outside' of the cluster.
   *
-  * @param {{vis.Node.id: vis.Node}} childNodesObj
+  * @param {{Node.id: vis.Node}} childNodesObj
   * @param {{vis.Edge.id: vis.Edge}} childEdgesObj
   * @param {Object} clusterNodeProperties
   * @param {Object} clusterEdgeProperties
@@ -609,7 +608,7 @@ class ClusterEngine {
 
   /**
   * Check if a node is a cluster.
-  * @param {vis.Node.id} nodeId
+  * @param {Node.id} nodeId
   * @returns {*}
   */
   isCluster(nodeId) {
@@ -947,7 +946,7 @@ class ClusterEngine {
   /**
   * Get the Id the node is connected to
   * @param {vis.Edge} edge
-  * @param {vis.Node.id} nodeId
+  * @param {Node.id} nodeId
   * @returns {*}
   * @private
   */
@@ -1005,8 +1004,8 @@ class ClusterEngine {
   /**
    * Create an edge for the cluster representation.
    *
-   * @param {vis.Node.id} fromId
-   * @param {vis.Node.id} toId
+   * @param {Node.id} fromId
+   * @param {Node.id} toId
    * @param {vis.Edge} baseEdge
    * @param {Object} clusterEdgeProperties
    * @param {Object} extraOptions
@@ -1107,7 +1106,7 @@ class ClusterEngine {
    *
    * NOTE: If you know a cleaner way to do this, please enlighten me (wimrijnders).
    *
-   * @param {vis.Node.id} nodeId
+   * @param {Node.id} nodeId
    * @returns {Node|undefined} Node instance for cluster, if present
    * @private
    */
@@ -1313,7 +1312,7 @@ class ClusterEngine {
  /**
   * Determine if node with given id is part of a cluster.
   *
-  * @param {vis.Node.id} nodeId
+  * @param {Node.id} nodeId
   * @return {boolean} true if part of a cluster.
   */
   _isClusteredNode(nodeId) {

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -119,7 +119,7 @@ class ClusterEngine {
 
   /**
   *
-  * @param {Number} hubsize
+  * @param {number} hubsize
   * @param {Object} options
   */
   clusterByHubsize(hubsize, options) {
@@ -150,7 +150,7 @@ class ClusterEngine {
   /**
    * loop over all nodes, check if they adhere to the condition and cluster if needed.
    * @param {Object} options
-   * @param {Boolean} [refreshData=true]
+   * @param {boolean} [refreshData=true]
    */
   cluster(options = {}, refreshData = true) {
     if (options.joinCondition === undefined) {throw new Error("Cannot call clusterByNodeData without a joinCondition function in the options.");}
@@ -186,9 +186,9 @@ class ClusterEngine {
 
   /**
    * Cluster all nodes in the network that have only X edges
-   * @param {Number} edgeCount
+   * @param {number} edgeCount
    * @param {Object} options
-   * @param {Boolean} [refreshData=true]
+   * @param {boolean} [refreshData=true]
    */
   clusterByEdgeCount(edgeCount, options, refreshData = true) {
     options = this._checkOptions(options);
@@ -302,7 +302,7 @@ class ClusterEngine {
   /**
    * Cluster all nodes in the network that have only 1 edge
    * @param {Object} options
-   * @param {Boolean} [refreshData=true]
+   * @param {boolean} [refreshData=true]
    */
   clusterOutliers(options, refreshData = true) {
     this.clusterByEdgeCount(1,options,refreshData);
@@ -311,7 +311,7 @@ class ClusterEngine {
   /**
    * Cluster all nodes in the network that have only 2 edge
    * @param {Object} options
-   * @param {Boolean} [refreshData=true]
+   * @param {boolean} [refreshData=true]
    */
   clusterBridges(options, refreshData = true) {
     this.clusterByEdgeCount(2,options,refreshData);
@@ -323,7 +323,7 @@ class ClusterEngine {
   * suck all connected nodes of a node into the node.
   * @param {Node.id} nodeId
   * @param {Object} options
-  * @param {Boolean} [refreshData=true]
+  * @param {boolean} [refreshData=true]
   */
   clusterByConnection(nodeId, options, refreshData = true) {
     // kill conditions
@@ -524,7 +524,7 @@ class ClusterEngine {
   * @param {Object}    childNodesObj         | object with node objects, id as keys, same as childNodes except it also contains a source node
   * @param {Object}    childEdgesObj         | object with edge objects, id as keys
   * @param {Array}     options               | object with {clusterNodeProperties, clusterEdgeProperties, processProperties}
-  * @param {Boolean}   refreshData | when true, do not wrap up
+  * @param {boolean}   refreshData | when true, do not wrap up
   * @private
   */
   _cluster(childNodesObj, childEdgesObj, options, refreshData = true) {
@@ -690,7 +690,7 @@ class ClusterEngine {
    * Open a cluster by calling this function.
    * @param {vis.Edge.id}  clusterNodeId | the ID of the cluster node
    * @param {Object} options
-   * @param {Boolean} refreshData | wrap up afterwards if not true
+   * @param {boolean} refreshData | wrap up afterwards if not true
    */
   openCluster(clusterNodeId, options, refreshData = true) {
     // kill conditions
@@ -824,7 +824,7 @@ class ClusterEngine {
   /**
    *
    * @param {Cluster.id} clusterId
-   * @returns {Array<Node.id>}
+   * @returns {Array.<Node.id>}
    */
   getNodesInCluster(clusterId) {
     let nodesArray = [];
@@ -906,7 +906,7 @@ class ClusterEngine {
   /**
   * Get a stack of clusterEdgeId's (+base edgeid) that a base edge is the same as. cluster edge C -> cluster edge B -> cluster edge A -> base edge(edgeId)
   * @param {vis.Edge.id} edgeId
-  * @returns {Array<vis.Edge.id>}
+  * @returns {Array.<vis.Edge.id>}
   */
   getClusteredEdges(edgeId) {
     let stack = [];
@@ -939,7 +939,7 @@ class ClusterEngine {
    * Get all regular edges for this clustered edge id.
    *
    * @param {vis.Edge.id} clusteredEdgeId
-   * @returns {Array<vis.Edge.id>} all baseEdgeId's under this clustered edge
+   * @returns {Array.<vis.Edge.id>} all baseEdgeId's under this clustered edge
    */
   getBaseEdges(clusteredEdgeId) {
     let IdsToHandle = [clusteredEdgeId];
@@ -1004,7 +1004,7 @@ class ClusterEngine {
   * We determine how many connections denote an important hub.
   * We take the mean + 2*std as the important hub size. (Assuming a normal distribution of data, ~2.2%)
   *
-  * @returns {Number}
+  * @returns {number}
   * @private
   */
   _getHubSize() {

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -7,8 +7,8 @@ var Label = require("./components/shared/Label").default;
 
 /**
  * @param {Object} body
- * @param {Array<Image>} images
- * @param {Array<Group>} groups
+ * @param {Array.<Image>} images
+ * @param {Array.<Group>} groups
  */
 class EdgesHandler {
   /**
@@ -278,7 +278,7 @@ class EdgesHandler {
 
   /**
    * Add edges
-   * @param {Number[] | String[]} ids
+   * @param {number[] | string[]} ids
    * @param {boolean} [doNotEmit=false]
    * @private
    */
@@ -309,7 +309,7 @@ class EdgesHandler {
 
   /**
    * Update existing edges, or create them when not yet existing
-   * @param {Number[] | String[]} ids
+   * @param {number[] | string[]} ids
    * @private
    */
   update(ids) {
@@ -345,7 +345,7 @@ class EdgesHandler {
 
   /**
    * Remove existing edges. Non existing ids will be ignored
-   * @param {Number[] | String[]} ids
+   * @param {number[] | string[]} ids
    * @param {boolean} [emit=true]
    * @private
    */

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -6,14 +6,13 @@ var Edge = require("./components/Edge").default;
 var Label = require("./components/shared/Label").default;
 
 /**
- * @class EdgesHandler
+ * @param {Object} body
+ * @param {Array<Image>} images
+ * @param {Array<Group>} groups
  */
 class EdgesHandler {
   /**
-   * @param {Object} body
-   * @param {Array<Image>} images
-   * @param {Array<Group>} groups
-   * @constructor EdgesHandler
+   * @inheritDoc
    */
   constructor(body, images, groups) {
     this.body = body;

--- a/lib/network/modules/Groups.js
+++ b/lib/network/modules/Groups.js
@@ -2,11 +2,10 @@ let util = require('../../util');
 
 /**
  * This class can store groups and options specific for groups.
- * @class Groups
  */
 class Groups {
   /**
-   * @constructor Groups
+   * @inheritDoc
    */
   constructor() {
     this.clear();

--- a/lib/network/modules/Groups.js
+++ b/lib/network/modules/Groups.js
@@ -106,7 +106,7 @@ class Groups {
   
   /**
    * Add a custom group style
-   * @param {String} groupName
+   * @param {string} groupName
    * @param {Object} style       An object containing borderColor,
    *                             backgroundColor, etc.
    * @return {Object} group      The created group object

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -4,14 +4,13 @@ var NavigationHandler = require('./components/NavigationHandler').default;
 var Popup = require('./../../shared/Popup').default;
 
 /**
- * @class InteractionHandler
+ * @param {Object} body
+ * @param {Canvas} canvas
+ * @param {SelectionHandler} selectionHandler
  */
 class InteractionHandler {
   /**
-   * @param {Object} body
-   * @param {Canvas} canvas
-   * @param {SelectionHandler} selectionHandler
-   * @constructor InteractionHandler
+   * @inheritDoc
    */
   constructor(body, canvas, selectionHandler) {
     this.body = body;
@@ -253,9 +252,9 @@ class InteractionHandler {
   /**
    * Remove all node and edge id's from the first set that are present in the second one.
    *
-   * @param {{nodes: Array<vis.Node>, edges: Array<vis.Edge>}} firstSet
-   * @param {{nodes: Array<vis.Node>, edges: Array<vis.Edge>}} secondSet
-   * @returns {{nodes: Array<vis.Node>, edges: Array<vis.Edge>}}
+   * @param {{nodes: Array<Node>, edges: Array<vis.Edge>}} firstSet
+   * @param {{nodes: Array<Node>, edges: Array<vis.Edge>}} secondSet
+   * @returns {{nodes: Array<Node>, edges: Array<vis.Edge>}}
    * @private
    */
   _determineDifference(firstSet, secondSet) {

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -97,8 +97,8 @@ class InteractionHandler {
 
   /**
    * Get the pointer location from a touch location
-   * @param {{x: Number, y: Number}} touch
-   * @return {{x: Number, y: Number}} pointer
+   * @param {{x: number, y: number}} touch
+   * @return {{x: number, y: number}} pointer
    * @private
    */
   getPointer(touch) {
@@ -203,7 +203,7 @@ class InteractionHandler {
    *
    * TODO: This is all SelectionHandler calls; the method should be moved to there.
    *
-   * @param {{x: Number, y: Number}} pointer
+   * @param {{x: number, y: number}} pointer
    * @param {Event} event
    * @param {boolean} [add=false]
    */
@@ -252,9 +252,9 @@ class InteractionHandler {
   /**
    * Remove all node and edge id's from the first set that are present in the second one.
    *
-   * @param {{nodes: Array<Node>, edges: Array<vis.Edge>}} firstSet
-   * @param {{nodes: Array<Node>, edges: Array<vis.Edge>}} secondSet
-   * @returns {{nodes: Array<Node>, edges: Array<vis.Edge>}}
+   * @param {{nodes: Array.<Node>, edges: Array.<vis.Edge>}} firstSet
+   * @param {{nodes: Array.<Node>, edges: Array.<vis.Edge>}} secondSet
+   * @returns {{nodes: Array.<Node>, edges: Array.<vis.Edge>}}
    * @private
    */
   _determineDifference(firstSet, secondSet) {
@@ -445,8 +445,8 @@ class InteractionHandler {
 
   /**
    * Zoom the network in or out
-   * @param {Number} scale a number around 1, and between 0.01 and 10
-   * @param {{x: Number, y: Number}} pointer    Position on screen
+   * @param {number} scale a number around 1, and between 0.01 and 10
+   * @param {{x: number, y: number}} pointer    Position on screen
    * @private
    */
   zoom(scale, pointer) {
@@ -591,7 +591,7 @@ class InteractionHandler {
    * (a node or edge). If so, and if this element has a title,
    * show a popup window with its title.
    *
-   * @param {{x:Number, y:Number}} pointer
+   * @param {{x:number, y:number}} pointer
    * @private
    */
  _checkShowPopup(pointer) {
@@ -684,7 +684,7 @@ class InteractionHandler {
   /**
    * Check if the popup must be hidden, which is the case when the mouse is no
    * longer hovering on the object
-   * @param {{x:Number, y:Number}} pointer
+   * @param {{x:number, y:number}} pointer
    * @private
    */
  _checkHidePopup(pointer) {

--- a/lib/network/modules/KamadaKawai.js
+++ b/lib/network/modules/KamadaKawai.js
@@ -10,14 +10,13 @@ import FloydWarshall from "./components/algorithms/FloydWarshall.js"
  *
  * Possible optimizations in the distance calculation can be implemented.
  *
- * @class KamadaKawai
+ * @param {Object} body
+ * @param {Number} edgeLength
+ * @param {Number} edgeStrength
  */
 class KamadaKawai {
   /**
-   * @param {Object} body
-   * @param {Number} edgeLength
-   * @param {Number} edgeStrength
-   * @constructor KamadaKawai
+   * @inheritDoc
    */
   constructor(body, edgeLength, edgeStrength) {
     this.body = body;
@@ -44,7 +43,7 @@ class KamadaKawai {
 
   /**
    * Position the system
-   * @param {Array<vis.Node>} nodesArray
+   * @param {Array<Node>} nodesArray
    * @param {Array<vis.Edge>} edgesArray
    * @param {boolean} [ignoreClusters=false]
    */
@@ -116,7 +115,7 @@ class KamadaKawai {
 
   /**
    * calculate the energy of a single node
-   * @param {vis.Node.id} m
+   * @param {Node.id} m
    * @returns {Number[]}
    * @private
    */

--- a/lib/network/modules/KamadaKawai.js
+++ b/lib/network/modules/KamadaKawai.js
@@ -11,8 +11,8 @@ import FloydWarshall from "./components/algorithms/FloydWarshall.js"
  * Possible optimizations in the distance calculation can be implemented.
  *
  * @param {Object} body
- * @param {Number} edgeLength
- * @param {Number} edgeStrength
+ * @param {number} edgeLength
+ * @param {number} edgeStrength
  */
 class KamadaKawai {
   /**
@@ -43,8 +43,8 @@ class KamadaKawai {
 
   /**
    * Position the system
-   * @param {Array<Node>} nodesArray
-   * @param {Array<vis.Edge>} edgesArray
+   * @param {Array.<Node>} nodesArray
+   * @param {Array.<vis.Edge>} edgesArray
    * @param {boolean} [ignoreClusters=false]
    */
   solve(nodesArray, edgesArray, ignoreClusters = false) {
@@ -86,7 +86,7 @@ class KamadaKawai {
   /**
    * get the node with the highest energy
    * @param {boolean} ignoreClusters
-   * @returns {Number[]}
+   * @returns {number[]}
    * @private
    */
   _getHighestEnergyNode(ignoreClusters) {
@@ -116,7 +116,7 @@ class KamadaKawai {
   /**
    * calculate the energy of a single node
    * @param {Node.id} m
-   * @returns {Number[]}
+   * @returns {number[]}
    * @private
    */
   _getEnergy(m) {
@@ -128,9 +128,9 @@ class KamadaKawai {
   /**
    * move the node based on it's energy
    * the dx and dy are calculated from the linear system proposed by Kamada and Kawai
-   * @param {Number} m
-   * @param {Number} dE_dx
-   * @param {Number} dE_dy
+   * @param {number} m
+   * @param {number} dE_dx
+   * @param {number} dE_dy
    * @private
    */
   _moveNode(m, dE_dx, dE_dy) {
@@ -252,7 +252,7 @@ class KamadaKawai {
   /**
    * Update method, just doing single column (rows are auto-updated) (update all sums)
    *
-   * @param {Number} m
+   * @param {number} m
    * @private
    */
   _updateE_matrix(m) {

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -37,12 +37,11 @@ var NetworkUtil = require('../NetworkUtil').default;
 /**
  * Container for derived data on current network, relating to hierarchy.
  *
- * @class HierarchicalStatus
  * @private
  */
 class HierarchicalStatus {
   /**
-   * @constructor HierarchicalStatus
+   * @inheritDoc
    */
   constructor() {
     this.childrenReference = {};     // child id's per node id
@@ -60,8 +59,8 @@ class HierarchicalStatus {
   /**
    * Add the relation between given nodes to the current state.
    *
-   * @param {vis.Node.id} parentNodeId
-   * @param {vis.Node.id} childNodeId
+   * @param {Node.id} parentNodeId
+   * @param {Node.id} childNodeId
    */
   addRelation(parentNodeId, childNodeId) {
     if (this.childrenReference[parentNodeId] === undefined) {
@@ -106,7 +105,7 @@ class HierarchicalStatus {
 
   /**
    * Assign a tree id to a node
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {String|Number} treeId
    */
   setTreeIndex(node, treeId) {
@@ -122,7 +121,7 @@ class HierarchicalStatus {
    *
    * Sets level to zero for given node id if not already present
    *
-   * @param {vis.Node.id} nodeId
+   * @param {Node.id} nodeId
    */
   ensureLevel(nodeId) {
     if (this.levels[nodeId] === undefined) {
@@ -135,7 +134,7 @@ class HierarchicalStatus {
    * get the maximum level of a branch.
    *
    * TODO: Never entered; find a test case to test this!
-   * @param {vis.Node.id} nodeId
+   * @param {Node.id} nodeId
    * @returns {Number}
    */
   getMaxLevel(nodeId) {
@@ -182,7 +181,7 @@ class HierarchicalStatus {
   /**
    * Small util method to set the minimum levels of the nodes to zero.
    *
-   * @param {Array<vis.Node>} nodes
+   * @param {Array<Node>} nodes
    */
   setMinLevelToZero(nodes) {
     let minLevel = 1e9;
@@ -209,7 +208,7 @@ class HierarchicalStatus {
   /**
    * Get the min and max xy-coordinates of a given tree
    *
-   * @param {Array<vis.Node>} nodes
+   * @param {Array<Node>} nodes
    * @param {Number} index
    * @returns {{min_x: number, max_x: number, min_y: number, max_y: number}}
    */
@@ -243,8 +242,8 @@ class HierarchicalStatus {
   /**
    * Check if two nodes have the same parent(s)
    *
-   * @param {vis.Node} node1
-   * @param {vis.Node} node2
+   * @param {Node} node1
+   * @param {Node} node2
    * @return {boolean} true if the two nodes have a same ancestor node, false otherwise
    */
   hasSameParent(node1, node2) {
@@ -268,8 +267,8 @@ class HierarchicalStatus {
   /**
    * Check if two nodes are in the same tree.
    *
-   * @param {vis.Node} node1
-   * @param {vis.Node} node2
+   * @param {Node} node1
+   * @param {Node} node2
    * @return {Boolean} true if this is so, false otherwise
    */
   inSameSubNetwork(node1, node2) {
@@ -290,7 +289,7 @@ class HierarchicalStatus {
   /**
    * Add a node to the ordering per level
    *
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {Number} level
    */
   addToOrdering(node, level) {
@@ -316,12 +315,11 @@ class HierarchicalStatus {
 }
 
 /**
- * @class LayoutEngine
+ * @param {Object} body
  */
 class LayoutEngine {
   /**
-   * @param {Object} body
-   * @constructor LayoutEngine
+   * @inheritDoc
    */
   constructor(body) {
     this.body = body;
@@ -1135,8 +1133,8 @@ class LayoutEngine {
   /**
    * This gives the space around the node. IF a map is supplied, it will only check against nodes NOT in the map.
    * This is used to only get the distances to nodes outside of a branch.
-   * @param {vis.Node} node
-   * @param {{vis.Node.id: vis.Node}} map
+   * @param {Node} node
+   * @param {{Node.id: vis.Node}} map
    * @returns {Number[]}
    * @private
    */
@@ -1178,7 +1176,7 @@ class LayoutEngine {
 
   /**
    * We use this method to center a parent node and check if it does not cross other nodes when it does.
-   * @param {vis.Node} node
+   * @param {Node} node
    * @private
    */
   _centerParent(node) {
@@ -1248,7 +1246,7 @@ class LayoutEngine {
    * This is a recursively called function to enumerate the branches from the largest hubs and place the nodes
    * on a X position that ensures there will be no overlap.
    *
-   * @param {vis.Node.id} parentId
+   * @param {Node.id} parentId
    * @param {Number} parentLevel
    * @private
    */
@@ -1300,7 +1298,7 @@ class LayoutEngine {
   /**
    * This method checks for overlap and if required shifts the branch. It also keeps records of positioned nodes.
    * Finally it will call _placeBranchNodes to place the branch nodes.
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {Number} level
    * @param {Number} pos
    * @private
@@ -1328,8 +1326,8 @@ class LayoutEngine {
   /**
    * Receives an array with node indices and returns an array with the actual node references.
    * Used for sorting based on node properties.
-   * @param {Array<vis.Node.id>} idArray
-   * @returns {Array<vis.Node>}
+   * @param {Array<Node.id>} idArray
+   * @returns {Array<Node>}
    */
   _indexArrayToNodes(idArray) {
     let array = [];
@@ -1377,7 +1375,7 @@ class LayoutEngine {
   /**
    * Return the active (i.e. visible) edges for this node
    *
-   * @param {vis.Node} node
+   * @param {Node} node
    * @returns {Array<vis.Edge>} Array of edge instances
    * @private
    */
@@ -1554,7 +1552,7 @@ class LayoutEngine {
   /**
    * Crawl over the entire network and use a callback on each node couple that is connected to each other.
    * @param {function} [callback=function(){}]          | will receive nodeA, nodeB and the connecting edge. A and B are distinct.
-   * @param {vis.Node.id} startingNodeId
+   * @param {Node.id} startingNodeId
    * @private
    */
   _crawlNetwork(callback = function() {}, startingNodeId) {
@@ -1615,7 +1613,7 @@ class LayoutEngine {
 
   /**
    * Shift a branch a certain distance
-   * @param {vis.Node.id} parentId
+   * @param {Node.id} parentId
    * @param {number} diff
    * @private
    */
@@ -1646,8 +1644,8 @@ class LayoutEngine {
 
   /**
    * Find a common parent between branches.
-   * @param {vis.Node.id} childA
-   * @param {vis.Node.id} childB
+   * @param {Node.id} childA
+   * @param {Node.id} childB
    * @returns {{foundParent, withChild}}
    * @private
    */
@@ -1686,7 +1684,7 @@ class LayoutEngine {
 
   /**
    * Abstract the getting of the position so we won't have to repeat the check for direction all the time
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {{x: Number, y: Number}} position
    * @param {Number} level
    * @param {boolean} [doNotUpdate=false]
@@ -1720,7 +1718,7 @@ class LayoutEngine {
 
   /**
    * Abstract the getting of the position of a node so we do not have to repeat the direction check all the time.
-   * @param {vis.Node} node
+   * @param {Node} node
    * @returns {number|*}
    * @private
    */
@@ -1736,7 +1734,7 @@ class LayoutEngine {
   /**
    * Use the x or y value to sort the array, allowing users to specify order.
    *
-   * @param {Array<vis.Node>} nodeArray
+   * @param {Array<Node>} nodeArray
    * @private
    */
   _sortNodeArray(nodeArray) {
@@ -1778,7 +1776,7 @@ class LayoutEngine {
    * Determine the center position of a branch from the passed list of child nodes
    *
    * This takes into account the positions of all the child nodes.
-   * @param {Array<vis.Node|vis.Node.id>} childNodes  Array of either child nodes or node id's
+   * @param {Array<Node|vis.Node.id>} childNodes  Array of either child nodes or node id's
    * @return {number}
    * @private
    */

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -96,7 +96,7 @@ class HierarchicalStatus {
 
   /**
    * Return the number of separate trees in the current network.
-   * @returns {Number}
+   * @returns {number}
    */
   numTrees() {
     return (this.treeIndex + 1);  // This assumes the indexes are assigned consecitively
@@ -106,7 +106,7 @@ class HierarchicalStatus {
   /**
    * Assign a tree id to a node
    * @param {Node} node
-   * @param {String|Number} treeId
+   * @param {string|number} treeId
    */
   setTreeIndex(node, treeId) {
     if (this.trees[node.id] === undefined) {
@@ -135,7 +135,7 @@ class HierarchicalStatus {
    *
    * TODO: Never entered; find a test case to test this!
    * @param {Node.id} nodeId
-   * @returns {Number}
+   * @returns {number}
    */
   getMaxLevel(nodeId) {
     let accumulator = {};
@@ -181,7 +181,7 @@ class HierarchicalStatus {
   /**
    * Small util method to set the minimum levels of the nodes to zero.
    *
-   * @param {Array<Node>} nodes
+   * @param {Array.<Node>} nodes
    */
   setMinLevelToZero(nodes) {
     let minLevel = 1e9;
@@ -208,8 +208,8 @@ class HierarchicalStatus {
   /**
    * Get the min and max xy-coordinates of a given tree
    *
-   * @param {Array<Node>} nodes
-   * @param {Number} index
+   * @param {Array.<Node>} nodes
+   * @param {number} index
    * @returns {{min_x: number, max_x: number, min_y: number, max_y: number}}
    */
   getTreeSize(nodes, index) {
@@ -290,7 +290,7 @@ class HierarchicalStatus {
    * Add a node to the ordering per level
    *
    * @param {Node} node
-   * @param {Number} level
+   * @param {number} level
    */
   addToOrdering(node, level) {
     if (this.distributionOrdering[level] === undefined) {
@@ -514,7 +514,7 @@ class LayoutEngine {
 
   /**
    *
-   * @param {Array<Node>} nodesArray
+   * @param {Array.<Node>} nodesArray
    */
   positionInitially(nodesArray) {
     if (this.options.hierarchical.enabled !== true) {
@@ -856,7 +856,7 @@ class LayoutEngine {
      * Condense elements. These can be nodes or branches depending on the callback.
      *
      * @param {function} callback
-     * @param {Array<Number>} levels
+     * @param {Array.<number>} levels
      * @param {*} centerParents
      */
     let shiftElementsCloser = (callback, levels, centerParents) => {
@@ -1135,7 +1135,7 @@ class LayoutEngine {
    * This is used to only get the distances to nodes outside of a branch.
    * @param {Node} node
    * @param {{Node.id: vis.Node}} map
-   * @returns {Number[]}
+   * @returns {number[]}
    * @private
    */
   _getSpaceAroundNode(node, map) {
@@ -1247,7 +1247,7 @@ class LayoutEngine {
    * on a X position that ensures there will be no overlap.
    *
    * @param {Node.id} parentId
-   * @param {Number} parentLevel
+   * @param {number} parentLevel
    * @private
    */
   _placeBranchNodes(parentId, parentLevel) {
@@ -1299,8 +1299,8 @@ class LayoutEngine {
    * This method checks for overlap and if required shifts the branch. It also keeps records of positioned nodes.
    * Finally it will call _placeBranchNodes to place the branch nodes.
    * @param {Node} node
-   * @param {Number} level
-   * @param {Number} pos
+   * @param {number} level
+   * @param {number} pos
    * @private
    */
   _validatePositionAndContinue(node, level, pos) {
@@ -1326,8 +1326,8 @@ class LayoutEngine {
   /**
    * Receives an array with node indices and returns an array with the actual node references.
    * Used for sorting based on node properties.
-   * @param {Array<Node.id>} idArray
-   * @returns {Array<Node>}
+   * @param {Array.<Node.id>} idArray
+   * @returns {Array.<Node>}
    */
   _indexArrayToNodes(idArray) {
     let array = [];
@@ -1376,7 +1376,7 @@ class LayoutEngine {
    * Return the active (i.e. visible) edges for this node
    *
    * @param {Node} node
-   * @returns {Array<vis.Edge>} Array of edge instances
+   * @returns {Array.<vis.Edge>} Array of edge instances
    * @private
    */
   _getActiveEdges(node) {
@@ -1685,8 +1685,8 @@ class LayoutEngine {
   /**
    * Abstract the getting of the position so we won't have to repeat the check for direction all the time
    * @param {Node} node
-   * @param {{x: Number, y: Number}} position
-   * @param {Number} level
+   * @param {{x: number, y: number}} position
+   * @param {number} level
    * @param {boolean} [doNotUpdate=false]
    * @private
    */
@@ -1734,7 +1734,7 @@ class LayoutEngine {
   /**
    * Use the x or y value to sort the array, allowing users to specify order.
    *
-   * @param {Array<Node>} nodeArray
+   * @param {Array.<Node>} nodeArray
    * @private
    */
   _sortNodeArray(nodeArray) {
@@ -1776,7 +1776,7 @@ class LayoutEngine {
    * Determine the center position of a branch from the passed list of child nodes
    *
    * This takes into account the positions of all the child nodes.
-   * @param {Array<Node|vis.Node.id>} childNodes  Array of either child nodes or node id's
+   * @param {Array.<Node|vis.Node.id>} childNodes  Array of either child nodes or node id's
    * @return {number}
    * @private
    */

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -6,14 +6,14 @@ let hammerUtil = require('../../hammerUtil');
 /**
  * clears the toolbar div element of children
  *
- * @class ManipulationSystem
+ * @param {Object} body
+ * @param {Canvas} canvas
+ * @param {SelectionHandler} selectionHandler
  * @private
  */
 class ManipulationSystem {
   /**
-   * @param {Object} body
-   * @param {Canvas} canvas
-   * @param {SelectionHandler} selectionHandler
+   * @inheritDoc
    */
   constructor(body, canvas, selectionHandler) {
     this.body = body;
@@ -559,7 +559,7 @@ class ManipulationSystem {
    *
    * @param {Number} x
    * @param {Number} y
-   * @returns {vis.Node}
+   * @returns {Node}
    * @private
    */
   _getNewTargetNode(x,y) {
@@ -1176,8 +1176,8 @@ class ManipulationSystem {
   /**
    * connect two nodes with a new edge.
    *
-   * @param {vis.Node.id} sourceNodeId
-   * @param {vis.Node.id} targetNodeId
+   * @param {Node.id} sourceNodeId
+   * @param {Node.id} targetNodeId
    * @private
    */
   _performAddEdge(sourceNodeId, targetNodeId) {
@@ -1206,8 +1206,8 @@ class ManipulationSystem {
   /**
    * connect two nodes with a new edge.
    *
-   * @param {vis.Node.id} sourceNodeId
-   * @param {vis.Node.id} targetNodeId
+   * @param {Node.id} sourceNodeId
+   * @param {Node.id} targetNodeId
    * @private
    */
   _performEditEdge(sourceNodeId, targetNodeId) {

--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -557,8 +557,8 @@ class ManipulationSystem {
   /**
    * generate a new target node. Used for creating new edges and editing edges
    *
-   * @param {Number} x
-   * @param {Number} y
+   * @param {number} x
+   * @param {number} y
    * @returns {Node}
    * @private
    */
@@ -676,7 +676,7 @@ class ManipulationSystem {
 
   /**
    * create a seperator line. the index is to differentiate in the manipulation dom
-   * @param {Number} [index=1]
+   * @param {number} [index=1]
    * @private
    */
   _createSeperator(index = 1) {
@@ -805,7 +805,7 @@ class ManipulationSystem {
 
   /**
    * this overrides an UI function until cleanup by the clean function
-   * @param {String} UIfunctionName
+   * @param {string} UIfunctionName
    * @param {function} newFunction
    * @private
    */

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -6,15 +6,14 @@ var Node = require("./components/Node").default;
 var Label = require("./components/shared/Label").default;
 
 /**
- * @class NodesHandler
+ * @param {Object} body
+ * @param {Images} images
+ * @param {Array<Group>} groups
+ * @param {LayoutEngine} layoutEngine
  */
 class NodesHandler {
   /**
-   * @param {Object} body
-   * @param {Images} images
-   * @param {Array<Group>} groups
-   * @param {LayoutEngine} layoutEngine
-   * @constructor NodesHandler
+   * @inheritDoc
    */
   constructor(body, images, groups, layoutEngine) {
     this.body = body;
@@ -388,7 +387,7 @@ class NodesHandler {
 
   /**
    * Returns the positions of the nodes.
-   * @param {Array<vis.Node.id>|String} [ids]  --> optional, can be array of nodeIds, can be string
+   * @param {Array<Node.id>|String} [ids]  --> optional, can be array of nodeIds, can be string
    * @returns {{}}
    */
   getPositions(ids) {
@@ -440,7 +439,7 @@ class NodesHandler {
 
   /**
    * get the bounding box of a node.
-   * @param {vis.Node.id} nodeId
+   * @param {Node.id} nodeId
    * @returns {j|*}
    */
   getBoundingBox(nodeId) {
@@ -452,7 +451,7 @@ class NodesHandler {
 
   /**
    * Get the Ids of nodes connected to this node.
-   * @param {vis.Node.id} nodeId
+   * @param {Node.id} nodeId
    * @param {'to'|'from'|undefined} direction values 'from' and 'to' select respectively parent and child nodes only.
    *                                          Any other value returns both parent and child nodes.
    * @returns {Array}
@@ -483,7 +482,7 @@ class NodesHandler {
 
   /**
    * Get the ids of the edges connected to this node.
-   * @param {vis.Node.id} nodeId
+   * @param {Node.id} nodeId
    * @returns {*}
    */
   getConnectedEdges(nodeId) {
@@ -504,7 +503,7 @@ class NodesHandler {
   /**
    * Move a node.
    *
-   * @param {vis.Node.id} nodeId
+   * @param {Node.id} nodeId
    * @param {Number} x
    * @param {Number} y
    */

--- a/lib/network/modules/NodesHandler.js
+++ b/lib/network/modules/NodesHandler.js
@@ -8,7 +8,7 @@ var Label = require("./components/shared/Label").default;
 /**
  * @param {Object} body
  * @param {Images} images
- * @param {Array<Group>} groups
+ * @param {Array.<Group>} groups
  * @param {LayoutEngine} layoutEngine
  */
 class NodesHandler {
@@ -217,7 +217,7 @@ class NodesHandler {
   /**
    * Set a data set with nodes for the network
    * @param {Array | DataSet | DataView} nodes         The data containing the nodes.
-   * @param {Boolean} [doNotEmit=false]
+   * @param {boolean} [doNotEmit=false]
    * @private
    */
   setData(nodes, doNotEmit = false) {
@@ -267,8 +267,8 @@ class NodesHandler {
 
   /**
    * Add nodes
-   * @param {Number[] | String[]} ids
-   * @param {Boolean} [doNotEmit=false]
+   * @param {number[] | string[]} ids
+   * @param {boolean} [doNotEmit=false]
    * @private
    */
   add(ids, doNotEmit = false) {
@@ -291,7 +291,7 @@ class NodesHandler {
 
   /**
    * Update existing nodes, or create them when not yet existing
-   * @param {Number[] | String[]} ids id's of changed nodes
+   * @param {number[] | string[]} ids id's of changed nodes
    * @param {Array} changedData array with changed data
    * @param {Array|undefined} oldData optional; array with previous data
    * @private
@@ -337,7 +337,7 @@ class NodesHandler {
 
   /**
    * Remove existing nodes. If nodes do not exist, the method will just ignore it.
-   * @param {Number[] | String[]} ids
+   * @param {number[] | string[]} ids
    * @private
    */
   remove(ids) {
@@ -387,7 +387,7 @@ class NodesHandler {
 
   /**
    * Returns the positions of the nodes.
-   * @param {Array<Node.id>|String} [ids]  --> optional, can be array of nodeIds, can be string
+   * @param {Array.<Node.id>|String} [ids]  --> optional, can be array of nodeIds, can be string
    * @returns {{}}
    */
   getPositions(ids) {
@@ -504,8 +504,8 @@ class NodesHandler {
    * Move a node.
    *
    * @param {Node.id} nodeId
-   * @param {Number} x
-   * @param {Number} y
+   * @param {number} x
+   * @param {number} y
    */
   moveNode(nodeId, x, y) {
     if (this.body.nodes[nodeId] !== undefined) {

--- a/lib/network/modules/PhysicsEngine.js
+++ b/lib/network/modules/PhysicsEngine.js
@@ -11,12 +11,11 @@ var util = require('../../util');
 
 
 /**
- * @class PhysicsEngine
+ * @param {Object} body
  */
 class PhysicsEngine {
   /**
-   * @param {Object} body
-   * @constructor PhysicsEngine
+   * @inheritDoc
    */
   constructor(body) {
     this.body = body;
@@ -522,7 +521,7 @@ class PhysicsEngine {
   /**
    * Perform the actual step
    *
-   * @param {vis.Node.id} nodeId
+   * @param {Node.id} nodeId
    * @param {number} maxVelocity
    * @returns {number}
    * @private

--- a/lib/network/modules/PhysicsEngine.js
+++ b/lib/network/modules/PhysicsEngine.js
@@ -295,7 +295,7 @@ class PhysicsEngine {
   /**
    * trigger the stabilized event.
    *
-   * @param {Number} [amountOfIterations=this.stabilizationIterations]
+   * @param {number} [amountOfIterations=this.stabilizationIterations]
    * @private
    */
   _emitStabilized(amountOfIterations = this.stabilizationIterations) {
@@ -615,7 +615,7 @@ class PhysicsEngine {
   /**
    * Find a stable position for all nodes
    *
-   * @param {Number} [iterations=this.options.stabilization.iterations]
+   * @param {number} [iterations=this.options.stabilization.iterations]
    */
   stabilize(iterations = this.options.stabilization.iterations) {
     if (typeof iterations !== 'number') {

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -68,7 +68,7 @@ class SelectionHandler {
 
   /**
    *
-   * @param {{x: Number, y: Number}} pointer
+   * @param {{x: number, y: number}} pointer
    * @returns {boolean}
    */
   selectAdditionalOnPoint(pointer) {
@@ -119,7 +119,7 @@ class SelectionHandler {
    * This adds some extra data to the event with respect to cursor position and
    * selected nodes and edges.
    *
-   * @param {String} eventType                          Name of event to send
+   * @param {string} eventType                          Name of event to send
    * @param {Event}  event
    * @param {{x: number, y: number}} pointer            Object with the x and y screen coordinates of the mouse
    * @param {Object|undefined} oldSelection             If present, selection state before event occured
@@ -180,7 +180,7 @@ class SelectionHandler {
   /**
    * retrieve all nodes overlapping with given object
    * @param {Object} object  An object with parameters left, top, right, bottom
-   * @return {Number[]}   An array with id's of the overlapping nodes
+   * @return {number[]}   An array with id's of the overlapping nodes
    * @private
    */
   _getAllNodesOverlappingWith(object) {
@@ -217,7 +217,7 @@ class SelectionHandler {
   /**
    * Get the top node at the passed point (like a click)
    *
-   * @param {{x: Number, y: Number}} pointer
+   * @param {{x: number, y: number}} pointer
    * @param {boolean} [returnNode=true]
    * @return {Node | undefined} node
    */
@@ -244,7 +244,7 @@ class SelectionHandler {
   /**
    * retrieve all edges overlapping with given object, selector is around center
    * @param {Object} object  An object with parameters left, top, right, bottom
-   * @param {Number[]} overlappingEdges An array with id's of the overlapping nodes
+   * @param {number[]} overlappingEdges An array with id's of the overlapping nodes
    * @private
    */
   _getEdgesOverlappingWith(object, overlappingEdges) {
@@ -261,7 +261,7 @@ class SelectionHandler {
   /**
    * retrieve all nodes overlapping with given object
    * @param {Object} object  An object with parameters left, top, right, bottom
-   * @return {Number[]}   An array with id's of the overlapping nodes
+   * @return {number[]}   An array with id's of the overlapping nodes
    * @private
    */
   _getAllEdgesOverlappingWith(object) {
@@ -274,7 +274,7 @@ class SelectionHandler {
   /**
    * Get the edges nearest to the passed point (like a click)
    *
-   * @param {{x: Number, y: Number}} pointer
+   * @param {{x: number, y: number}} pointer
    * @param {boolean} [returnEdge=true]
    * @return {Edge | undefined} node
    */
@@ -663,7 +663,7 @@ class SelectionHandler {
   /**
    *
    * retrieve the currently selected objects
-   * @return {{nodes: Array.<String>, edges: Array.<String>}} selection
+   * @return {{nodes: Array.<string>, edges: Array.<string>}} selection
    */
   getSelection() {
     let nodeIds = this.getSelectedNodes();
@@ -674,7 +674,7 @@ class SelectionHandler {
   /**
    *
    * retrieve the currently selected nodes
-   * @return {String[]} selection    An array with the ids of the
+   * @return {string[]} selection    An array with the ids of the
    *                                            selected nodes.
    */
   getSelectedNodes() {
@@ -709,7 +709,7 @@ class SelectionHandler {
 
   /**
    * Updates the current selection
-   * @param {{nodes: Array.<String>, edges: Array.<String>}} selection
+   * @param {{nodes: Array.<string>, edges: Array.<string>}} selection
    * @param {Object} options                                 Options
    */
   setSelection(selection, options = {}) {
@@ -751,7 +751,7 @@ class SelectionHandler {
 
   /**
    * select zero or more nodes with the option to highlight edges
-   * @param {Number[] | String[]} selection     An array with the ids of the
+   * @param {number[] | string[]} selection     An array with the ids of the
    *                                            selected nodes.
    * @param {boolean} [highlightEdges]
    */
@@ -765,7 +765,7 @@ class SelectionHandler {
 
   /**
    * select zero or more edges
-   * @param {Number[] | String[]} selection     An array with the ids of the
+   * @param {number[] | string[]} selection     An array with the ids of the
    *                                            selected nodes.
    */
   selectEdges(selection) {

--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -4,13 +4,12 @@ var Edge = require('./components/Edge').default;
 let util = require('../../util');
 
 /**
- * @class SelectionHandler
+ * @param {Object} body
+ * @param {Canvas} canvas
  */
 class SelectionHandler {
   /**
-   * @param {Object} body
-   * @param {Canvas} canvas
-   * @constructor SelectionHandler
+   * @inheritDoc
    */
   constructor(body, canvas) {
     this.body = body;
@@ -552,7 +551,7 @@ class SelectionHandler {
    *
    * @param {Event}  event
    * @param {{x: number, y: number}} pointer object with the x and y screen coordinates of the mouse
-   * @param {vis.Node|vis.Edge} object
+   * @param {Node|vis.Edge} object
    * @private
    */
   emitBlurEvent(event, pointer, object) {
@@ -577,7 +576,7 @@ class SelectionHandler {
    *
    * @param {Event}  event
    * @param {{x: number, y: number}} pointer object with the x and y screen coordinates of the mouse
-   * @param {vis.Node|vis.Edge} object
+   * @param {Node|vis.Edge} object
    * @returns {boolean} hoverChanged
    * @private
    */

--- a/lib/network/modules/View.js
+++ b/lib/network/modules/View.js
@@ -44,7 +44,7 @@ class View {
   /**
    * This function zooms out to fit all data on screen based on amount of nodes
    * @param {Object} [options={{nodes=Array}}]
-   * @param {Boolean} [initialZoom=false]  | zoom based on fitted formula or range, true = fitted, default = false;
+   * @param {boolean} [initialZoom=false]  | zoom based on fitted formula or range, true = fitted, default = false;
    */
   fit(options = {nodes:[]}, initialZoom = false) {
     let range;
@@ -109,8 +109,8 @@ class View {
   /**
    * Center a node in view.
    *
-   * @param {Number} nodeId
-   * @param {Number} [options]
+   * @param {number} nodeId
+   * @param {number} [options]
    */
   focus(nodeId, options = {}) {
     if (this.body.nodes[nodeId] !== undefined) {
@@ -127,10 +127,10 @@ class View {
 
   /**
    *
-   * @param {Object} options  |  options.offset   = {x:Number, y:Number}   // offset from the center in DOM pixels
-   *                          |  options.scale    = Number                 // scale to move to
-   *                          |  options.position = {x:Number, y:Number}   // position to move to
-   *                          |  options.animation = {duration:Number, easingFunction:String} || Boolean   // position to move to
+   * @param {Object} options  |  options.offset   = {x:number, y:number}   // offset from the center in DOM pixels
+   *                          |  options.scale    = number                 // scale to move to
+   *                          |  options.position = {x:number, y:number}   // position to move to
+   *                          |  options.animation = {duration:number, easingFunction:String} || Boolean   // position to move to
    */
   moveTo(options) {
     if (options === undefined) {
@@ -153,10 +153,10 @@ class View {
 
   /**
    *
-   * @param {Object} options  |  options.offset   = {x:Number, y:Number}   // offset from the center in DOM pixels
-   *                          |  options.time     = Number                 // animation time in milliseconds
-   *                          |  options.scale    = Number                 // scale to animate to
-   *                          |  options.position = {x:Number, y:Number}   // position to animate to
+   * @param {Object} options  |  options.offset   = {x:number, y:number}   // offset from the center in DOM pixels
+   *                          |  options.time     = number                 // animation time in milliseconds
+   *                          |  options.scale    = number                 // scale to animate to
+   *                          |  options.position = {x:number, y:number}   // position to animate to
    *                          |  options.easingFunction = String           // linear, easeInQuad, easeOutQuad, easeInOutQuad,
    *                                                                       // easeInCubic, easeOutCubic, easeInOutCubic,
    *                                                                       // easeInQuart, easeOutQuart, easeInOutQuart,

--- a/lib/network/modules/View.js
+++ b/lib/network/modules/View.js
@@ -3,13 +3,12 @@ let util = require('../../util');
 var NetworkUtil = require('../NetworkUtil').default;
 
 /**
- * @class View
+ * @param {Object} body
+ * @param {Canvas} canvas
  */
 class View {
   /**
-   * @param {Object} body
-   * @param {Canvas} canvas
-   * @constructor View
+   * @inheritDoc
    */
   constructor(body, canvas) {
     this.body = body;

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -115,6 +115,7 @@ class Edge {
    * @param {Object} newOptions
    * @param {boolean} [allowDeletion=false]
    * @param {Object} [globalOptions={}]
+   * @static
    */
   static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}) {
     var fields = [
@@ -655,7 +656,6 @@ class Edge {
    * @param {Number} percentage Value between 0 (line start) and 1 (line end)
    * @return {Object} point
    * @private
-   * @static
    */
   _pointOnCircle(x, y, radius, percentage) {
     var angle = percentage * 2 * Math.PI;

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -7,25 +7,23 @@ var BezierEdgeStatic = require('./edges/BezierEdgeStatic').default;
 var StraightEdge = require('./edges/StraightEdge').default;
 
 /**
- * A edge connects two nodes
- * @class Edge
+ * An edge connects two nodes
+ * @param {Object} options         Object with options. Must contain
+ *                                At least options from and to.
+ *                                Available options: from (number),
+ *                                to (number), label (string, color (string),
+ *                                width (number), style (string),
+ *                                length (number), title (string)
+ * @param {Object} body            A Network object, used to find and edge to
+ *                                nodes.
+ * @param {Object} globalOptions   An object with default values for
+ *                                example for the color
+ * @param {Object} defaultOptions
+ * @param {Object} edgeOptions
  */
 class Edge {
   /**
-   *
-   * @param {Object} options         Object with options. Must contain
-   *                                At least options from and to.
-   *                                Available options: from (number),
-   *                                to (number), label (string, color (string),
-   *                                width (number), style (string),
-   *                                length (number), title (string)
-   * @param {Object} body            A Network object, used to find and edge to
-   *                                nodes.
-   * @param {Object} globalOptions   An object with default values for
-   *                                example for the color
-   * @param {Object} defaultOptions
-   * @param {Object} edgeOptions
-   * @constructor Edge
+   * @inheritDoc
    */
   constructor(options, body, globalOptions, defaultOptions, edgeOptions) {
     if (body === undefined) {

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -112,8 +112,9 @@ class Edge {
    *
    * @param {Object} parentOptions
    * @param {Object} newOptions
-   * @param {boolean} [allowDeletion=false]
+   * @param {Boolean} [allowDeletion=false]
    * @param {Object} [globalOptions={}]
+   * @param {Boolean} [copyFromGlobals=false]
    */
   static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}, copyFromGlobals = false) {
     var fields = [

--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -112,9 +112,9 @@ class Edge {
    *
    * @param {Object} parentOptions
    * @param {Object} newOptions
-   * @param {Boolean} [allowDeletion=false]
+   * @param {boolean} [allowDeletion=false]
    * @param {Object} [globalOptions={}]
-   * @param {Boolean} [copyFromGlobals=false]
+   * @param {boolean} [copyFromGlobals=false]
    */
   static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}, copyFromGlobals = false) {
     var fields = [
@@ -441,7 +441,7 @@ class Edge {
 
   /**
    * Retrieve the value of the edge. Can be undefined
-   * @return {Number} value
+   * @return {number} value
    */
   getValue() {
     return this.options.value;
@@ -451,9 +451,9 @@ class Edge {
   /**
    * Adjust the value range of the edge. The edge will adjust it's width
    * based on its value.
-   * @param {Number} min
-   * @param {Number} max
-   * @param {Number} total
+   * @param {number} min
+   * @param {number} max
+   * @param {number} total
    */
   setValueRange(min, max, total) {
     if (this.options.value !== undefined) {
@@ -650,10 +650,10 @@ class Edge {
 
   /**
    * Get a point on a circle
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} radius
-   * @param {Number} percentage Value between 0 (line start) and 1 (line end)
+   * @param {number} x
+   * @param {number} y
+   * @param {number} radius
+   * @param {number} percentage Value between 0 (line start) and 1 (line end)
    * @return {Object} point
    * @private
    */

--- a/lib/network/modules/components/NavigationHandler.js
+++ b/lib/network/modules/components/NavigationHandler.js
@@ -121,7 +121,7 @@ class NavigationHandler {
 
   /**
    *
-   * @param {String} action
+   * @param {string} action
    */
   bindToRedraw(action) {
     if (this.boundFunctions[action] === undefined) {
@@ -133,7 +133,7 @@ class NavigationHandler {
 
   /**
    *
-   * @param {String} action
+   * @param {string} action
    */
   unbindFromRedraw(action) {
     if (this.boundFunctions[action] !== undefined) {

--- a/lib/network/modules/components/NavigationHandler.js
+++ b/lib/network/modules/components/NavigationHandler.js
@@ -3,13 +3,12 @@ var hammerUtil = require('../../../hammerUtil');
 var keycharm = require('keycharm');
 
 /**
- * @class NavigationHandler
+ * @param {Object} body
+ * @param {Canvas} canvas
  */
 class NavigationHandler {
   /**
-   * @param {Object} body
-   * @param {Canvas} canvas
-   * @constructor NavigationHandler
+   * @inheritDoc
    */
   constructor(body, canvas) {
     this.body = body;

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -429,7 +429,7 @@ class Node {
   /**
    * Calculate the distance to the border of the Node
    * @param {CanvasRenderingContext2D}   ctx
-   * @param {Number} angle        Angle in radians
+   * @param {number} angle        Angle in radians
    * @returns {number} distance   Distance to the border in pixels
    */
   distanceToBorder(ctx, angle) {
@@ -457,7 +457,7 @@ class Node {
 
   /**
    * Retrieve the value of the node. Can be undefined
-   * @return {Number} value
+   * @return {number} value
    */
   getValue() {
     return this.options.value;
@@ -467,9 +467,9 @@ class Node {
   /**
    * Adjust the value range of the node. The node will adjust it's size
    * based on its value.
-   * @param {Number} min
-   * @param {Number} max
-   * @param {Number} total
+   * @param {number} min
+   * @param {number} max
+   * @param {number} total
    */
   setValueRange(min, max, total) {
     if (this.options.value !== undefined) {

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -205,6 +205,7 @@ class Node {
    * @param {Object} newOptions
    * @param {boolean} [allowDeletion=false]
    * @param {Object} [globalOptions={}]
+   * @static
    */
   static parseOptions(parentOptions, newOptions, allowDeletion = false, globalOptions = {}) {
     var fields = [
@@ -572,6 +573,7 @@ class Node {
   *
   * @param {object} options
   * @param {vis.Node.id} id
+   * @static
   */
   static checkMass(options, id) {
     if (options.mass !== undefined && options.mass <= 0) {

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -572,7 +572,7 @@ class Node {
   * The mass may not be negative or zero. If it is, reset to 1
   *
   * @param {object} options
-  * @param {vis.Node.id} id
+  * @param {Node.id} id
    * @static
   */
   static checkMass(options, id) {

--- a/lib/network/modules/components/algorithms/FloydWarshall.js
+++ b/lib/network/modules/components/algorithms/FloydWarshall.js
@@ -14,7 +14,6 @@ class FloydWarshall {
    * @param {Array<Node>} nodesArray
    * @param {Array<Edge>} edgesArray
    * @returns {{}}
-   * @static
    */
   getDistances(body, nodesArray, edgesArray) {
     let D_matrix = {};

--- a/lib/network/modules/components/algorithms/FloydWarshall.js
+++ b/lib/network/modules/components/algorithms/FloydWarshall.js
@@ -13,8 +13,8 @@ class FloydWarshall {
   /**
    *
    * @param {Object} body
-   * @param {Array<Node>} nodesArray
-   * @param {Array<Edge>} edgesArray
+   * @param {Array.<Node>} nodesArray
+   * @param {Array.<Edge>} edgesArray
    * @returns {{}}
    */
   getDistances(body, nodesArray, edgesArray) {

--- a/lib/network/modules/components/algorithms/FloydWarshall.js
+++ b/lib/network/modules/components/algorithms/FloydWarshall.js
@@ -1,9 +1,11 @@
 /**
- * @class FloydWarshall
+ *  The Floyd–Warshall algorithm is an algorithm for finding shortest paths in
+ *  a weighted graph with positive or negative edge weights (but with no negative
+ *  cycles). - https://en.wikipedia.org/wiki/Floyd–Warshall_algorithm
  */
 class FloydWarshall {
   /**
-   * @constructor FloydWarshall
+   * @inheritDoc
    */
   constructor() {
   }

--- a/lib/network/modules/components/edges/BezierEdgeDynamic.js
+++ b/lib/network/modules/components/edges/BezierEdgeDynamic.js
@@ -5,15 +5,14 @@ import BezierEdgeBase from './util/BezierEdgeBase'
  * curves in paths between nodes. The Dynamic piece refers to how the curve
  * reacts to physics changes.
  *
- * @class BezierEdgeDynamic
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends BezierEdgeBase
  */
 class BezierEdgeDynamic extends BezierEdgeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor BezierEdgeDynamic
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     //this.via = undefined; // Here for completeness but not allowed to defined before super() is invoked.
@@ -125,7 +124,7 @@ class BezierEdgeDynamic extends BezierEdgeBase {
    * Draw a line between two nodes
    * @param {CanvasRenderingContext2D} ctx
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @private
    */
   _line(ctx, values, viaNode) {
@@ -145,7 +144,7 @@ class BezierEdgeDynamic extends BezierEdgeBase {
    * Combined function of pointOnLine and pointOnBezier. This gives the coordinates of a point on the line at a certain percentage of the way
    *
    * @param {number} percentage
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @returns {{x: number, y: number}}
    * @private
    */
@@ -153,7 +152,7 @@ class BezierEdgeDynamic extends BezierEdgeBase {
     let t = percentage;
     let x, y;
     if (this.from === this.to){
-      let [cx,cy,cr]  = this._getCircleData(this.from)
+      let [cx,cy,cr]  = this._getCircleData(this.from);
       let a = 2 * Math.PI * (1 - t);
       x = cx + cr * Math.sin(a);
       y = cy + cr - cr * (1 - Math.cos(a));
@@ -167,7 +166,7 @@ class BezierEdgeDynamic extends BezierEdgeBase {
 
   /**
    *
-   * @param {vis.Node} nearNode
+   * @param {Node} nearNode
    * @param {CanvasRenderingContext2D} ctx
    * @returns {*}
    * @private
@@ -190,8 +189,6 @@ class BezierEdgeDynamic extends BezierEdgeBase {
   _getDistanceToEdge(x1, y1, x2, y2, x3, y3) { // x3,y3 is the point
     return this._getDistanceToBezierEdge(x1, y1, x2, y2, x3, y3, this.via);
   }
-
-
 }
 
 

--- a/lib/network/modules/components/edges/BezierEdgeStatic.js
+++ b/lib/network/modules/components/edges/BezierEdgeStatic.js
@@ -4,15 +4,14 @@ import BezierEdgeBase from './util/BezierEdgeBase'
  * A Static Bezier Edge. Bezier curves are used to model smooth gradual
  * curves in paths between nodes.
  *
- * @class BezierEdgeStatic
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends BezierEdgeBase
  */
 class BezierEdgeStatic extends BezierEdgeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor BezierEdgeStatic
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);
@@ -22,7 +21,7 @@ class BezierEdgeStatic extends BezierEdgeBase {
    * Draw a line between two nodes
    * @param {CanvasRenderingContext2D} ctx
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @private
    */
   _line(ctx, values, viaNode) {
@@ -163,7 +162,7 @@ class BezierEdgeStatic extends BezierEdgeBase {
 
   /**
    *
-   * @param {vis.Node} nearNode
+   * @param {Node} nearNode
    * @param {CanvasRenderingContext2D} ctx
    * @param {Object} options
    * @returns {*}
@@ -181,7 +180,7 @@ class BezierEdgeStatic extends BezierEdgeBase {
    * @param {number} y2
    * @param {number} x3
    * @param {number} y3
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @returns {number}
    * @private
    */
@@ -192,7 +191,7 @@ class BezierEdgeStatic extends BezierEdgeBase {
   /**
    * Combined function of pointOnLine and pointOnBezier. This gives the coordinates of a point on the line at a certain percentage of the way
    * @param {number} percentage
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @returns {{x: number, y: number}}
    * @private
    */

--- a/lib/network/modules/components/edges/BezierEdgeStatic.js
+++ b/lib/network/modules/components/edges/BezierEdgeStatic.js
@@ -30,7 +30,7 @@ class BezierEdgeStatic extends BezierEdgeBase {
 
   /**
    *
-   * @returns {Array<{x: number, y: number}>}
+   * @returns {Array.<{x: number, y: number}>}
    */
   getViaNode() {
     return this._getViaCoordinates();

--- a/lib/network/modules/components/edges/CubicBezierEdge.js
+++ b/lib/network/modules/components/edges/CubicBezierEdge.js
@@ -4,15 +4,14 @@ import CubicBezierEdgeBase from './util/CubicBezierEdgeBase'
  * A Cubic Bezier Edge. Bezier curves are used to model smooth gradual
  * curves in paths between nodes.
  *
- * @class CubicBezierEdge
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends CubicBezierEdgeBase
  */
 class CubicBezierEdge extends CubicBezierEdgeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor CubicBezierEdge
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);
@@ -22,7 +21,7 @@ class CubicBezierEdge extends CubicBezierEdgeBase {
    * Draw a line between two nodes
    * @param {CanvasRenderingContext2D} ctx
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
-   * @param {Array<vis.Node>} viaNodes
+   * @param {Array<Node>} viaNodes
    * @private
    */
   _line(ctx, values, viaNodes) {

--- a/lib/network/modules/components/edges/CubicBezierEdge.js
+++ b/lib/network/modules/components/edges/CubicBezierEdge.js
@@ -21,7 +21,7 @@ class CubicBezierEdge extends CubicBezierEdgeBase {
    * Draw a line between two nodes
    * @param {CanvasRenderingContext2D} ctx
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
-   * @param {Array<Node>} viaNodes
+   * @param {Array.<Node>} viaNodes
    * @private
    */
   _line(ctx, values, viaNodes) {
@@ -33,7 +33,7 @@ class CubicBezierEdge extends CubicBezierEdgeBase {
 
   /**
    *
-   * @returns {Array<{x: number, y: number}>}
+   * @returns {Array.<{x: number, y: number}>}
    * @private
    */
   _getViaCoordinates() {
@@ -62,7 +62,7 @@ class CubicBezierEdge extends CubicBezierEdgeBase {
 
   /**
    *
-   * @returns {Array<{x: number, y: number}>}
+   * @returns {Array.<{x: number, y: number}>}
    */
   getViaNode() {
     return this._getViaCoordinates();

--- a/lib/network/modules/components/edges/StraightEdge.js
+++ b/lib/network/modules/components/edges/StraightEdge.js
@@ -37,7 +37,6 @@ class StraightEdge extends EdgeBase {
   /**
    *
    * @returns {undefined}
-   * @static
    */
   getViaNode() {
     return undefined;

--- a/lib/network/modules/components/edges/StraightEdge.js
+++ b/lib/network/modules/components/edges/StraightEdge.js
@@ -3,15 +3,14 @@ import EdgeBase from './util/EdgeBase'
 /**
  * A Straight Edge.
  *
- * @class StraightEdge
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends EdgeBase
  */
 class StraightEdge extends EdgeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor StraightEdge
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/edges/util/BezierEdgeBase.js
+++ b/lib/network/modules/components/edges/util/BezierEdgeBase.js
@@ -4,15 +4,14 @@ import EdgeBase from './EdgeBase'
  * The Base Class for all Bezier edges. Bezier curves are used to model smooth
  * gradual curves in paths between nodes.
  *
- * @class BezierEdgeBase
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends EdgeBase
  */
 class BezierEdgeBase extends EdgeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor BezierEdgeBase
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);
@@ -21,9 +20,9 @@ class BezierEdgeBase extends EdgeBase {
   /**
    * This function uses binary search to look for the point where the bezier curve crosses the border of the node.
    *
-   * @param {vis.Node} nearNode
+   * @param {Node} nearNode
    * @param {CanvasRenderingContext2D} ctx
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @returns {*}
    * @private
    */
@@ -88,7 +87,7 @@ class BezierEdgeBase extends EdgeBase {
    * @param {number} y2 to y
    * @param {number} x3 point to check x
    * @param {number} y3 point to check y
-   * @param {vis.Node} via
+   * @param {Node} via
    * @returns {number}
    * @private
    */

--- a/lib/network/modules/components/edges/util/CubicBezierEdgeBase.js
+++ b/lib/network/modules/components/edges/util/CubicBezierEdgeBase.js
@@ -4,15 +4,14 @@ import BezierEdgeBase from './BezierEdgeBase'
  * A Base Class for all Cubic Bezier Edges. Bezier curves are used to model
  * smooth gradual curves in paths between nodes.
  *
- * @class CubicBezierEdgeBase
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends BezierEdgeBase
  */
 class CubicBezierEdgeBase extends BezierEdgeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor CubicBezierEdgeBase
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);
@@ -29,8 +28,8 @@ class CubicBezierEdgeBase extends BezierEdgeBase {
    * @param {number} y2 to y
    * @param {number} x3 point to check x
    * @param {number} y3 point to check y
-   * @param {vis.Node} via1
-   * @param {vis.Node} via2
+   * @param {Node} via1
+   * @param {Node} via2
    * @returns {number}
    * @private
    */

--- a/lib/network/modules/components/edges/util/EdgeBase.js
+++ b/lib/network/modules/components/edges/util/EdgeBase.js
@@ -436,7 +436,6 @@ class EdgeBase {
    * @param {number} y3
    * @returns {number}
    * @private
-   * @static
    */
   _getDistanceToLine(x1, y1, x2, y2, x3, y3) {
     let px = x2 - x1;
@@ -582,7 +581,6 @@ class EdgeBase {
    *
    * @param {CanvasRenderingContext2D} ctx
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
-   * @static
    */
   enableShadow(ctx, values) {
     if (values.shadow === true) {
@@ -597,7 +595,6 @@ class EdgeBase {
    *
    * @param {CanvasRenderingContext2D} ctx
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
-   * @static
    */
   disableShadow(ctx, values) {
     if (values.shadow === true) {

--- a/lib/network/modules/components/edges/util/EdgeBase.js
+++ b/lib/network/modules/components/edges/util/EdgeBase.js
@@ -82,8 +82,8 @@ class EdgeBase {
    * @param {CanvasRenderingContext2D}   ctx
    * @param {Array} values
    * @param {Node} viaNode
-   * @param {{x: Number, y: Number}} [fromPoint]
-   * @param {{x: Number, y: Number}} [toPoint]
+   * @param {{x: number, y: number}} [fromPoint]
+   * @param {{x: number, y: number}} [toPoint]
    * @private
    */
   _drawLine(ctx, values, viaNode, fromPoint, toPoint) {
@@ -102,8 +102,8 @@ class EdgeBase {
    * @param {CanvasRenderingContext2D} ctx
    * @param {Array} values
    * @param {Node} viaNode
-   * @param {{x: Number, y: Number}} [fromPoint]  TODO: Remove in next major release
-   * @param {{x: Number, y: Number}} [toPoint]    TODO: Remove in next major release
+   * @param {{x: number, y: number}} [fromPoint]  TODO: Remove in next major release
+   * @param {{x: number, y: number}} [toPoint]    TODO: Remove in next major release
    * @private
    */
   _drawDashedLine(ctx, values, viaNode, fromPoint, toPoint) {  // eslint-disable-line no-unused-vars
@@ -161,7 +161,7 @@ class EdgeBase {
    * @param {Node} nearNode
    * @param {CanvasRenderingContext2D} ctx
    * @param {Object} options
-   * @returns {{x: Number, y: Number}}
+   * @returns {{x: number, y: number}}
    */
   findBorderPosition(nearNode, ctx, options) {
     if (this.from != this.to) {
@@ -196,7 +196,7 @@ class EdgeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @returns {Array<Number>} x, y, radius
+   * @returns {Array.<number>} x, y, radius
    * @private
    */
   _getCircleData(ctx) {
@@ -224,10 +224,10 @@ class EdgeBase {
 
   /**
    * Get a point on a circle
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} radius
-   * @param {Number} percentage - Value between 0 (line start) and 1 (line end)
+   * @param {number} x
+   * @param {number} y
+   * @param {number} radius
+   * @param {number} percentage - Value between 0 (line start) and 1 (line end)
    * @return {Object} point
    * @private
    */
@@ -301,7 +301,7 @@ class EdgeBase {
    * connected nodes is selected.
    * @param {boolean} selected
    * @param {boolean} hover
-   * @returns {Number} width
+   * @returns {number} width
    * @private
    */
   getLineWidth(selected, hover) {
@@ -367,9 +367,9 @@ class EdgeBase {
    *
    * @param {CanvasRenderingContext2D} ctx
    * @param {Array} values
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} radius
+   * @param {number} x
+   * @param {number} y
+   * @param {number} radius
    * @private
    */
   _circle(ctx, values, x, y, radius) {

--- a/lib/network/modules/components/edges/util/EdgeBase.js
+++ b/lib/network/modules/components/edges/util/EdgeBase.js
@@ -3,14 +3,13 @@ let util = require("../../../../../util");
 /**
  * The Base Class for all edges.
  *
- * @class EdgeBase
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  */
 class EdgeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor EdgeBase
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     this.body = body;
@@ -61,7 +60,7 @@ class EdgeBase {
    * @param {Array} values
    * @param {boolean} selected
    * @param {boolean} hover
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @private
    */
   drawLine(ctx, values, selected, hover, viaNode) {
@@ -82,7 +81,7 @@ class EdgeBase {
    *
    * @param {CanvasRenderingContext2D}   ctx
    * @param {Array} values
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @param {{x: Number, y: Number}} [fromPoint]
    * @param {{x: Number, y: Number}} [toPoint]
    * @private
@@ -102,7 +101,7 @@ class EdgeBase {
    *
    * @param {CanvasRenderingContext2D} ctx
    * @param {Array} values
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @param {{x: Number, y: Number}} [fromPoint]  TODO: Remove in next major release
    * @param {{x: Number, y: Number}} [toPoint]    TODO: Remove in next major release
    * @private
@@ -242,7 +241,7 @@ class EdgeBase {
 
   /**
    * This function uses binary search to look for the point where the circle crosses the border of the node.
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {CanvasRenderingContext2D} ctx
    * @param {Object} options
    * @returns {*}
@@ -398,7 +397,7 @@ class EdgeBase {
    * @param {number} y2
    * @param {number} x3
    * @param {number} y3
-   * @param {vis.Node} via
+   * @param {Node} via
    * @param {Array} values
    * @returns {number}
    * @private
@@ -468,7 +467,7 @@ class EdgeBase {
   /**
    * @param {CanvasRenderingContext2D} ctx
    * @param {string} position
-   * @param {vis.Node} viaNode
+   * @param {Node} viaNode
    * @param {boolean} selected
    * @param {boolean} hover
    * @param {Array} values

--- a/lib/network/modules/components/nodes/Cluster.js
+++ b/lib/network/modules/components/nodes/Cluster.js
@@ -4,17 +4,16 @@ import Node from '../Node'
  * A Cluster is a special Node that allows a group of Nodes positioned closely together
  * to be represented by a single Cluster Node.
  *
- * @class Cluster
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Array<HTMLImageElement>}imagelist
+ * @param {Array} grouplist
+ * @param {Object} globalOptions
  * @extends Node
  */
 class Cluster extends Node {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Array<HTMLImageElement>}imagelist
-   * @param {Array} grouplist
-   * @param {Object} globalOptions
-   * @constructor Cluster
+   * @inheritDoc
    */
   constructor(options, body, imagelist, grouplist, globalOptions) {
     super(options, body, imagelist, grouplist, globalOptions);

--- a/lib/network/modules/components/nodes/Cluster.js
+++ b/lib/network/modules/components/nodes/Cluster.js
@@ -6,7 +6,7 @@ import Node from '../Node'
  *
  * @param {Object} options
  * @param {Object} body
- * @param {Array<HTMLImageElement>}imagelist
+ * @param {Array.<HTMLImageElement>}imagelist
  * @param {Array} grouplist
  * @param {Object} globalOptions
  * @extends Node

--- a/lib/network/modules/components/nodes/shapes/Box.js
+++ b/lib/network/modules/components/nodes/shapes/Box.js
@@ -5,15 +5,14 @@ import NodeBase from '../util/NodeBase'
 /**
  * A Box Node/Cluster shape.
  *
- * @class Box
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends NodeBase
  */
 class Box extends NodeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Box
+   * @inheritDoc
    */
   constructor (options, body, labelModule) {
     super(options,body,labelModule);

--- a/lib/network/modules/components/nodes/shapes/Circle.js
+++ b/lib/network/modules/components/nodes/shapes/Circle.js
@@ -5,15 +5,14 @@ import CircleImageBase from '../util/CircleImageBase'
 /**
  * A Circle Node/Cluster shape.
  *
- * @class Circle
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends CircleImageBase
  */
 class Circle extends CircleImageBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Circle
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/nodes/shapes/CircularImage.js
+++ b/lib/network/modules/components/nodes/shapes/CircularImage.js
@@ -5,17 +5,16 @@ import CircleImageBase from '../util/CircleImageBase'
 /**
  * A CircularImage Node/Cluster shape.
  *
- * @class CircularImage
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
+ * @param {Image} imageObj
+ * @param {Image} imageObjAlt
  * @extends CircleImageBase
  */
 class CircularImage extends CircleImageBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @param {Image} imageObj
-   * @param {Image} imageObjAlt
-   * @constructor CircularImage
+   * @inheritDoc
    */
   constructor (options, body, labelModule, imageObj, imageObjAlt) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/nodes/shapes/CircularImage.js
+++ b/lib/network/modules/components/nodes/shapes/CircularImage.js
@@ -102,7 +102,7 @@ class CircularImage extends CircleImageBase {
    *
    * @param {CanvasRenderingContext2D} ctx
    * @param {number} angle - Unused
-   * @returns {Number}
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {  // eslint-disable-line no-unused-vars
     this.resize(ctx);

--- a/lib/network/modules/components/nodes/shapes/Database.js
+++ b/lib/network/modules/components/nodes/shapes/Database.js
@@ -5,15 +5,14 @@ import NodeBase from '../util/NodeBase'
 /**
  * A Database Node/Cluster shape.
  *
- * @class Database
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends NodeBase
  */
 class Database extends NodeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Database
+   * @inheritDoc
    */
   constructor (options, body, labelModule) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/nodes/shapes/Diamond.js
+++ b/lib/network/modules/components/nodes/shapes/Diamond.js
@@ -5,15 +5,14 @@ import ShapeBase from '../util/ShapeBase'
 /**
  * A Diamond Node/Cluster shape.
  *
- * @class Diamond
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends ShapeBase
  */
 class Diamond extends ShapeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Diamond
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule)

--- a/lib/network/modules/components/nodes/shapes/Diamond.js
+++ b/lib/network/modules/components/nodes/shapes/Diamond.js
@@ -34,8 +34,8 @@ class Diamond extends ShapeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
     return this._distanceToBorder(ctx,angle);

--- a/lib/network/modules/components/nodes/shapes/Dot.js
+++ b/lib/network/modules/components/nodes/shapes/Dot.js
@@ -5,15 +5,14 @@ import ShapeBase from '../util/ShapeBase'
 /**
  * A Dot Node/Cluster shape.
  *
- * @class Dot
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends ShapeBase
  */
 class Dot extends ShapeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Dot
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule)

--- a/lib/network/modules/components/nodes/shapes/Dot.js
+++ b/lib/network/modules/components/nodes/shapes/Dot.js
@@ -34,8 +34,8 @@ class Dot extends ShapeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {  // eslint-disable-line no-unused-vars
     this.resize(ctx);

--- a/lib/network/modules/components/nodes/shapes/Ellipse.js
+++ b/lib/network/modules/components/nodes/shapes/Ellipse.js
@@ -21,8 +21,8 @@ class Ellipse extends NodeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx - Unused.
-   * @param {Boolean} [selected]
-   * @param {Boolean} [hover]
+   * @param {boolean} [selected]
+   * @param {boolean} [hover]
    */
   resize(ctx, selected = this.selected, hover = this.hover) {
     if (this.needsRefresh(selected, hover)) {
@@ -59,8 +59,8 @@ class Ellipse extends NodeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
     this.resize(ctx);

--- a/lib/network/modules/components/nodes/shapes/Ellipse.js
+++ b/lib/network/modules/components/nodes/shapes/Ellipse.js
@@ -5,15 +5,14 @@ import NodeBase from '../util/NodeBase'
 /**
  * Am Ellipse Node/Cluster shape.
  *
- * @class Ellipse
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends NodeBase
  */
 class Ellipse extends NodeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Ellipse
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/nodes/shapes/Icon.js
+++ b/lib/network/modules/components/nodes/shapes/Icon.js
@@ -22,8 +22,8 @@ class Icon extends NodeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx - Unused.
-   * @param {Boolean} [selected]
-   * @param {Boolean} [hover]
+   * @param {boolean} [selected]
+   * @param {boolean} [hover]
    */
   resize(ctx, selected, hover) {
     if (this.needsRefresh(selected, hover)) {
@@ -65,8 +65,8 @@ class Icon extends NodeBase {
 
   /**
    *
-   * @param {Number} x
-   * @param {Number} y
+   * @param {number} x
+   * @param {number} y
    */
   updateBoundingBox(x, y) {
     this.boundingBox.top    = y - this.options.icon.size * 0.5;
@@ -117,8 +117,8 @@ class Icon extends NodeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
     return this._distanceToBorder(ctx,angle);

--- a/lib/network/modules/components/nodes/shapes/Icon.js
+++ b/lib/network/modules/components/nodes/shapes/Icon.js
@@ -5,15 +5,14 @@ import NodeBase from '../util/NodeBase'
 /**
  * An icon replacement for the default Node shape.
  *
- * @class Icon
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends NodeBase
  */
 class Icon extends NodeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Icon
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/nodes/shapes/Image.js
+++ b/lib/network/modules/components/nodes/shapes/Image.js
@@ -26,8 +26,8 @@ class Image extends CircleImageBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx - Unused.
-   * @param {Boolean} [selected]
-   * @param {Boolean} [hover]
+   * @param {boolean} [selected]
+   * @param {boolean} [hover]
    */
   resize(ctx, selected = this.selected, hover = this.hover) {
     var imageAbsent = (this.imageObj.src === undefined) ||
@@ -96,8 +96,8 @@ class Image extends CircleImageBase {
 
   /**
    *
-   * @param {Number} x
-   * @param {Number} y
+   * @param {number} x
+   * @param {number} y
    */
   updateBoundingBox(x, y) {
     this.resize();
@@ -113,8 +113,8 @@ class Image extends CircleImageBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
      return this._distanceToBorder(ctx,angle);

--- a/lib/network/modules/components/nodes/shapes/Image.js
+++ b/lib/network/modules/components/nodes/shapes/Image.js
@@ -6,17 +6,16 @@ import CircleImageBase from '../util/CircleImageBase'
 /**
  * An image-based replacement for the default Node shape.
  *
- * @class Image
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
+ * @param {Image} imageObj
+ * @param {Image} imageObjAlt
  * @extends CircleImageBase
  */
 class Image extends CircleImageBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @param {Image} imageObj
-   * @param {Image} imageObjAlt
-   * @constructor Image
+   * @inheritDoc
    */
   constructor (options, body, labelModule, imageObj, imageObjAlt) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/nodes/shapes/Square.js
+++ b/lib/network/modules/components/nodes/shapes/Square.js
@@ -34,8 +34,8 @@ class Square extends ShapeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
     return this._distanceToBorder(ctx,angle);

--- a/lib/network/modules/components/nodes/shapes/Square.js
+++ b/lib/network/modules/components/nodes/shapes/Square.js
@@ -5,15 +5,14 @@ import ShapeBase from '../util/ShapeBase'
 /**
  * A Square Node/Cluster shape.
  *
- * @class Square
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends ShapeBase
  */
 class Square extends ShapeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Square
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule)

--- a/lib/network/modules/components/nodes/shapes/Star.js
+++ b/lib/network/modules/components/nodes/shapes/Star.js
@@ -5,15 +5,14 @@ import ShapeBase from '../util/ShapeBase'
 /**
  * A Star Node/Cluster shape.
  *
- * @class TriangleDown
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends ShapeBase
  */
 class Star extends ShapeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor TriangleDown
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule)

--- a/lib/network/modules/components/nodes/shapes/Star.js
+++ b/lib/network/modules/components/nodes/shapes/Star.js
@@ -34,8 +34,8 @@ class Star extends ShapeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
     return this._distanceToBorder(ctx,angle);

--- a/lib/network/modules/components/nodes/shapes/Text.js
+++ b/lib/network/modules/components/nodes/shapes/Text.js
@@ -5,15 +5,14 @@ import NodeBase from '../util/NodeBase'
 /**
  * A text-based replacement for the default Node shape.
  *
- * @class Text
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends NodeBase
  */
 class Text extends NodeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Text
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/nodes/shapes/Text.js
+++ b/lib/network/modules/components/nodes/shapes/Text.js
@@ -62,8 +62,8 @@ class Text extends NodeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
     return this._distanceToBorder(ctx,angle);

--- a/lib/network/modules/components/nodes/shapes/Triangle.js
+++ b/lib/network/modules/components/nodes/shapes/Triangle.js
@@ -21,10 +21,10 @@ class Triangle extends ShapeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Boolean} selected
-   * @param {Boolean} hover
+   * @param {number} x
+   * @param {number} y
+   * @param {boolean} selected
+   * @param {boolean} hover
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
    */
   draw(ctx, x, y, selected, hover, values) {
@@ -34,8 +34,8 @@ class Triangle extends ShapeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
     return this._distanceToBorder(ctx,angle);

--- a/lib/network/modules/components/nodes/shapes/Triangle.js
+++ b/lib/network/modules/components/nodes/shapes/Triangle.js
@@ -5,15 +5,14 @@ import ShapeBase from '../util/ShapeBase'
 /**
  * A Triangle Node/Cluster shape.
  *
- * @class Triangle
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends ShapeBase
  */
 class Triangle extends ShapeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor Triangle
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule)

--- a/lib/network/modules/components/nodes/shapes/TriangleDown.js
+++ b/lib/network/modules/components/nodes/shapes/TriangleDown.js
@@ -21,10 +21,10 @@ class TriangleDown extends ShapeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Boolean} selected
-   * @param {Boolean} hover
+   * @param {number} x
+   * @param {number} y
+   * @param {boolean} selected
+   * @param {boolean} hover
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
    */
   draw(ctx, x, y, selected, hover, values) {
@@ -34,8 +34,8 @@ class TriangleDown extends ShapeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    */
   distanceToBorder(ctx, angle) {
     return this._distanceToBorder(ctx,angle);

--- a/lib/network/modules/components/nodes/shapes/TriangleDown.js
+++ b/lib/network/modules/components/nodes/shapes/TriangleDown.js
@@ -5,15 +5,14 @@ import ShapeBase from '../util/ShapeBase'
 /**
  * A downward facing Triangle Node/Cluster shape.
  *
- * @class TriangleDown
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends ShapeBase
  */
 class TriangleDown extends ShapeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor TriangleDown
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule)

--- a/lib/network/modules/components/nodes/util/CircleImageBase.js
+++ b/lib/network/modules/components/nodes/util/CircleImageBase.js
@@ -13,16 +13,14 @@ import NodeBase from './NodeBase';
  *       Rename this to ImageBase
  *       Consolidate common code in Image and CircleImage to base class
  *
- * @class CircleImageBase
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends NodeBase
  */
 class CircleImageBase extends NodeBase {
   /**
-   *
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor CircleImageBase
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule);

--- a/lib/network/modules/components/nodes/util/CircleImageBase.js
+++ b/lib/network/modules/components/nodes/util/CircleImageBase.js
@@ -70,7 +70,7 @@ class CircleImageBase extends NodeBase {
    *
    * Do the switch only if imageObjAlt exists.
    *
-   * @param {Boolean} selected value of new selected state for current node
+   * @param {boolean} selected value of new selected state for current node
    */
   switchImages(selected) {
     var selection_changed = ((selected && !this.selected) || (!selected && this.selected));

--- a/lib/network/modules/components/nodes/util/NodeBase.js
+++ b/lib/network/modules/components/nodes/util/NodeBase.js
@@ -1,14 +1,13 @@
 /**
  * The Base class for all Nodes.
  *
- * @class NodeBase
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  */
 class NodeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor NodeBase
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     this.body = body;

--- a/lib/network/modules/components/nodes/util/NodeBase.js
+++ b/lib/network/modules/components/nodes/util/NodeBase.js
@@ -57,8 +57,8 @@ class NodeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} angle
-   * @returns {Number}
+   * @param {number} angle
+   * @returns {number}
    * @private
    */
   _distanceToBorder(ctx,angle) {
@@ -209,7 +209,7 @@ class NodeBase {
 
   /**
    *
-   * @param {Number} margin
+   * @param {number} margin
    * @private
    */
   _addBoundingBoxMargin(margin) {

--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -19,8 +19,8 @@ class ShapeBase extends NodeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Boolean} [selected]
-   * @param {Boolean} [hover]
+   * @param {boolean} [selected]
+   * @param {boolean} [hover]
    * @param {Object} [values={size: this.options.size}]
    */
   resize(ctx, selected = this.selected, hover = this.hover, values = { size: this.options.size }) {
@@ -36,12 +36,12 @@ class ShapeBase extends NodeBase {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {String} shape
-   * @param {Number} sizeMultiplier - Unused! TODO: Remove next major release
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Boolean} selected
-   * @param {Boolean} hover
+   * @param {string} shape
+   * @param {number} sizeMultiplier - Unused! TODO: Remove next major release
+   * @param {number} x
+   * @param {number} y
+   * @param {boolean} selected
+   * @param {boolean} hover
    * @param {{toArrow: boolean, toArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), toArrowType: *, middleArrow: boolean, middleArrowScale: (number|allOptions.edges.arrows.middle.scaleFactor|{number}|Array), middleArrowType: (allOptions.edges.arrows.middle.type|{string}|string|*), fromArrow: boolean, fromArrowScale: (allOptions.edges.arrows.to.scaleFactor|{number}|allOptions.edges.arrows.middle.scaleFactor|allOptions.edges.arrows.from.scaleFactor|Array|number), fromArrowType: *, arrowStrikethrough: (*|boolean|allOptions.edges.arrowStrikethrough|{boolean}), color: undefined, inheritsColor: (string|string|string|allOptions.edges.color.inherit|{string, boolean}|Array|*), opacity: *, hidden: *, length: *, shadow: *, shadowColor: *, shadowSize: *, shadowX: *, shadowY: *, dashes: (*|boolean|Array|allOptions.edges.dashes|{boolean, array}), width: *}} values
    * @private
    */
@@ -66,8 +66,8 @@ class ShapeBase extends NodeBase {
 
   /**
    *
-   * @param {Number} x
-   * @param {Number} y
+   * @param {number} x
+   * @param {number} y
    */
   updateBoundingBox(x, y) {
     this.boundingBox.top = y - this.options.size;

--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -3,15 +3,14 @@ import NodeBase from '../util/NodeBase'
 /**
  * Base class for constructing Node/Cluster Shapes.
  *
- * @class ShapeBase
+ * @param {Object} options
+ * @param {Object} body
+ * @param {Label} labelModule
  * @extends NodeBase
  */
 class ShapeBase extends NodeBase {
   /**
-   * @param {Object} options
-   * @param {Object} body
-   * @param {Label} labelModule
-   * @constructor ShapeBase
+   * @inheritDoc
    */
   constructor(options, body, labelModule) {
     super(options, body, labelModule)

--- a/lib/network/modules/components/physics/BarnesHutSolver.js
+++ b/lib/network/modules/components/physics/BarnesHutSolver.js
@@ -148,8 +148,8 @@ class BarnesHutSolver {
   /**
    * This function constructs the barnesHut tree recursively. It creates the root, splits it and starts placing the nodes.
    *
-   * @param {Array<Node>} nodes
-   * @param {Array<number>} nodeIndices
+   * @param {Array.<Node>} nodes
+   * @param {Array.<number>} nodeIndices
    * @returns {{root: {centerOfMass: {x: number, y: number}, mass: number, range: {minX: number, maxX: number, minY: number, maxY: number}, size: number, calcSize: number, children: {data: null}, maxWidth: number, level: number, childrenCount: number}}} BarnesHutTree
    * @private
    */

--- a/lib/network/modules/components/physics/BarnesHutSolver.js
+++ b/lib/network/modules/components/physics/BarnesHutSolver.js
@@ -1,12 +1,11 @@
 /**
- * @class BarnesHutSolver
+ * @param {Object} body
+ * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
+ * @param {Object} options
  */
 class BarnesHutSolver {
   /**
-   * @param {Object} body
-   * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
-   * @param {Object} options
-   * @constructor BarnesHutSolver
+   * @inheritDoc
    */
   constructor(body, physicsBody, options) {
     this.body = body;
@@ -78,7 +77,7 @@ class BarnesHutSolver {
    * If a region contains a single node, we check if it is not itself, then we apply the force.
    *
    * @param {Object} parentBranch
-   * @param {vis.Node} node
+   * @param {Node} node
    * @private
    */
   _getForceContribution(parentBranch, node) {
@@ -121,7 +120,7 @@ class BarnesHutSolver {
    * @param {number} distance
    * @param {number} dx
    * @param {number} dy
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {Object} parentBranch
    * @private
    */
@@ -149,7 +148,7 @@ class BarnesHutSolver {
   /**
    * This function constructs the barnesHut tree recursively. It creates the root, splits it and starts placing the nodes.
    *
-   * @param {Array<vis.Node>} nodes
+   * @param {Array<Node>} nodes
    * @param {Array<number>} nodeIndices
    * @returns {{root: {centerOfMass: {x: number, y: number}, mass: number, range: {minX: number, maxX: number, minY: number, maxY: number}, size: number, calcSize: number, children: {data: null}, maxWidth: number, level: number, childrenCount: number}}} BarnesHutTree
    * @private
@@ -235,7 +234,7 @@ class BarnesHutSolver {
    * this updates the mass of a branch. this is increased by adding a node.
    *
    * @param {Object} parentBranch
-   * @param {vis.Node} node
+   * @param {Node} node
    * @private
    */
   _updateBranchMass(parentBranch, node) {
@@ -259,7 +258,7 @@ class BarnesHutSolver {
    * determine in which branch the node will be placed.
    *
    * @param {Object} parentBranch
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {boolean} skipMassUpdate
    * @private
    */
@@ -292,7 +291,7 @@ class BarnesHutSolver {
    * actually place the node in a region (or branch)
    *
    * @param {Object} parentBranch
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {'NW'| 'NE' | 'SW' | 'SE'} region
    * @private
    */

--- a/lib/network/modules/components/physics/CentralGravitySolver.js
+++ b/lib/network/modules/components/physics/CentralGravitySolver.js
@@ -1,13 +1,11 @@
 /**
- * @class CentralGravitySolver
+ * @param {Object} body
+ * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
+ * @param {Object} options
  */
 class CentralGravitySolver {
   /**
-   *
-   * @param {Object} body
-   * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
-   * @param {Object} options
-   * @constructor CentralGravitySolver
+   * @inheritDoc
    */
   constructor(body, physicsBody, options) {
     this.body = body;
@@ -48,8 +46,8 @@ class CentralGravitySolver {
    * @param {number} distance
    * @param {number} dx
    * @param {number} dy
-   * @param {Object<vis.Node.id, vis.Node>} forces
-   * @param {vis.Node} node
+   * @param {Object<Node.id, vis.Node>} forces
+   * @param {Node} node
    * @private
    */
   _calculateForces(distance, dx, dy, forces, node) {

--- a/lib/network/modules/components/physics/FA2BasedCentralGravitySolver.js
+++ b/lib/network/modules/components/physics/FA2BasedCentralGravitySolver.js
@@ -1,15 +1,14 @@
 import CentralGravitySolver from "./CentralGravitySolver"
 
 /**
- * @class ForceAtlas2BasedCentralGravitySolver
+ * @param {Object} body
+ * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
+ * @param {Object} options
  * @extends CentralGravitySolver
  */
 class ForceAtlas2BasedCentralGravitySolver extends CentralGravitySolver {
   /**
-   * @param {Object} body
-   * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
-   * @param {Object} options
-   * @constructor ForceAtlas2BasedCentralGravitySolver
+   * @inheritDoc
    */
   constructor(body, physicsBody, options) {
     super(body, physicsBody, options);
@@ -22,8 +21,8 @@ class ForceAtlas2BasedCentralGravitySolver extends CentralGravitySolver {
    * @param {number} distance
    * @param {number} dx
    * @param {number} dy
-   * @param {Object<vis.Node.id, vis.Node>} forces
-   * @param {vis.Node} node
+   * @param {Object<Node.id, Node>} forces
+   * @param {Node} node
    * @private
    */
   _calculateForces(distance, dx, dy, forces, node) {

--- a/lib/network/modules/components/physics/FA2BasedRepulsionSolver.js
+++ b/lib/network/modules/components/physics/FA2BasedRepulsionSolver.js
@@ -1,16 +1,14 @@
 import BarnesHutSolver from "./BarnesHutSolver"
 
 /**
- * @class ForceAtlas2BasedRepulsionSolver
+ * @param {Object} body
+ * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
+ * @param {Object} options
  * @extends BarnesHutSolver
  */
 class ForceAtlas2BasedRepulsionSolver extends BarnesHutSolver {
   /**
-   * @param {Object} body
-   * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
-   * @param {Object} options
-   * @constructor ForceAtlas2BasedRepulsionSolver
-   * @extends BarnesHutSolver
+   * @inheritDoc
    */
   constructor(body, physicsBody, options) {
     super(body, physicsBody, options);
@@ -22,7 +20,7 @@ class ForceAtlas2BasedRepulsionSolver extends BarnesHutSolver {
    * @param {number} distance
    * @param {number} dx
    * @param {number} dy
-   * @param {vis.Node} node
+   * @param {Node} node
    * @param {Object} parentBranch
    * @private
    */

--- a/lib/network/modules/components/physics/HierarchicalRepulsionSolver.js
+++ b/lib/network/modules/components/physics/HierarchicalRepulsionSolver.js
@@ -1,12 +1,11 @@
 /**
- * @class HierarchicalRepulsionSolver
+ * @param {Object} body
+ * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
+ * @param {Object} options
  */
 class HierarchicalRepulsionSolver {
   /**
-   * @param {Object} body
-   * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
-   * @param {Object} options
-   * @constructor HierarchicalRepulsionSolver
+   * @inheritDoc
    */
   constructor(body, physicsBody, options) {
     this.body = body;

--- a/lib/network/modules/components/physics/HierarchicalSpringSolver.js
+++ b/lib/network/modules/components/physics/HierarchicalSpringSolver.js
@@ -1,12 +1,11 @@
 /**
- * @class HierarchicalSpringSolver
+ * @param {Object} body
+ * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
+ * @param {Object} options
  */
 class HierarchicalSpringSolver {
   /**
-   * @param {Object} body
-   * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
-   * @param {Object} options
-   * @constructor HierarchicalSpringSolver
+   * @inheritDoc
    */
   constructor(body, physicsBody, options) {
     this.body = body;

--- a/lib/network/modules/components/physics/RepulsionSolver.js
+++ b/lib/network/modules/components/physics/RepulsionSolver.js
@@ -1,12 +1,11 @@
 /**
- * @class RepulsionSolver
+ * @param {Object} body
+ * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
+ * @param {Object} options
  */
 class RepulsionSolver {
   /**
-   * @param {Object} body
-   * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
-   * @param {Object} options
-   * @constructor RepulsionSolver
+   * @inheritDoc
    */
   constructor(body, physicsBody, options) {
     this.body = body;

--- a/lib/network/modules/components/physics/SpringSolver.js
+++ b/lib/network/modules/components/physics/SpringSolver.js
@@ -1,12 +1,11 @@
 /**
- * @class SpringSolver
+ * @param {Object} body
+ * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
+ * @param {Object} options
  */
 class SpringSolver {
   /**
-   * @param {Object} body
-   * @param {{physicsNodeIndices: Array, physicsEdgeIndices: Array, forces: {}, velocities: {}}} physicsBody
-   * @param {Object} options
-   * @constructor SpringSolver
+   * @inheritDoc
    */
   constructor(body, physicsBody, options) {
     this.body = body;
@@ -63,8 +62,8 @@ class SpringSolver {
   /**
    * This is the code actually performing the calculation for the function above.
    *
-   * @param {vis.Node} node1
-   * @param {vis.Node} node2
+   * @param {Node} node1
+   * @param {Node} node2
    * @param {number} edgeLength
    * @private
    */

--- a/lib/network/modules/components/shared/ComponentUtil.js
+++ b/lib/network/modules/components/shared/ComponentUtil.js
@@ -22,7 +22,7 @@ class ComponentUtil {
    * TODO: examine if 'most' in previous sentence can be replaced with 'all'. In that case, we
    *       should be able to get rid of this method.
    *
-   * @param {String}  subOption  option within object 'chosen' to consider; either 'node', 'edge' or 'label'
+   * @param {string}  subOption  option within object 'chosen' to consider; either 'node', 'edge' or 'label'
    * @param {Object}  pile       array of options objects to consider
    * 
    * @return {boolean|function}  value for passed subOption of 'chosen' to use

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -165,7 +165,7 @@ class Label {
   /**
    *
    * @param {Object} options
-   * @param {Boolean} [allowDeletion=false]
+   * @param {boolean} [allowDeletion=false]
    */
   setOptions(options, allowDeletion = false) {
     this.elementOptions = options;
@@ -195,7 +195,7 @@ class Label {
    *
    * @param {Object} parentOptions
    * @param {Object} newOptions
-   * @param {Boolean} [allowDeletion=false]
+   * @param {boolean} [allowDeletion=false]
    * @static
    */
   static parseOptions(parentOptions, newOptions, allowDeletion = false) {
@@ -585,10 +585,10 @@ class Label {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {Number} x
-   * @param {Number} yLine
-   * @param {String} baseline
-   * @returns {Array<Number>}
+   * @param {number} x
+   * @param {number} yLine
+   * @param {string} baseline
+   * @returns {Array.<number>}
    * @private
    */
   _setAlignment(ctx, x, yLine, baseline) {
@@ -624,7 +624,7 @@ class Label {
    * @param {string} color  The font color to use
    * @param {number} viewFontSize
    * @param {string} initialStrokeColor
-   * @returns {Array<string>} An array containing the font color and stroke color
+   * @returns {Array.<string>} An array containing the font color and stroke color
    * @private
    */
   _getColor(color, viewFontSize, initialStrokeColor) {
@@ -699,7 +699,7 @@ class Label {
    * Explodes a piece of text into single-font blocks using a given markup
    * @param {string} text
    * @param {boolean|'md'|'markdown'|'html'} markupSystem
-   * @returns {Array<{text: string, mod: string}>}
+   * @returns {Array.<{text: string, mod: string}>}
    */
   splitBlocks(text, markupSystem) {
     let system = this.decodeMarkupSystem(markupSystem);
@@ -717,7 +717,7 @@ class Label {
 
   /**
    *
-   * @param {String} text
+   * @param {string} text
    * @returns {Array}
    */
   splitMarkdownBlocks(text) {
@@ -840,7 +840,7 @@ class Label {
 
   /**
    *
-   * @param {String} text
+   * @param {string} text
    * @returns {Array}
    */
   splitHtmlBlocks(text) {
@@ -1020,7 +1020,7 @@ class Label {
    * @param {CanvasRenderingContext2D} ctx
    * @param {boolean} selected
    * @param {boolean} hover
-   * @param {String} text  the text to explode
+   * @param {string} text  the text to explode
    * @returns {{width, height, lines}|*}
    * @private
    */

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -372,7 +372,7 @@ class Label {
      * Get property value from options.font[mod][property] if present.
      * If mod not passed, use property value from options.font[property].
      *
-     * @param {vis.Label.options} options
+     * @param {Label.options} options
      * @param {'bold'|'ital'|'boldital'|'mono'|'normal'} mod
      * @param {string} property
      * @return {*|null} value if found, null otherwise.

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -197,6 +197,7 @@ class Label {
    * @param {Object} parentOptions
    * @param {Object} newOptions
    * @param {Boolean} [allowDeletion=false]
+   * @static
    */
   static parseOptions(parentOptions, newOptions, allowDeletion = false) {
     if (Label.parseFontString(parentOptions, newOptions.font)) {
@@ -220,6 +221,7 @@ class Label {
    * @param {Object} outOptions  out-parameter, object in which to store the parse results (if any)
    * @param {Object} inOptions  font options to parse
    * @return {boolean} true if font parsed as string, false otherwise
+   * @static
    */
   static parseFontString(outOptions, inOptions) {
     if (!inOptions || typeof inOptions !== 'string') return false;

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -6,14 +6,13 @@ let util = require('../../../../util');
  *
  * This has been moved away from the label processing code for better undestanding upon reading.
  *
- * @class LabelAccumulator
+ * @callback measureText
+ * @param {function} measureText - callback to determine text dimensions, using the parent label settings.
  * @private
  */
 class LabelAccumulator {
   /**
-   * @callback measureText
-   * @param {function} measureText - callback to determine text dimensions, using the parent label settings.
-   * @constructor LabelAccumulator
+   * @inheritDoc
    */
   constructor(measureText) {
     this.measureText = measureText;
@@ -143,14 +142,13 @@ class LabelAccumulator {
 /**
  * A Label to be used for Nodes or Edges.
  *
- * @class Label
+ * @param {Object} body
+ * @param {Object} options
+ * @param {boolean} [edgelabel=false]
  */
 class Label {
   /**
-   * @param {Object} body
-   * @param {Object} options
-   * @param {boolean} [edgelabel=false]
-   * @constructor Label
+   * @inheritDoc
    */
   constructor(body, options, edgelabel = false) {
     this.body = body;

--- a/lib/network/shapes.js
+++ b/lib/network/shapes.js
@@ -6,9 +6,9 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
   /**
    * Draw a circle shape
    *
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} r
+   * @param {number} x
+   * @param {number} y
+   * @param {number} r
    */
   CanvasRenderingContext2D.prototype.circle = function (x, y, r) {
     this.beginPath();
@@ -18,9 +18,9 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
 
   /**
    * Draw a square shape
-   * @param {Number} x horizontal center
-   * @param {Number} y vertical center
-   * @param {Number} r   size, width and height of the square
+   * @param {number} x horizontal center
+   * @param {number} y vertical center
+   * @param {number} r   size, width and height of the square
    */
   CanvasRenderingContext2D.prototype.square = function (x, y, r) {
     this.beginPath();
@@ -30,9 +30,9 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
 
   /**
    * Draw a triangle shape
-   * @param {Number} x horizontal center
-   * @param {Number} y vertical center
-   * @param {Number} r   radius, half the length of the sides of the triangle
+   * @param {number} x horizontal center
+   * @param {number} y vertical center
+   * @param {number} r   radius, half the length of the sides of the triangle
    */
   CanvasRenderingContext2D.prototype.triangle = function (x, y, r) {
     // http://en.wikipedia.org/wiki/Equilateral_triangle
@@ -59,9 +59,9 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
 
   /**
    * Draw a triangle shape in downward orientation
-   * @param {Number} x horizontal center
-   * @param {Number} y vertical center
-   * @param {Number} r radius
+   * @param {number} x horizontal center
+   * @param {number} y vertical center
+   * @param {number} r radius
    */
   CanvasRenderingContext2D.prototype.triangleDown = function (x, y, r) {
     // http://en.wikipedia.org/wiki/Equilateral_triangle
@@ -85,9 +85,9 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
 
   /**
    * Draw a star shape, a star with 5 points
-   * @param {Number} x horizontal center
-   * @param {Number} y vertical center
-   * @param {Number} r   radius, half the length of the sides of the triangle
+   * @param {number} x horizontal center
+   * @param {number} y vertical center
+   * @param {number} r   radius, half the length of the sides of the triangle
    */
   CanvasRenderingContext2D.prototype.star = function (x, y, r) {
     // http://www.html5canvastutorials.com/labs/html5-canvas-star-spinner/
@@ -110,9 +110,9 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
 
   /**
    * Draw a Diamond shape
-   * @param {Number} x horizontal center
-   * @param {Number} y vertical center
-   * @param {Number} r   radius, half the length of the sides of the triangle
+   * @param {number} x horizontal center
+   * @param {number} y vertical center
+   * @param {number} r   radius, half the length of the sides of the triangle
    */
   CanvasRenderingContext2D.prototype.diamond = function (x, y, r) {
     // http://www.html5canvastutorials.com/labs/html5-canvas-star-spinner/
@@ -130,11 +130,11 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
   /**
    * http://stackoverflow.com/questions/1255512/how-to-draw-a-rounded-rectangle-on-html-canvas
    *
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} w
-   * @param {Number} h
-   * @param {Number} r
+   * @param {number} x
+   * @param {number} y
+   * @param {number} w
+   * @param {number} h
+   * @param {number} r
    */
   CanvasRenderingContext2D.prototype.roundRect = function (x, y, w, h, r) {
     var r2d = Math.PI / 180;
@@ -162,10 +162,10 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
    *
    * Postfix '_vis' added to discern it from standard method ellipse().
    *
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} w
-   * @param {Number} h
+   * @param {number} x
+   * @param {number} y
+   * @param {number} w
+   * @param {number} h
    */
   CanvasRenderingContext2D.prototype.ellipse_vis = function (x, y, w, h) {
     var kappa = .5522848,
@@ -189,10 +189,10 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
   /**
    * http://stackoverflow.com/questions/2172798/how-to-draw-an-oval-in-html5-canvas
    *
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} w
-   * @param {Number} h
+   * @param {number} x
+   * @param {number} y
+   * @param {number} w
+   * @param {number} h
    */
   CanvasRenderingContext2D.prototype.database = function (x, y, w, h) {
     var f = 1 / 3;
@@ -230,10 +230,10 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
   /**
    * Draw an arrow at the end of a line with the given angle.
    *
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} angle
-   * @param {Number} length
+   * @param {number} x
+   * @param {number} y
+   * @param {number} angle
+   * @param {number} length
    */
   CanvasRenderingContext2D.prototype.arrowEndpoint = function (x, y, angle, length) {
     // tail
@@ -263,10 +263,10 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
   /**
    * Draw an circle an the end of an line with the given angle.
    *
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} angle
-   * @param {Number} length
+   * @param {number} x
+   * @param {number} y
+   * @param {number} angle
+   * @param {number} length
    */
   CanvasRenderingContext2D.prototype.circleEndpoint = function (x, y, angle, length) {
     var radius = length * 0.4;
@@ -281,11 +281,11 @@ if (typeof CanvasRenderingContext2D !== 'undefined') {
    * @author David Jordan
    * @date 2012-08-08
    *
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} x2
-   * @param {Number} y2
-   * @param {String} pattern
+   * @param {number} x
+   * @param {number} y
+   * @param {number} x2
+   * @param {number} y2
+   * @param {string} pattern
    */
   CanvasRenderingContext2D.prototype.dashedLine = function (x, y, x2, y2, pattern) {
     this.beginPath();

--- a/lib/shared/ColorPicker.js
+++ b/lib/shared/ColorPicker.js
@@ -3,7 +3,7 @@ let hammerUtil = require('../hammerUtil');
 let util = require('../util');
 
 /**
- * @param {Number} [pixelRatio=1]
+ * @param {number} [pixelRatio=1]
  */
 class ColorPicker {
   /**
@@ -73,7 +73,7 @@ class ColorPicker {
 
   /**
    *
-   * @param {String} color
+   * @param {string} color
    * @returns {String}
    * @private
    */
@@ -94,7 +94,7 @@ class ColorPicker {
    * 'rgba(255,255,255,1.0)' --> rgba string
    * {r:255,g:255,b:255}     --> rgb object
    * {r:255,g:255,b:255,a:1.0} --> rgba object
-   * @param {String|Object} color
+   * @param {string|Object} color
    * @param {boolean} [setInitial=true]
    */
   setColor(color, setInitial = true) {

--- a/lib/shared/ColorPicker.js
+++ b/lib/shared/ColorPicker.js
@@ -3,12 +3,11 @@ let hammerUtil = require('../hammerUtil');
 let util = require('../util');
 
 /**
- * @class ColorPicker
+ * @param {Number} [pixelRatio=1]
  */
 class ColorPicker {
   /**
-   * @param {Number} [pixelRatio=1]
-   * @constructor ColorPicker
+   * @inheritDoc
    */
   constructor(pixelRatio = 1) {
     this.pixelRatio = pixelRatio;

--- a/lib/shared/Configurator.js
+++ b/lib/shared/Configurator.js
@@ -14,7 +14,7 @@ var ColorPicker = require('./ColorPicker').default;
  * @param {Object} parentModule        | the location where parentModule.setOptions() can be called
  * @param {Object} defaultContainer    | the default container of the module
  * @param {Object} configureOptions    | the fully configured and predefined options set found in allOptions.js
- * @param {Number} pixelRatio          | canvas pixel ratio
+ * @param {number} pixelRatio          | canvas pixel ratio
  */
 class Configurator {
   /**
@@ -232,8 +232,8 @@ class Configurator {
   /**
    * all option elements are wrapped in an item
    * @param {Array} path    | where to look for the actual option
-   * @param {Array<Element>} domElements
-   * @returns {Number}
+   * @param {Array.<Element>} domElements
+   * @returns {number}
    * @private
    */
   _makeItem(path, ...domElements) {
@@ -286,7 +286,7 @@ class Configurator {
 
   /**
    * make a dropdown list for multiple possible string optoins
-   * @param {Array<number>} arr
+   * @param {Array.<number>} arr
    * @param {number} value
    * @param {array} path    | where to look for the actual option
    * @private
@@ -321,7 +321,7 @@ class Configurator {
 
   /**
    * make a range object for numeric options
-   * @param {Array<number>} arr
+   * @param {Array.<number>} arr
    * @param {number} value
    * @param {array} path    | where to look for the actual option
    * @private
@@ -392,7 +392,7 @@ class Configurator {
   /**
    * prepare the popup
    * @param {string} string
-   * @param {Number} index
+   * @param {number} index
    * @private
    */
   _setupPopup(string, index) {
@@ -501,7 +501,7 @@ class Configurator {
 
   /**
    * make a color field with a color picker for color fields
-   * @param {Array<number>} arr
+   * @param {Array.<number>} arr
    * @param {number} value
    * @param {array} path    | where to look for the actual option
    * @private
@@ -644,7 +644,7 @@ class Configurator {
 
   /**
    * handle the array type of option
-   * @param {Array<number>} arr
+   * @param {Array.<number>} arr
    * @param {number} value
    * @param {array} path    | where to look for the actual option
    * @private
@@ -685,8 +685,8 @@ class Configurator {
 
   /**
    *
-   * @param {String|Boolean} value
-   * @param {Array<String>} path
+   * @param {string|Boolean} value
+   * @param {Array.<string>} path
    * @param {{}} optionsObj
    * @returns {{}}
    * @private

--- a/lib/shared/Configurator.js
+++ b/lib/shared/Configurator.js
@@ -11,16 +11,14 @@ var ColorPicker = require('./ColorPicker').default;
  *
  * The options are matched with their counterparts in each of the modules and the values used in the configuration are
  *
- * @class Configurator
+ * @param {Object} parentModule        | the location where parentModule.setOptions() can be called
+ * @param {Object} defaultContainer    | the default container of the module
+ * @param {Object} configureOptions    | the fully configured and predefined options set found in allOptions.js
+ * @param {Number} pixelRatio          | canvas pixel ratio
  */
 class Configurator {
   /**
-   *
-   * @param {Object} parentModule        | the location where parentModule.setOptions() can be called
-   * @param {Object} defaultContainer    | the default container of the module
-   * @param {Object} configureOptions    | the fully configured and predefined options set found in allOptions.js
-   * @param {Number} pixelRatio          | canvas pixel ratio
-   * @constructor Configurator
+   * @inheritDoc
    */
   constructor(parentModule, defaultContainer, configureOptions, pixelRatio = 1) {
     this.parent = parentModule;

--- a/lib/shared/Popup.js
+++ b/lib/shared/Popup.js
@@ -1,12 +1,11 @@
 /**
  * Popup is a class to create a popup window with some text
- * @class Popup
+ * @param {Element} container       The container object.
+ * @param {string}  overflowMethod  How the popup should act to overflowing ('flip' or 'cap')
  */
 class Popup {
   /**
-   * @param {Element} container       The container object.
-   * @param {string}  overflowMethod  How the popup should act to overflowing ('flip' or 'cap')
-   * @constructor Popup
+   * @inheritDoc
    */
   constructor(container, overflowMethod) {
     this.container = container;

--- a/lib/shared/Validator.js
+++ b/lib/shared/Validator.js
@@ -5,11 +5,10 @@ let allOptions;
 let printStyle = 'background: #FFeeee; color: #dd0000';
 /**
  *  Used to validate options.
- *  @class Validator
  */
 class Validator {
   /**
-   * @constructor Validator
+   * @inheritDoc
    */
   constructor() {
   }

--- a/lib/shared/Validator.js
+++ b/lib/shared/Validator.js
@@ -20,6 +20,7 @@ class Validator {
    * @param {Object} referenceOptions
    * @param {Object} subObject
    * @returns {boolean}
+   * @static
    */
   static validate(options, referenceOptions, subObject) {
     errorFound = false;
@@ -38,6 +39,7 @@ class Validator {
    * @param {Object} options
    * @param {Object} referenceOptions
    * @param {array} path    | where to look for the actual option
+   * @static
    */
   static parse(options, referenceOptions, path) {
     for (let option in options) {
@@ -54,6 +56,7 @@ class Validator {
    * @param {Object} options
    * @param {Object} referenceOptions
    * @param {array} path    | where to look for the actual option
+   * @static
    */
   static check(option, options, referenceOptions, path) {
     if (referenceOptions[option] === undefined && referenceOptions.__any__ === undefined) {
@@ -98,6 +101,7 @@ class Validator {
    * @param {String}  referenceOption  | Usually this is the same as option, except when handling an __any__ tag.
    * @param {String}  refOptionObj     | This is the type object from the reference options
    * @param {Array}   path             | where in the object is the option
+   * @static
    */
   static checkFields(option, options, referenceOptions, referenceOption, refOptionObj, path) {
     let log = function(message) {
@@ -133,6 +137,7 @@ class Validator {
    *
    * @param {Object|Boolean|Number|String|Array<Number>|Date|Node|Moment|undefined|null} object
    * @returns {String}
+   * @static
    */
   static getType(object) {
     var type = typeof object;
@@ -183,6 +188,7 @@ class Validator {
    * @param {String} option
    * @param {Object} options
    * @param {Array<String>} path
+   * @static
    */
   static getSuggestion(option, options, path) {
     let localSearch = Validator.findInOptions(option,options,path,false);
@@ -221,6 +227,7 @@ class Validator {
    * @param {Array} path    | where to look for the actual option
    * @param {Boolean} [recursive=false]
    * @returns {{closestMatch: string, path: Array, distance: number}}
+   * @static
    */
   static findInOptions(option, options, path, recursive = false) {
     let min = 1e9;
@@ -259,6 +266,7 @@ class Validator {
    * @param {Object} option
    * @param {String} prefix
    * @returns {String}
+   * @static
    */
   static printLocation(path, option, prefix = 'Problem value found at: \n') {
     let str = '\n\n' + prefix + 'options = {\n';
@@ -284,6 +292,7 @@ class Validator {
   /**
    * @param {Object} options
    * @returns {String}
+   * @static
    */
   static print(options) {
     return JSON.stringify(options).replace(/(\")|(\[)|(\])|(,"__type__")/g, "").replace(/(\,)/g, ', ')
@@ -305,6 +314,7 @@ class Validator {
    * @param {string} a
    * @param {string} b
    * @returns {Array<Array<Number>>}}
+   * @static
    */
   static levenshteinDistance(a, b) {
     if (a.length === 0) return b.length;

--- a/lib/shared/Validator.js
+++ b/lib/shared/Validator.js
@@ -51,7 +51,7 @@ class Validator {
 
   /**
    * Check every value. If the value is an object, call the parse function on that object.
-   * @param {String} option
+   * @param {string} option
    * @param {Object} options
    * @param {Object} referenceOptions
    * @param {array} path    | where to look for the actual option
@@ -94,11 +94,11 @@ class Validator {
 
   /**
    *
-   * @param {String}  option           | the option property
+   * @param {string}  option           | the option property
    * @param {Object}  options          | The supplied options object
    * @param {Object}  referenceOptions | The reference options containing all options and their allowed formats
-   * @param {String}  referenceOption  | Usually this is the same as option, except when handling an __any__ tag.
-   * @param {String}  refOptionObj     | This is the type object from the reference options
+   * @param {string}  referenceOption  | Usually this is the same as option, except when handling an __any__ tag.
+   * @param {string}  refOptionObj     | This is the type object from the reference options
    * @param {Array}   path             | where in the object is the option
    * @static
    */
@@ -134,8 +134,8 @@ class Validator {
 
   /**
    *
-   * @param {Object|Boolean|Number|String|Array<Number>|Date|Node|Moment|undefined|null} object
-   * @returns {String}
+   * @param {Object|boolean|number|string|Array.<number>|Date|Node|Moment|undefined|null} object
+   * @returns {string}
    * @static
    */
   static getType(object) {
@@ -184,9 +184,9 @@ class Validator {
   }
 
   /**
-   * @param {String} option
+   * @param {string} option
    * @param {Object} options
-   * @param {Array<String>} path
+   * @param {Array.<string>} path
    * @static
    */
   static getSuggestion(option, options, path) {
@@ -221,10 +221,10 @@ class Validator {
 
   /**
    * traverse the options in search for a match.
-   * @param {String} option
+   * @param {string} option
    * @param {Object} options
    * @param {Array} path    | where to look for the actual option
-   * @param {Boolean} [recursive=false]
+   * @param {boolean} [recursive=false]
    * @returns {{closestMatch: string, path: Array, distance: number}}
    * @static
    */
@@ -261,9 +261,9 @@ class Validator {
   }
 
   /**
-   * @param {Array<string>} path
+   * @param {Array.<string>} path
    * @param {Object} option
-   * @param {String} prefix
+   * @param {string} prefix
    * @returns {String}
    * @static
    */
@@ -312,7 +312,7 @@ class Validator {
    *
    * @param {string} a
    * @param {string} b
-   * @returns {Array<Array<Number>>}}
+   * @returns {Array.<Array.<number>>}}
    * @static
    */
   static levenshteinDistance(a, b) {

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -331,23 +331,23 @@ Core.prototype._create = function (container) {
  *                           {String} orientation
  *                              Vertical orientation for the Timeline,
  *                              can be 'bottom' (default) or 'top'.
- *                           {String | Number} width
+ *                           {string | number} width
  *                              Width for the timeline, a number in pixels or
  *                              a css string like '1000px' or '75%'. '100%' by default.
- *                           {String | Number} height
+ *                           {string | number} height
  *                              Fixed height for the Timeline, a number in pixels or
  *                              a css string like '400px' or '75%'. If undefined,
  *                              The Timeline will automatically size such that
  *                              its contents fit.
- *                           {String | Number} minHeight
+ *                           {string | number} minHeight
  *                              Minimum height for the Timeline, a number in pixels or
  *                              a css string like '400px' or '75%'.
- *                           {String | Number} maxHeight
+ *                           {string | number} maxHeight
  *                              Maximum height for the Timeline, a number in pixels or
  *                              a css string like '400px' or '75%'.
- *                           {Number | Date | String} start
+ *                           {number | Date | string} start
  *                              Start date for the visible window
- *                           {Number | Date | String} end
+ *                           {number | Date | string} end
  *                              End date for the visible window
  */
 Core.prototype.setOptions = function (options) {
@@ -557,7 +557,7 @@ Core.prototype.getCustomTime = function(id) {
 
 /**
  * Set a custom title for the custom time bar.
- * @param {String} [title] Custom title
+ * @param {string} [title] Custom title
  * @param {number} [id=undefined]    Id of the custom time bar.
  * @returns {*}
  */
@@ -586,13 +586,13 @@ Core.prototype.getEventProperties = function (event) {
 
 /**
  * Add custom vertical bar
- * @param {Date | String | Number} [time]  A Date, unix timestamp, or
+ * @param {Date | string | number} [time]  A Date, unix timestamp, or
  *                                         ISO date string. Time point where
  *                                         the new bar should be placed.
  *                                         If not provided, `new Date()` will
  *                                         be used.
- * @param {Number | String} [id=undefined] Id of the new bar. Optional
- * @return {Number | String}               Returns the id of the new bar
+ * @param {number | string} [id=undefined] Id of the new bar. Optional
+ * @return {number | string}               Returns the id of the new bar
  */
 Core.prototype.addCustomTime = function (time, id) {
   var timestamp = time !== undefined
@@ -696,8 +696,8 @@ Core.prototype.getDataRange = function() {
  * Where start and end can be a Date, number, or string, and range is an
  * object with properties start and end.
  *
- * @param {Date | Number | String | Object} [start] Start date of visible window
- * @param {Date | Number | String} [end]            End date of visible window
+ * @param {Date | number | string | Object} [start] Start date of visible window
+ * @param {Date | number | string} [end]            End date of visible window
  * @param {Object} [options]  Available options:
  *                                `animation: boolean | {duration: number, easingFunction: string}`
  *                                    If true (default), the range is animated
@@ -733,7 +733,7 @@ Core.prototype.setWindow = function(start, end, options, callback) {
 
 /**
  * Move the window such that given time is centered on screen.
- * @param {Date | Number | String} time
+ * @param {Date | number | string} time
  * @param {Object} [options]  Available options:
  *                                `animation: boolean | {duration: number, easingFunction: string}`
  *                                    If true (default), the range is animated
@@ -772,7 +772,7 @@ Core.prototype.getWindow = function() {
 
 /**
  * Zoom in the window such that given time is centered on screen.
- * @param {Number} percentage - must be between [0..1]
+ * @param {number} percentage - must be between [0..1]
  * @param {Object} [options]  Available options:
  *                                `animation: boolean | {duration: number, easingFunction: string}`
  *                                    If true (default), the range is animated
@@ -802,7 +802,7 @@ Core.prototype.zoomIn = function(percentage, options, callback) {
 
 /**
  * Zoom out the window such that given time is centered on screen.
- * @param {Number} percentage - must be between [0..1]
+ * @param {number} percentage - must be between [0..1]
  * @param {Object} [options]  Available options:
  *                                `animation: boolean | {duration: number, easingFunction: string}`
  *                                    If true (default), the range is animated
@@ -1065,7 +1065,7 @@ Core.prototype.repaint = function () {
  * Set a current time. This can be used for example to ensure that a client's
  * time is synchronized with a shared server time.
  * Only applicable when option `showCurrentTime` is true.
- * @param {Date | String | Number} time     A Date, unix timestamp, or
+ * @param {Date | string | number} time     A Date, unix timestamp, or
  *                                          ISO date string.
  */
 Core.prototype.setCurrentTime = function(time) {
@@ -1265,8 +1265,8 @@ Core.prototype._onDrag = function (event) {
 
 /**
  * Apply a scrollTop
- * @param {Number} scrollTop
- * @returns {Number} scrollTop  Returns the applied scrollTop
+ * @param {number} scrollTop
+ * @returns {number} scrollTop  Returns the applied scrollTop
  * @private
  */
 Core.prototype._setScrollTop = function (scrollTop) {
@@ -1277,7 +1277,7 @@ Core.prototype._setScrollTop = function (scrollTop) {
 
 /**
  * Update the current scrollTop when the height of  the containers has been changed
- * @returns {Number} scrollTop  Returns the applied scrollTop
+ * @returns {number} scrollTop  Returns the applied scrollTop
  * @private
  */
 Core.prototype._updateScrollTop = function () {

--- a/lib/timeline/DateUtil.js
+++ b/lib/timeline/DateUtil.js
@@ -5,7 +5,7 @@
  * @param {function} moment
  * @param {Object} body
  * @param {Array | Object} hiddenDates
- * @returns {Number}
+ * @returns {number}
  */
 exports.convertHiddenOptions = function(moment, body, hiddenDates) {
   if (hiddenDates && !Array.isArray(hiddenDates)) {
@@ -288,8 +288,8 @@ exports.stepOverHiddenDates = function(moment, timeStep, previousTime) {
  *
  * @param {vis.Core} Core
  * @param {Date} time
- * @param {Number} width
- * @returns {Number}
+ * @param {number} width
+ * @returns {number}
  */
 exports.toScreen = function (Core, time, width) {
   var conversion;
@@ -352,7 +352,7 @@ exports.toTime = function(Core, x, width) {
 /**
  * Support function
  *
- * @param {Array<{start: Window.start, end: *}>} hiddenDates
+ * @param {Array.<{start: Window.start, end: *}>} hiddenDates
  * @param {number} start
  * @param {number} end
  * @returns {number}
@@ -373,7 +373,7 @@ exports.getHiddenDurationBetween = function(hiddenDates, start, end) {
 /**
  * Support function
  *
- * @param {Array<{start: Window.start, end: *}>} hiddenDates
+ * @param {Array.<{start: Window.start, end: *}>} hiddenDates
  * @param {number} start
  * @param {number} end
  * @returns {number}
@@ -395,7 +395,7 @@ exports.getHiddenDurationBeforeStart = function (hiddenDates, start, end) {
 /**
  * Support function
  * @param {function} moment
- * @param {Array<{start: Window.start, end: *}>} hiddenDates
+ * @param {Array.<{start: Window.start, end: *}>} hiddenDates
  * @param {{start: number, end: number}} range
  * @param {Date} time
  * @returns {number}
@@ -426,7 +426,7 @@ exports.getHiddenDurationBefore = function(moment, hiddenDates, range, time) {
 /**
  * sum the duration from start to finish, including the hidden duration,
  * until the required amount has been reached, return the accumulated hidden duration
- * @param {Array<{start: Window.start, end: *}>} hiddenDates
+ * @param {Array.<{start: Window.start, end: *}>} hiddenDates
  * @param {{start: number, end: number}} range
  * @param {number} [requiredDuration=0]
  * @returns {number}
@@ -459,11 +459,11 @@ exports.getAccumulatedHiddenDuration = function(hiddenDates, range, requiredDura
 
 /**
  * used to step over to either side of a hidden block. Correction is disabled on tablets, might be set to true
- * @param {Array<{start: Window.start, end: *}>} hiddenDates
+ * @param {Array.<{start: Window.start, end: *}>} hiddenDates
  * @param {Date} time
- * @param {Number} direction
- * @param {Boolean} correctionEnabled
- * @returns {Date|Number}
+ * @param {number} direction
+ * @param {boolean} correctionEnabled
+ * @returns {Date|number}
  */
 exports.snapAwayFromHidden = function(hiddenDates, time, direction, correctionEnabled) {
   var isHidden = exports.isHidden(time, hiddenDates);
@@ -496,7 +496,7 @@ exports.snapAwayFromHidden = function(hiddenDates, time, direction, correctionEn
  * Check if a time is hidden
  *
  * @param {Date} time
- * @param {Array<{start: Window.start, end: *}>} hiddenDates
+ * @param {Array.<{start: Window.start, end: *}>} hiddenDates
  * @returns {{hidden: boolean, startDate: Window.start, endDate: *}}
  */
 exports.isHidden = function(time, hiddenDates) {

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -451,6 +451,7 @@ Range.prototype.conversion = function (width, totalHidden) {
  * @param {Number} width
  * @param {Number} [totalHidden=0]
  * @returns {{offset: number, scale: number}} conversion
+ * @static
  */
 Range.conversion = function (start, end, width, totalHidden) {
   if (totalHidden === undefined) {

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -81,17 +81,17 @@ Range.prototype = new Component();
 /**
  * Set options for the range controller
  * @param {Object} options      Available options:
- *                              {Number | Date | String} start  Start date for the range
- *                              {Number | Date | String} end    End date for the range
- *                              {Number} min    Minimum value for start
- *                              {Number} max    Maximum value for end
- *                              {Number} zoomMin    Set a minimum value for
+ *                              {number | Date | String} start  Start date for the range
+ *                              {number | Date | String} end    End date for the range
+ *                              {number} min    Minimum value for start
+ *                              {number} max    Maximum value for end
+ *                              {number} zoomMin    Set a minimum value for
  *                                                  (end - start).
- *                              {Number} zoomMax    Set a maximum value for
+ *                              {number} zoomMax    Set a maximum value for
  *                                                  (end - start).
- *                              {Boolean} moveable Enable moving of the range
+ *                              {boolean} moveable Enable moving of the range
  *                                                 by dragging. True by default
- *                              {Boolean} zoomable Enable zooming of the range
+ *                              {boolean} zoomable Enable zooming of the range
  *                                                 by pinching/scrolling. True by default
  */
 Range.prototype.setOptions = function (options) {
@@ -115,7 +115,7 @@ Range.prototype.setOptions = function (options) {
 
 /**
  * Test whether direction has a valid value
- * @param {String} direction    'horizontal' or 'vertical'
+ * @param {string} direction    'horizontal' or 'vertical'
  */
 function validateDirection (direction) {
   if (direction != 'horizontal' && direction != 'vertical') {
@@ -176,16 +176,16 @@ Range.prototype.stopRolling = function() {
 
 /**
  * Set a new start and end range
- * @param {Date | Number | String} [start]
- * @param {Date | Number | String} [end]
+ * @param {Date | number | string} [start]
+ * @param {Date | number | string} [end]
  * @param {Object} options      Available options:
- *                              {Boolean | {duration: number, easingFunction: string}} [animation=false]
+ *                              {boolean | {duration: number, easingFunction: string}} [animation=false]
  *                                    If true, the range is animated
  *                                    smoothly to the new window. An object can be
  *                                    provided to specify duration and easing function.
  *                                    Default duration is 500 ms, and default easing
  *                                    function is 'easeInOutQuad'.
- *                              {Boolean} [byUser=false]
+ *                              {boolean} [byUser=false]
  *                              {Event}  event  Mouse event
  *                              {Function} a callback funtion to be executed at the end of this function 
  *
@@ -282,7 +282,7 @@ Range.prototype.setRange = function(start, end, options, callback) {
 /**
  * Get the number of milliseconds per pixel.
  *
- * @returns {undefined|Number}
+ * @returns {undefined|number}
  */
 Range.prototype.getMillisecondsPerPixel = function() {
   if (this.millisecondsPerPixelCache === undefined) {
@@ -306,9 +306,9 @@ Range.prototype._cancelAnimation = function () {
  * Set a new start and end range. This method is the same as setRange, but
  * does not trigger a range change and range changed event, and it returns
  * true when the range is changed
- * @param {Number} [start]
- * @param {Number} [end]
- * @return {Boolean} changed
+ * @param {number} [start]
+ * @param {number} [end]
+ * @return {boolean} changed
  * @private
  */
 Range.prototype._applyRange = function(start, end) {
@@ -435,8 +435,8 @@ Range.prototype.getRange = function() {
 /**
  * Calculate the conversion offset and scale for current range, based on
  * the provided width
- * @param {Number} width
- * @param {Number} [totalHidden=0]
+ * @param {number} width
+ * @param {number} [totalHidden=0]
  * @returns {{offset: number, scale: number}} conversion
  */
 Range.prototype.conversion = function (width, totalHidden) {
@@ -446,10 +446,10 @@ Range.prototype.conversion = function (width, totalHidden) {
 /**
  * Static method to calculate the conversion offset and scale for a range,
  * based on the provided start, end, and width
- * @param {Number} start
- * @param {Number} end
- * @param {Number} width
- * @param {Number} [totalHidden=0]
+ * @param {number} start
+ * @param {number} end
+ * @param {number} width
+ * @param {number} [totalHidden=0]
  * @returns {{offset: number, scale: number}} conversion
  */
 Range.conversion = function (start, end, width, totalHidden) {
@@ -756,7 +756,7 @@ Range.prototype._isInsideRange = function(event) {
 
 /**
  * Helper function to calculate the center date for zooming
- * @param {{x: Number, y: Number}} pointer
+ * @param {{x: number, y: number}} pointer
  * @return {number} date
  * @private
  */
@@ -778,9 +778,9 @@ Range.prototype._pointerToDate = function (pointer) {
 
 /**
  * Get the pointer location relative to the location of the dom element
- * @param {{x: Number, y: Number}} touch
+ * @param {{x: number, y: number}} touch
  * @param {Element} element   HTML DOM element
- * @return {{x: Number, y: Number}} pointer
+ * @return {{x: number, y: number}} pointer
  * @private
  */
 Range.prototype.getPointer = function (touch, element) {
@@ -802,11 +802,11 @@ Range.prototype.getPointer = function (touch, element) {
  * be adjusted, and the timeline will be redrawn. You can optionally give a
  * date around which to zoom.
  * For example, try scale = 0.9 or 1.1
- * @param {Number} scale      Scaling factor. Values above 1 will zoom out,
+ * @param {number} scale      Scaling factor. Values above 1 will zoom out,
  *                            values below 1 will zoom in.
- * @param {Number} [center]   Value representing a date around which will
+ * @param {number} [center]   Value representing a date around which will
  *                            be zoomed.
- * @param {Number} delta
+ * @param {number} delta
  * @param {Event} event
  */
 Range.prototype.zoom = function(scale, center, delta, event) {
@@ -849,7 +849,7 @@ Range.prototype.zoom = function(scale, center, delta, event) {
 /**
  * Move the range with a given delta to the left or right. Start and end
  * value will be adjusted. For example, try delta = 0.1 or -0.1
- * @param {Number}  delta     Moving amount. Positive value will move right,
+ * @param {number}  delta     Moving amount. Positive value will move right,
  *                            negative value will move left
  */
 Range.prototype.move = function(delta) {
@@ -868,7 +868,7 @@ Range.prototype.move = function(delta) {
 
 /**
  * Move the range to a new center point
- * @param {Number} moveTo      New center point of the range
+ * @param {number} moveTo      New center point of the range
  */
 Range.prototype.moveTo = function(moveTo) {
   var center = (this.start + this.end) / 2;

--- a/lib/timeline/Range.js
+++ b/lib/timeline/Range.js
@@ -451,7 +451,6 @@ Range.prototype.conversion = function (width, totalHidden) {
  * @param {Number} width
  * @param {Number} [totalHidden=0]
  * @returns {{offset: number, scale: number}} conversion
- * @static
  */
 Range.conversion = function (start, end, width, totalHidden) {
   if (totalHidden === undefined) {

--- a/lib/timeline/Stack.js
+++ b/lib/timeline/Stack.js
@@ -108,7 +108,7 @@ exports.nostack = function(items, margin, subgroups, stackSubgroups) {
 /**
  * Adjust vertical positions of the subgroups such that they don't overlap each
  * other.
- * @param {Array<vis.Item>} items
+ * @param {Array.<vis.Item>} items
  * @param {{item: {horizontal: number, vertical: number}, axis: number}} margin Margins between items and between items and the axis.
  * @param {subgroups[]} subgroups
  *            All subgroups

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -25,8 +25,8 @@ var util = require('../util');
  * @param {Date} [start]         The start date, for example new Date(2010, 9, 21)
  *                               or new Date(2010, 9, 21, 23, 45, 00)
  * @param {Date} [end]           The end date
- * @param {Number} [minimumStep] Optional. Minimum step size in milliseconds
- * @param {Date|Array<Date>} [hiddenDates] Optional.
+ * @param {number} [minimumStep] Optional. Minimum step size in milliseconds
+ * @param {Date|Array.<Date>} [hiddenDates] Optional.
  * @param {{showMajorLabels: boolean}} [options] Optional.
  * @constructor  TimeStep
  */
@@ -313,7 +313,7 @@ TimeStep.prototype.setAutoScale = function (enable) {
 
 /**
  * Automatically determine the scale that bests fits the provided minimum step
- * @param {Number} [minimumStep]  The minimum step size in milliseconds
+ * @param {number} [minimumStep]  The minimum step size in milliseconds
  */
 TimeStep.prototype.setMinimumStep = function(minimumStep) {
   if (minimumStep == undefined) {
@@ -622,7 +622,7 @@ TimeStep.prototype.getClassName = function() {
 
   /**
    *
-   * @param {Number} value
+   * @param {number} value
    * @returns {String}
    */
   function even(value) {

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -371,7 +371,6 @@ TimeStep.prototype.setMinimumStep = function(minimumStep) {
  *                       'minute', 'hour', 'weekday, 'day', 'week', 'month', 'year'.
  * @param {number} step  Current step (1, 2, 4, 5, ...
  * @return {Date} snappedDate
- * @static
  */
 TimeStep.snap = function(date, scale, step) {
   var clone = moment(date);

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -371,6 +371,7 @@ TimeStep.prototype.setMinimumStep = function(minimumStep) {
  *                       'minute', 'hour', 'weekday, 'day', 'week', 'month', 'year'.
  * @param {number} step  Current step (1, 2, 4, 5, ...
  * @return {Date} snappedDate
+ * @static
  */
 TimeStep.snap = function(date, scale, step) {
   var clone = moment(date);

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -354,7 +354,7 @@ Timeline.prototype.getSelection = function() {
 /**
  * Adjust the visible window such that the selected item (or multiple items)
  * are centered on screen.
- * @param {String | String[]} id     An item id or array with item ids
+ * @param {string | String[]} id     An item id or array with item ids
  * @param {Object} [options]      Available options:
  *                                `animation: boolean | {duration: number, easingFunction: string}`
  *                                    If true (default), the range is animated
@@ -432,7 +432,7 @@ Timeline.prototype.fit = function (options) {
 /**
  *
  * @param {vis.Item} item
- * @returns {Number}
+ * @returns {number}
  */
 function getStart(item) {
   return util.convert(item.data.start, 'Date').valueOf()
@@ -441,7 +441,7 @@ function getStart(item) {
 /**
  *
  * @param {vis.Item} item
- * @returns {Number}
+ * @returns {number}
  */
 function getEnd(item) {
   var end = item.data.end != undefined ? item.data.end : item.data.start;

--- a/lib/timeline/component/BackgroundGroup.js
+++ b/lib/timeline/component/BackgroundGroup.js
@@ -2,7 +2,7 @@ var Group = require('./Group');
 
 /**
  * @constructor BackgroundGroup
- * @param {Number | String} groupId
+ * @param {number | string} groupId
  * @param {Object} data
  * @param {ItemSet} itemSet
  * @extends Group

--- a/lib/timeline/component/CurrentTime.js
+++ b/lib/timeline/component/CurrentTime.js
@@ -159,7 +159,7 @@ CurrentTime.prototype.stop = function() {
 /**
  * Set a current time. This can be used for example to ensure that a client's
  * time is synchronized with a shared server time.
- * @param {Date | String | Number} time     A Date, unix timestamp, or
+ * @param {Date | string | number} time     A Date, unix timestamp, or
  *                                          ISO date string.
  */
 CurrentTime.prototype.setCurrentTime = function(time) {

--- a/lib/timeline/component/GraphGroup.js
+++ b/lib/timeline/component/GraphGroup.js
@@ -116,7 +116,7 @@ GraphGroup.prototype.update = function (group) {
  *
  * @param {number} iconWidth
  * @param {number} iconHeight
- * @param {{svg: (*|Element), svgElements: Object, options: Object, groups: Array<Object>}} framework
+ * @param {{svg: (*|Element), svgElements: Object, options: Object, groups: Array.<Object>}} framework
  * @param {number} x
  * @param {number} y
  * @returns {{icon: (*|Element), label: (*|string), orientation: *}}

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -2,7 +2,7 @@ var util = require('../../util');
 var stack = require('../Stack');
 
 /**
- * @param {Number | String} groupId
+ * @param {number | string} groupId
  * @param {Object} data
  * @param {ItemSet} itemSet
  * @constructor Group
@@ -743,7 +743,7 @@ Group.prototype._checkIfVisible = function(item, visibleItems, range) {
  * this one is for brute forcing and hiding.
  *
  * @param {Item} item
- * @param {Array<vis.Item>} visibleItems
+ * @param {Array.<vis.Item>} visibleItems
  * @param {Object<number, boolean>} visibleItemsLookup
  * @param {{start:number, end:number}} range
  * @private

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -296,51 +296,51 @@ ItemSet.prototype._create = function(){
 /**
  * Set options for the ItemSet. Existing options will be extended/overwritten.
  * @param {Object} [options] The following options are available:
- *                           {String} type
+ *                           {string} type
  *                              Default type for the items. Choose from 'box'
  *                              (default), 'point', 'range', or 'background'.
  *                              The default style can be overwritten by
  *                              individual items.
- *                           {String} align
+ *                           {string} align
  *                              Alignment for the items, only applicable for
  *                              BoxItem. Choose 'center' (default), 'left', or
  *                              'right'.
- *                           {String} orientation.item
+ *                           {string} orientation.item
  *                              Orientation of the item set. Choose 'top' or
  *                              'bottom' (default).
  *                           {Function} groupOrder
  *                              A sorting function for ordering groups
- *                           {Boolean} stack
+ *                           {boolean} stack
  *                              If true (default), items will be stacked on
  *                              top of each other.
- *                           {Number} margin.axis
+ *                           {number} margin.axis
  *                              Margin between the axis and the items in pixels.
  *                              Default is 20.
- *                           {Number} margin.item.horizontal
+ *                           {number} margin.item.horizontal
  *                              Horizontal margin between items in pixels.
  *                              Default is 10.
- *                           {Number} margin.item.vertical
+ *                           {number} margin.item.vertical
  *                              Vertical Margin between items in pixels.
  *                              Default is 10.
- *                           {Number} margin.item
+ *                           {number} margin.item
  *                              Margin between items in pixels in both horizontal
  *                              and vertical direction. Default is 10.
- *                           {Number} margin
+ *                           {number} margin
  *                              Set margin for both axis and items in pixels.
- *                           {Boolean} selectable
+ *                           {boolean} selectable
  *                              If true (default), items can be selected.
- *                           {Boolean} multiselect
+ *                           {boolean} multiselect
  *                              If true, multiple items can be selected.
  *                              False by default.
- *                           {Boolean} editable
+ *                           {boolean} editable
  *                              Set all editable options to true or false
- *                           {Boolean} editable.updateTime
+ *                           {boolean} editable.updateTime
  *                              Allow dragging an item to an other moment in time
- *                           {Boolean} editable.updateGroup
+ *                           {boolean} editable.updateGroup
  *                              Allow dragging an item to an other group
- *                           {Boolean} editable.add
+ *                           {boolean} editable.add
  *                              Allow creating new items on double tap
- *                           {Boolean} editable.remove
+ *                           {boolean} editable.remove
  *                              Allow removing items by clicking the delete button
  *                              top right of a selected item.
  *                           {Function(item: Item, callback: Function)} onAdd
@@ -610,7 +610,7 @@ ItemSet.prototype.getVisibleItems = function() {
 
 /**
  * Deselect a selected item
- * @param {String | Number} id
+ * @param {string | number} id
  * @private
  */
 ItemSet.prototype._deselect = function(id) {
@@ -920,7 +920,7 @@ ItemSet.prototype.getGroups = function() {
 
 /**
  * Remove an item by its id
- * @param {String | Number} id
+ * @param {string | number} id
  */
 ItemSet.prototype.removeItem = function(id) {
   var item = this.itemsData.get(id),
@@ -967,7 +967,7 @@ ItemSet.prototype._getGroupId = function (itemData) {
 
 /**
  * Handle updated items
- * @param {Number[]} ids
+ * @param {number[]} ids
  * @protected
  */
 ItemSet.prototype._onUpdate = function(ids) {
@@ -1023,14 +1023,14 @@ ItemSet.prototype._onUpdate = function(ids) {
 
 /**
  * Handle added items
- * @param {Number[]} ids
+ * @param {number[]} ids
  * @protected
  */
 ItemSet.prototype._onAdd = ItemSet.prototype._onUpdate;
 
 /**
  * Handle removed items
- * @param {Number[]} ids
+ * @param {number[]} ids
  * @protected
  */
 ItemSet.prototype._onRemove = function(ids) {
@@ -1065,7 +1065,7 @@ ItemSet.prototype._order = function() {
 
 /**
  * Handle updated groups
- * @param {Number[]} ids
+ * @param {number[]} ids
  * @private
  */
 ItemSet.prototype._onUpdateGroups = function(ids) {
@@ -1074,7 +1074,7 @@ ItemSet.prototype._onUpdateGroups = function(ids) {
 
 /**
  * Handle changed groups (added or updated)
- * @param {Number[]} ids
+ * @param {number[]} ids
  * @private
  */
 ItemSet.prototype._onAddGroups = function(ids) {
@@ -1122,7 +1122,7 @@ ItemSet.prototype._onAddGroups = function(ids) {
 
 /**
  * Handle removed groups
- * @param {Number[]} ids
+ * @param {number[]} ids
  * @private
  */
 ItemSet.prototype._onRemoveGroups = function(ids) {
@@ -1181,8 +1181,8 @@ ItemSet.prototype._orderGroups = function () {
 /**
  * Reorder the nested groups
  *
- * @param {Array<number>} groupIds
- * @returns {Array<number>}
+ * @param {Array.<number>} groupIds
+ * @returns {Array.<number>}
  * @private
  */
 ItemSet.prototype._orderNestedGroups = function(groupIds) {
@@ -1271,7 +1271,7 @@ ItemSet.prototype._removeItem = function(item) {
 
 /**
  * Create an array containing all items being a range (having an end date)
- * @param {Array<Object>} array
+ * @param {Array.<Object>} array
  * @returns {Array}
  * @private
  */
@@ -1612,7 +1612,7 @@ ItemSet.prototype._onDrag = function (event) {
 /**
  * Move an item to another group
  * @param {Item} item
- * @param {String | Number} groupId
+ * @param {string | number} groupId
  * @private
  */
 ItemSet.prototype._moveToGroup = function(item, groupId) {

--- a/lib/timeline/component/LineGraph.js
+++ b/lib/timeline/component/LineGraph.js
@@ -856,7 +856,7 @@ LineGraph.prototype._getRelevantData = function (groupIds, groupsData, minDate, 
 
 /**
  *
- * @param {Array<vis.GraphGroup.id>} groupIds
+ * @param {Array.<vis.GraphGroup.id>} groupIds
  * @param {vis.DataSet} groupsData
  * @private
  */
@@ -893,7 +893,7 @@ LineGraph.prototype._applySampling = function (groupIds, groupsData) {
 
 /**
  *
- * @param {Array<vis.GraphGroup.id>} groupIds
+ * @param {Array.<vis.GraphGroup.id>} groupIds
  * @param {vis.DataSet} groupsData
  * @param {object} groupRanges  | this is being filled here
  * @private
@@ -933,7 +933,7 @@ LineGraph.prototype._getYRanges = function (groupIds, groupsData, groupRanges) {
 
 /**
  * this sets the Y ranges for the Y axis. It also determines which of the axis should be shown or hidden.
- * @param {Array<vis.GraphGroup.id>} groupIds
+ * @param {Array.<vis.GraphGroup.id>} groupIds
  * @param {Object} groupRanges
  * @returns {boolean} resized
  * @private
@@ -1060,7 +1060,7 @@ LineGraph.prototype._toggleAxisVisiblity = function (axisUsed, axis) {
  * util function toScreen to get the x coordinate from the timestamp. It also pre-filters the data and get the minMax ranges for
  * the yAxis.
  *
- * @param {Array<Object>} datapoints
+ * @param {Array.<Object>} datapoints
  * @private
  */
 LineGraph.prototype._convertXcoordinates = function (datapoints) {
@@ -1083,7 +1083,7 @@ LineGraph.prototype._convertXcoordinates = function (datapoints) {
  * util function toScreen to get the x coordinate from the timestamp. It also pre-filters the data and get the minMax ranges for
  * the yAxis.
  *
- * @param {Array<Object>} datapoints
+ * @param {Array.<Object>} datapoints
  * @param {vis.GraphGroup} group
  * @private
  */

--- a/lib/timeline/component/TimeAxis.js
+++ b/lib/timeline/component/TimeAxis.js
@@ -318,10 +318,10 @@ TimeAxis.prototype._repaintLabels = function () {
 
 /**
  * Create a minor label for the axis at position x
- * @param {Number} x
- * @param {String} text
- * @param {String} orientation   "top" or "bottom" (default)
- * @param {String} className
+ * @param {number} x
+ * @param {string} text
+ * @param {string} orientation   "top" or "bottom" (default)
+ * @param {string} className
  * @return {Element} Returns the HTML element of the created label
  * @private
  */
@@ -355,10 +355,10 @@ TimeAxis.prototype._repaintMinorText = function (x, text, orientation, className
 
 /**
  * Create a Major label for the axis at position x
- * @param {Number} x
- * @param {String} text
- * @param {String} orientation   "top" or "bottom" (default)
- * @param {String} className
+ * @param {number} x
+ * @param {string} text
+ * @param {string} orientation   "top" or "bottom" (default)
+ * @param {string} className
  * @return {Element} Returns the HTML element of the created label
  * @private
  */
@@ -392,10 +392,10 @@ TimeAxis.prototype._repaintMajorText = function (x, text, orientation, className
 
 /**
  * Create a minor line for the axis at position x
- * @param {Number} x
- * @param {Number} width
- * @param {String} orientation   "top" or "bottom" (default)
- * @param {String} className
+ * @param {number} x
+ * @param {number} width
+ * @param {string} orientation   "top" or "bottom" (default)
+ * @param {string} className
  * @return {Element} Returns the created line
  * @private
  */
@@ -434,10 +434,10 @@ TimeAxis.prototype._repaintMinorLine = function (x, width, orientation, classNam
 
 /**
  * Create a Major line for the axis at position x
- * @param {Number} x
- * @param {Number} width
- * @param {String} orientation   "top" or "bottom" (default)
- * @param {String} className
+ * @param {number} x
+ * @param {number} width
+ * @param {string} orientation   "top" or "bottom" (default)
+ * @param {string} className
  * @return {Element} Returns the created line
  * @private
  */

--- a/lib/timeline/component/graph2d_types/bar.js
+++ b/lib/timeline/component/graph2d_types/bar.js
@@ -45,9 +45,9 @@ Bargraph.drawIcon = function (group, x, y, iconWidth, iconHeight, framework) {
 /**
  * draw a bar graph
  *
- * @param {Array<vis.GraphGroup.id>} groupIds
+ * @param {Array.<vis.GraphGroup.id>} groupIds
  * @param {Object} processedGroupData
- * @param {{svg: Object, svgElements: Array<Object>, options: Object, groups: Array<vis.Group>}} framework
+ * @param {{svg: Object, svgElements: Array.<Object>, options: Object, groups: Array.<vis.Group>}} framework
  */
 Bargraph.draw = function (groupIds, processedGroupData, framework) {
   var combinedData = [];
@@ -168,7 +168,7 @@ Bargraph.draw = function (groupIds, processedGroupData, framework) {
 /**
  * Fill the intersections object with counters of how many datapoints share the same x coordinates
  * @param {Object} intersections
- * @param {Array<Object>} combinedData
+ * @param {Array.<Object>} combinedData
  * @private
  */
 Bargraph._getDataIntersections = function (intersections, combinedData) {
@@ -202,7 +202,7 @@ Bargraph._getDataIntersections = function (intersections, combinedData) {
  * @param {number} coreDistance
  * @param {vis.Group} group
  * @param {number} minWidth
- * @returns {{width: Number, offset: Number}}
+ * @returns {{width: number, offset: number}}
  * @private
  */
 Bargraph._getSafeDrawData = function (coreDistance, group, minWidth) {

--- a/lib/timeline/component/graph2d_types/line.js
+++ b/lib/timeline/component/graph2d_types/line.js
@@ -117,9 +117,9 @@ Line.drawShading = function (pathArray, group, subPathArray, framework) {
 /**
  * draw a line graph
  *
- * @param {Array<Object>} pathArray
+ * @param {Array.<Object>} pathArray
  * @param {vis.Group} group
- * @param {{svg: Object, svgElements: Array<Object>, options: Object, groups: Array<vis.Group>}} framework
+ * @param {{svg: Object, svgElements: Array.<Object>, options: Object, groups: Array.<vis.Group>}} framework
  */
 Line.draw = function (pathArray, group, framework) {
     if (pathArray != null && pathArray != undefined) {
@@ -161,7 +161,7 @@ Line.serializePath = function(pathArray,type,inverse){
 /**
  * This uses an uniform parametrization of the interpolation algorithm:
  * 'On the Parameterization of Catmull-Rom Curves' by Cem Yuksel et al.
- * @param {Array<Object>} data
+ * @param {Array.<Object>} data
  * @returns {string}
  * @private
  */
@@ -211,7 +211,7 @@ Line._catmullRomUniform = function (data) {
  * These parameterizations are relatively heavy because the distance between 4 points have to be calculated.
  *
  * One optimization can be used to reuse distances since this is a sliding window approach.
- * @param {Array<Object>} data
+ * @param {Array.<Object>} data
  * @param {vis.GraphGroup} group
  * @returns {string}
  * @private
@@ -293,7 +293,7 @@ Line._catmullRom = function (data, group) {
 
 /**
  * this generates the SVG path for a linear drawing between datapoints.
- * @param {Array<Object>} data
+ * @param {Array.<Object>} data
  * @returns {string}
  * @private
  */

--- a/lib/timeline/component/graph2d_types/points.js
+++ b/lib/timeline/component/graph2d_types/points.js
@@ -2,7 +2,7 @@ var DOMutil = require('../../../DOMutil');
 
 /**
  *
- * @param {Number | String} groupId
+ * @param {number | string} groupId
  * @param {Object} options   // TODO: Describe options
  *
  * @constructor Points
@@ -16,7 +16,7 @@ function Points(groupId, options) {  // eslint-disable-line no-unused-vars
  * @param {Array} dataset
  * @param {GraphGroup} group
  * @param {Object} framework            | SVG DOM element
- * @param {Number} [offset]
+ * @param {number} [offset]
  */
 Points.draw = function (dataset, group, framework, offset) {
   offset = offset || 0;

--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -36,7 +36,7 @@ BoxItem.prototype = new Item (null, null, null);
 
 /**
  * Check whether this item is visible inside given range
- * @param {{start: Number, end: Number}} range with a timestamp for start and end
+ * @param {{start: number, end: number}} range with a timestamp for start and end
  * @returns {boolean} True if visible
  */
 BoxItem.prototype.isVisible = function(range) {

--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -38,7 +38,7 @@ PointItem.prototype = new Item (null, null, null);
 
 /**
  * Check whether this item is visible inside given range
- * @param {{start: Number, end: Number}} range with a timestamp for start and end
+ * @param {{start: number, end: number}} range with a timestamp for start and end
  * @returns {boolean} True if visible
  */
 PointItem.prototype.isVisible = function(range) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -84,7 +84,7 @@ exports.isDate = function (object) {
 /**
  * Create a semi UUID
  * source: http://stackoverflow.com/a/105074/1262753
- * @return {String} uuid
+ * @return {string} uuid
  */
 exports.randomUUID = function () {
   return uuid.v4();
@@ -174,7 +174,7 @@ exports.extend = function (a, b) {  // eslint-disable-line no-unused-vars
 /**
  * Extend object a with selected properties of object b or a series of objects
  * Only properties with defined values are copied
- * @param {Array.<String>} props
+ * @param {Array.<string>} props
  * @param {Object} a
  * @param {Object} b
  * @return {Object} a
@@ -200,10 +200,10 @@ exports.selectiveExtend = function (props, a, b) {  // eslint-disable-line no-un
 /**
  * Extend object a with selected properties of object b or a series of objects
  * Only properties with defined values are copied
- * @param {Array.<String>} props
+ * @param {Array.<string>} props
  * @param {Object} a
  * @param {Object} b
- * @param {Boolean} [allowDeletion=false]
+ * @param {boolean} [allowDeletion=false]
  * @return {Object} a
  */
 exports.selectiveDeepExtend = function (props, a, b, allowDeletion = false) {
@@ -251,10 +251,10 @@ exports.selectiveDeepExtend = function (props, a, b, allowDeletion = false) {
 /**
  * Extend object a with selected properties of object b or a series of objects
  * Only properties with defined values are copied
- * @param {Array.<String>} props
+ * @param {Array.<string>} props
  * @param {Object} a
  * @param {Object} b
- * @param {Boolean} [allowDeletion=false]
+ * @param {boolean} [allowDeletion=false]
  * @return {Object} a
  */
 exports.selectiveNotDeepExtend = function (props, a, b, allowDeletion = false) {
@@ -303,9 +303,9 @@ exports.selectiveNotDeepExtend = function (props, a, b, allowDeletion = false) {
  * Deep extend an object a with the properties of object b
  * @param {Object} a
  * @param {Object} b
- * @param {Boolean} [protoExtend]   --> optional parameter. If true, the prototype values will also be extended.
+ * @param {boolean} [protoExtend]   --> optional parameter. If true, the prototype values will also be extended.
  *                                    (ie. the options objects that inherit from others will also get the inherited options)
- * @param {Boolean} [allowDeletion] --> optional parameter. If true, the values of fields that are null will be deleted
+ * @param {boolean} [allowDeletion] --> optional parameter. If true, the values of fields that are null will be deleted
  * @returns {Object}
  */
 exports.deepExtend = function (a, b, protoExtend, allowDeletion) {
@@ -363,8 +363,8 @@ exports.equalArray = function (a, b) {
 
 /**
  * Convert an object to another type
- * @param {Boolean | Number | String | Date | Moment | Null | undefined} object
- * @param {String | undefined} type   Name of the type. Available types:
+ * @param {boolean | number | string | Date | Moment | Null | undefined} object
+ * @param {string | undefined} type   Name of the type. Available types:
  *                                    'Boolean', 'Number', 'String',
  *                                    'Date', 'Moment', ISODate', 'ASPDate'.
  * @return {*} object
@@ -520,7 +520,7 @@ var ASPDateRegex = /^\/?Date\((\-?\d+)/i;
 /**
  * Get the type of an object, for example exports.getType([]) returns 'Array'
  * @param {*} object
- * @return {String} type
+ * @return {string} type
  */
 exports.getType = function (object) {
   var type = typeof object;
@@ -621,7 +621,7 @@ exports.getAbsoluteTop = function (elem) {
 /**
  * add a className to the given elements style
  * @param {Element} elem
- * @param {String} classNames
+ * @param {string} classNames
  */
 exports.addClassName = function (elem, classNames) {
   var classes = elem.className.split(' ');
@@ -635,7 +635,7 @@ exports.addClassName = function (elem, classNames) {
 /**
  * add a className to the given elements style
  * @param {Element} elem
- * @param {String} classNames
+ * @param {string} classNames
  */
 exports.removeClassName = function (elem, classNames) {
   var classes = elem.className.split(' ');
@@ -693,7 +693,7 @@ exports.toArray = function (object) {
 /**
  * Update a property in an object
  * @param {Object} object
- * @param {String} key
+ * @param {string} key
  * @param {*} value
  * @return {Boolean} changed
  */
@@ -841,7 +841,7 @@ exports.option = {};
 /**
  * Convert a value into a boolean
  * @param {Boolean | function | undefined} value
- * @param {Boolean} [defaultValue]
+ * @param {boolean} [defaultValue]
  * @returns {Boolean} bool
  */
 exports.option.asBoolean = function (value, defaultValue) {
@@ -859,8 +859,8 @@ exports.option.asBoolean = function (value, defaultValue) {
 /**
  * Convert a value into a number
  * @param {Boolean | function | undefined} value
- * @param {Number} [defaultValue]
- * @returns {Number} number
+ * @param {number} [defaultValue]
+ * @returns {number} number
  */
 exports.option.asNumber = function (value, defaultValue) {
   if (typeof value == 'function') {
@@ -876,8 +876,8 @@ exports.option.asNumber = function (value, defaultValue) {
 
 /**
  * Convert a value into a string
- * @param {String | function | undefined} value
- * @param {String} [defaultValue]
+ * @param {string | function | undefined} value
+ * @param {string} [defaultValue]
  * @returns {String} str
  */
 exports.option.asString = function (value, defaultValue) {
@@ -894,8 +894,8 @@ exports.option.asString = function (value, defaultValue) {
 
 /**
  * Convert a size or location into a string with pixels or a percentage
- * @param {String | Number | function | undefined} value
- * @param {String} [defaultValue]
+ * @param {string | number | function | undefined} value
+ * @param {string} [defaultValue]
  * @returns {String} size
  */
 exports.option.asSize = function (value, defaultValue) {
@@ -931,7 +931,7 @@ exports.option.asElement = function (value, defaultValue) {
 /**
  * http://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
  *
- * @param {String} hex
+ * @param {string} hex
  * @returns {{r: *, g: *, b: *}} | 255 range
  */
 exports.hexToRGB = function (hex) {
@@ -950,8 +950,8 @@ exports.hexToRGB = function (hex) {
 
 /**
  * This function takes color in hex format or rgb() or rgba() format and overrides the opacity. Returns rgba() string.
- * @param {String} color
- * @param {Number} opacity
+ * @param {string} color
+ * @param {number} opacity
  * @returns {String}
  */
 exports.overrideOpacity = function (color, opacity) {
@@ -976,9 +976,9 @@ exports.overrideOpacity = function (color, opacity) {
 
 /**
  *
- * @param {Number} red     0 -- 255
- * @param {Number} green   0 -- 255
- * @param {Number} blue    0 -- 255
+ * @param {number} red     0 -- 255
+ * @param {number} green   0 -- 255
+ * @param {number} blue    0 -- 255
  * @returns {String}
  * @constructor
  */
@@ -1071,10 +1071,10 @@ exports.parseColor = function (color) {
 /**
  * http://www.javascripter.net/faq/rgb2hsv.htm
  *
- * @param {Number} red
- * @param {Number} green
- * @param {Number} blue
- * @returns {{h: Number, s: Number, v: Number}}
+ * @param {number} red
+ * @param {number} green
+ * @param {number} blue
+ * @returns {{h: number, s: number, v: number}}
  * @constructor
  */
 exports.RGBToHSV = function (red, green, blue) {
@@ -1126,7 +1126,7 @@ var cssUtil = {
 /**
  * Append a string with css styles to an element
  * @param {Element} element
- * @param {String} cssText
+ * @param {string} cssText
  */
 exports.addCssText = function (element, cssText) {
   var currentStyles = cssUtil.split(element.style.cssText);
@@ -1139,7 +1139,7 @@ exports.addCssText = function (element, cssText) {
 /**
  * Remove a string with css styles from an element
  * @param {Element} element
- * @param {String} cssText
+ * @param {string} cssText
  */
 exports.removeCssText = function (element, cssText) {
   var styles = cssUtil.split(element.style.cssText);
@@ -1156,9 +1156,9 @@ exports.removeCssText = function (element, cssText) {
 
 /**
  * https://gist.github.com/mjijackson/5311256
- * @param {Number} h
- * @param {Number} s
- * @param {Number} v
+ * @param {number} h
+ * @param {number} s
+ * @param {number} v
  * @returns {{r: number, g: number, b: number}}
  * @constructor
  */
@@ -1213,7 +1213,7 @@ exports.isValidRGBA = function (rgba) {
  * This recursively redirects the prototype of JSON objects to the referenceObject
  * This is used for default options.
  *
- * @param {Array<String>} fields
+ * @param {Array.<string>} fields
  * @param {Object} referenceObject
  * @returns {*}
  */
@@ -1294,7 +1294,7 @@ exports.insertSort = function (a,compare) {
  *
  * @param {object} mergeTarget   | either this.options or the options used for the groups.
  * @param {object} options       | options
- * @param {String} option        | option key in the options argument
+ * @param {string} option        | option key in the options argument
  * @param {object} globalOptions | global options, passed in to determine value of option 'enabled'
  */
 exports.mergeOptions = function (mergeTarget, options, option, globalOptions = {}) {
@@ -1413,8 +1413,8 @@ exports.mergeOptions = function (mergeTarget, options, option, globalOptions = {
  *
  * @param {Item[]} orderedItems       | Items ordered by start
  * @param {function} comparator       | -1 is lower, 0 is equal, 1 is higher
- * @param {String} field
- * @param {String} field2
+ * @param {string} field
+ * @param {string} field2
  * @returns {number}
  * @private
  */
@@ -1454,8 +1454,8 @@ exports.binarySearchCustom = function (orderedItems, comparator, field, field2) 
  *
  * @param {Array} orderedItems
  * @param {{start: number, end: number}} target
- * @param {String} field
- * @param {String} sidePreference   'before' or 'after'
+ * @param {string} field
+ * @param {string} sidePreference   'before' or 'after'
  * @param {function} comparator an optional comparator, returning -1,0,1 for <,==,>.
  * @returns {number}
  * @private


### PR DESCRIPTION
@wimrijnders had feedback on 3382 that was unaddressed prior to merge.

I have addressed the majority of the feedback.
- [x] Correct use of `@static`
- [x] Correct unresolvable/incorrectly name-spaced types
- [x] Remove extraneous `@class` and `@constructor` from explicitly defined classes & constructors (note: added `@inheritDoc` to constructors to satisfy linter)

I will address the rest of the feedback around unreadable/overly complex types in a follow-up PR, as they will require code changes beyond just jsdoc.

R: @wimrijnders & @yotamberk 