### PR TITLE
Network: Cluster node handling due to dynamic data change.

### DIFF
--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -63,7 +63,7 @@ A cluster node has the following extra fields:
 - `isCluster : true` - indication that this is a cluster node
 - `containedNodes`   - hash of nodes contained in this cluster
 - `containedEdges`   - same for edges
-- `edges`            - hash of cluster edges for this node 
+- `edges`            - array of cluster edges for this node 
 
 
 **NOTE:**
@@ -710,6 +710,27 @@ class ClusterEngine {
       throw new Error("The node:" + clusterNodeId + " is not a valid cluster.");
     }
 
+    // Check if current cluster is clustered itself
+    let stack = this.findNode(clusterNodeId);
+    let parentIndex = stack.indexOf(clusterNodeId) - 1;
+    if (parentIndex >= 0) {
+      // Current cluster is clustered; transfer contained nodes and edges to parent
+      let parentClusterNodeId = stack[parentIndex];
+      let parentClusterNode   = this.body.nodes[parentClusterNodeId];
+
+      // clustering.clusteredNodes and clustering.clusteredEdges remain unchanged
+      parentClusterNode._openChildCluster(clusterNodeId);
+
+      // At this point, all components of clustering node have been transferred.
+      // It can die now.
+      delete this.body.nodes[clusterNodeId];
+      if (refreshData === true) {
+        this.body.emitter.emit('_dataChanged');
+      }
+
+      return;
+    }
+
     // main body 
     let containedNodes = clusterNode.containedNodes;
     let containedEdges = clusterNode.containedEdges;
@@ -738,15 +759,11 @@ class ClusterEngine {
     }
     else {
       // copy the position from the cluster
-      for (let nodeId in containedNodes) {
-        if (containedNodes.hasOwnProperty(nodeId)) {
-          let containedNode = this.body.nodes[nodeId];
-          containedNode = containedNodes[nodeId];
-          // inherit position
-          if (containedNode.options.fixed.x === false) {containedNode.x = clusterNode.x;}
-          if (containedNode.options.fixed.y === false) {containedNode.y = clusterNode.y;}
-        }
-      }
+      util.forEach(containedNodes, function(containedNode) {
+        // inherit position
+        if (containedNode.options.fixed.x === false) {containedNode.x = clusterNode.x;}
+        if (containedNode.options.fixed.y === false) {containedNode.y = clusterNode.y;}
+      });
     }
 
     // release nodes

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -1227,6 +1227,8 @@ class ClusterEngine {
 
     /**
      * Utility function to iterate over clustering nodes only
+     *
+     * @param {Function} callback  function to call for each cluster node
      */
     let eachClusterNode = (callback) => {
       for (nodeId in this.body.nodes) {

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -3,10 +3,8 @@
 # TODO
 
 - `edgeReplacedById` not cleaned up yet on cluster edge removal
-- check correct working for everything for clustered clusters (could use a unit test)
-- Handle recursive unclustering on node removal
-- `updateState()` not complete; scan TODO's there
-
+- allowSingleNodeCluster could be a global option as well; currently needs to always
+  be passed to clustering methods
 
 ----------------------------------------------
 
@@ -598,9 +596,9 @@ class ClusterEngine {
     // force the ID to remain the same
     clusterNodeProperties.id = clusterId;
 
-    // create the clusterNode
+    // create the cluster Node
+    // Note that allowSingleNodeCluster, if present, is stored in the options as well
     let clusterNode = this.body.functions.createNode(clusterNodeProperties, Cluster);
-    clusterNode.isCluster = true;
     clusterNode.containedNodes = childNodesObj;
     clusterNode.containedEdges = childEdgesObj;
     // cache a copy from the cluster edge properties if we have to reconnect others later on
@@ -1295,7 +1293,25 @@ class ClusterEngine {
     for (edgeId in this.body.edges) {
       let edge = this.body.edges[edgeId];
 
-      if (!edge.endPointsValid()) {
+      // Explicitly scan the contained edges for validity
+      let isValid = true;
+      let replacedIds = edge.clusteringEdgeReplacingIds;
+      if (replacedIds !== undefined) {
+        let numValid = 0;
+
+        for (let n in replacedIds) {
+          let containedEdgeId = replacedIds[n];
+          let containedEdge   = this.body.edges[containedEdgeId];
+
+          if (containedEdge !== undefined && containedEdge.endPointsValid()) {
+            numValid += 1;
+          }
+        }
+
+        isValid = (numValid > 0);
+      }
+
+      if (!edge.endPointsValid() || !isValid) {
         deletedEdgeIds.push(edgeId);
       }
     }
@@ -1384,8 +1400,8 @@ class ClusterEngine {
       // Determine the id's of clusters that need opening
       eachClusterNode(function(clusterNode) {
         let numNodes = Object.keys(clusterNode.containedNodes).length;
-        if (numNodes < 2) {
-//         || (numNodes == 1 && options.clusterNodeProperties.allowSingleNodeCluster === true) {
+        let allowSingle = (clusterNode.options.allowSingleNodeCluster === true);
+        if ((allowSingle && numNodes < 1) || (!allowSingle && numNodes < 2)) {
           clustersToOpen.push(clusterNode.id);
         }
       });

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -657,13 +657,22 @@ class ClusterEngine {
    */
   openCluster(clusterNodeId, options, refreshData = true) {
     // kill conditions
-    if (clusterNodeId === undefined)                    {throw new Error("No clusterNodeId supplied to openCluster.");}
-    if (this.body.nodes[clusterNodeId] === undefined)   {throw new Error("The clusterNodeId supplied to openCluster does not exist.");}
-    if (this.body.nodes[clusterNodeId].containedNodes === undefined) {
-      console.log("The node:" + clusterNodeId + " is not a cluster.");
-      return
+    if (clusterNodeId === undefined) {
+      throw new Error("No clusterNodeId supplied to openCluster.");
     }
+
     let clusterNode = this.body.nodes[clusterNodeId];
+
+    if (clusterNode === undefined) {
+      throw new Error("The clusterNodeId supplied to openCluster does not exist.");
+    }
+    if (clusterNode.isCluster !== true
+     || clusterNode.containedNodes === undefined
+     || clusterNode.containedEdges === undefined) {
+      throw new Error("The node:" + clusterNodeId + " is not a valid cluster.");
+    }
+
+    // main body 
     let containedNodes = clusterNode.containedNodes;
     let containedEdges = clusterNode.containedEdges;
 
@@ -1163,6 +1172,10 @@ class ClusterEngine {
     let deletedEdgeIds = [];
     let self = this;
 
+
+    /**
+     * Utility function to iterate over clustering nodes only
+     */
     let eachClusterNode = (callback) => {
       for (nodeId in this.body.nodes) {
         let node = this.body.nodes[nodeId];
@@ -1264,7 +1277,7 @@ class ClusterEngine {
 
     // Remove cluster edges from active list (this.body.edges).
     // deletedEdgeIds still contains id of regular edges, but these should all
-    // be gone upon entering this method
+    // be gone when you reach here.
     for (n in deletedEdgeIds) {
       delete this.body.edges[deletedEdgeIds[n]];
     }
@@ -1307,6 +1320,34 @@ class ClusterEngine {
 
     // TODO: Cluster nodes may now be empty or because of selected options may not be allowed to contain 1 node
     //       Remove these cluster nodes if necessary.
+
+    // Clusters may be nested to any level. Keep on opening until nothing to open
+    var changed = false;
+    var continueLoop = true;
+    while (continueLoop) {
+      let clustersToOpen = [];
+
+      // Determine the id's of clusters that need opening
+      eachClusterNode(function(clusterNode) {
+        let numNodes = Object.keys(clusterNode.containedNodes).length;
+        if (numNodes < 2) {
+//         || (numNodes == 1 && options.clusterNodeProperties.allowSingleNodeCluster === true) {
+          clustersToOpen.push(clusterNode.id);
+        }
+      });
+
+      // Open them
+      for (let n in clustersToOpen) {
+        this.openCluster(clustersToOpen[n], {}, false /* Don't refresh, we're in an refresh/update already */);
+      }
+
+      continueLoop = (clustersToOpen.length > 0);
+      changed = changed || continueLoop;
+    }
+
+    if (changed) {
+      this._updateState() // Redo this method (recursion possible! should be safe)
+    }
   }
 
 

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -1390,9 +1390,6 @@ class ClusterEngine {
     }
 
 
-    // TODO: Cluster nodes may now be empty or because of selected options may not be allowed to contain 1 node
-    //       Remove these cluster nodes if necessary.
-
     // Clusters may be nested to any level. Keep on opening until nothing to open
     var changed = false;
     var continueLoop = true;

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -721,8 +721,7 @@ class ClusterEngine {
       // clustering.clusteredNodes and clustering.clusteredEdges remain unchanged
       parentClusterNode._openChildCluster(clusterNodeId);
 
-      // At this point, all components of clustering node have been transferred.
-      // It can die now.
+      // All components of child cluster node have been transferred. It can die now.
       delete this.body.nodes[clusterNodeId];
       if (refreshData === true) {
         this.body.emitter.emit('_dataChanged');

--- a/lib/network/modules/components/nodes/Cluster.js
+++ b/lib/network/modules/components/nodes/Cluster.js
@@ -59,13 +59,13 @@ class Cluster extends Node {
 
     // Transfer edges within cluster edges which are clustered
     for (let n in childCluster.edges) {
-      let clusterEdgeId = childCluster.edges[n].id;
+      let clusterEdge = childCluster.edges[n];
+
       for (let m in this.edges) {
         let parentClusterEdge = this.edges[m];
-        let index = parentClusterEdge.clusteringEdgeReplacingIds.indexOf(clusterEdgeId);
+        let index = parentClusterEdge.clusteringEdgeReplacingIds.indexOf(clusterEdge.id);
         if (index === -1) continue;
 
-        let clusterEdge = childCluster.edges[clusterEdgeId];
         for (let n in clusterEdge.clusteringEdgeReplacingIds) {
           let srcId = clusterEdge.clusteringEdgeReplacingIds[n];
           parentClusterEdge.clusteringEdgeReplacingIds.push(srcId);

--- a/lib/network/modules/components/nodes/Cluster.js
+++ b/lib/network/modules/components/nodes/Cluster.js
@@ -30,7 +30,7 @@ class Cluster extends Node {
    *
    * Please consult the header comment in 'Clustering.js' for the fields set here.
    *
-   * @param {string|number} id of child cluster to open
+   * @param {string|number} childClusterId  id of child cluster to open
    */
   _openChildCluster(childClusterId) {
     let childCluster = this.body.nodes[childClusterId];

--- a/lib/network/modules/components/nodes/Cluster.js
+++ b/lib/network/modules/components/nodes/Cluster.js
@@ -23,6 +23,65 @@ class Cluster extends Node {
     this.containedNodes = {};
     this.containedEdges = {};
   }
+
+
+  /**
+   * Transfer child cluster data to current and disconnect the child cluster.
+   *
+   * @param {string|number} id of child cluster to open
+   */
+  _openChildCluster(childClusterId) {
+    let childCluster = this.body.nodes[childClusterId];
+    if (this.containedNodes[childClusterId] === undefined) {
+      throw new Error('node with id: ' + childClusterId + ' not in current cluster');
+    }
+    if (!childCluster.isCluster) {
+      throw new Error('node with id: ' + childClusterId + ' is not a cluster');
+    }
+
+    // Disconnect child cluster from current cluster
+    delete this.containedNodes[childClusterId];
+    for(let n in childCluster.edges) {
+      let edgeId = childCluster.edges[n].id;
+      delete this.containedEdges[edgeId];
+    }
+
+    // Transfer nodes and edges
+    for (let nodeId in childCluster.containedNodes) {
+      this.containedNodes[nodeId] = childCluster.containedNodes[nodeId];
+    }
+    childCluster.containedNodes = {};
+
+    for (let edgeId in childCluster.containedEdges) {
+      this.containedEdges[edgeId] = childCluster.containedEdges[edgeId];
+    }
+    childCluster.containedEdges = {};
+
+    // Transfer edges within cluster edges which are clustered
+    for (let n in childCluster.edges) {
+      let clusterEdgeId = childCluster.edges[n].id;
+      for (let m in this.edges) {
+        let parentClusterEdge = this.edges[m];
+        let index = parentClusterEdge.clusteringEdgeReplacingIds.indexOf(clusterEdgeId);
+        if (index === -1) continue;
+
+        let clusterEdge = childCluster.edges[clusterEdgeId];
+        for (let n in clusterEdge.clusteringEdgeReplacingIds) {
+          let srcId = clusterEdge.clusteringEdgeReplacingIds[n];
+          parentClusterEdge.clusteringEdgeReplacingIds.push(srcId);
+
+          // Maintain correct bookkeeping for transferred edge
+          this.body.edges[srcId].edgeReplacedById = parentClusterEdge.id;
+        }
+
+        // Remove cluster edge from parent cluster edge
+        parentClusterEdge.clusteringEdgeReplacingIds.splice(index, 1);
+        break;  // Assumption: a clustered edge can only be present in a single clustering edge
+      }
+    }
+    childCluster.edges = [];
+  }
 }
+
 
 export default Cluster;

--- a/lib/network/modules/components/nodes/Cluster.js
+++ b/lib/network/modules/components/nodes/Cluster.js
@@ -28,6 +28,8 @@ class Cluster extends Node {
   /**
    * Transfer child cluster data to current and disconnect the child cluster.
    *
+   * Please consult the header comment in 'Clustering.js' for the fields set here.
+   *
    * @param {string|number} id of child cluster to open
    */
   _openChildCluster(childClusterId) {

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -903,10 +903,10 @@ describe('Clustering', function () {
 
 
   /**
-   * Check correct opening of multiple clusters of clusters.
+   * Check correct opening of nested clusters.
    * The test uses clustering three levels deep and opens the middle one.
    */
-  it('properly opens multi-level clusters', function () {
+  it('properly opens clustered clusters', function () {
     var [network, data, numNodes, numEdges] = createSampleNetwork();
 		data.edges.update({from: 1, to: 11,});
     numEdges += 1;
@@ -934,7 +934,9 @@ describe('Clustering', function () {
     assertNumNodes(network, numNodes, numNodes - 5);
     assertNumEdges(network, numEdges, numEdges - 5);
 
-    // Same, with external connection to cluster
+    //
+    // Same, with one external connection to cluster
+    //
     var [network, data, numNodes, numEdges] = createSampleNetwork();
 		data.edges.update({from: 1, to: 11,});
 		data.edges.update({from: 2, to: 12,});


### PR DESCRIPTION
Fix for #3368.

**Changes:**

* Cluster nodes are now opened dynamically when data changes. A node gets removed if it can't exist any more due to deleted nodes and/or edges.
* Opening of nested clusters is now handled. On opening, the data of a nested cluster is transferred to the parent cluster. This functionality plays nice with previous item.
* Recursive opening of clusters due to previous two items is handled.
* The setting of cluster option `allowSingleNodeCluster` is taken into account with the dynamic updating.

Extensive unit tests have been added for all changes.