### PR TITLE
fix orientation option

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -375,7 +375,9 @@ Core.prototype.setOptions = function (options) {
       }
     }
 
-    this.options.orientation = {item:undefined,axis:undefined};
+    if (typeof this.options.orientation !== 'object') {
+      this.options.orientation = {item:undefined,axis:undefined};
+    }
     if ('orientation' in options) {
       if (typeof options.orientation === 'string') {
         this.options.orientation = {


### PR DESCRIPTION
If Timeline is created with `orientation` option set and then options are updated using `setOptions` method with different option only, the original `orientation` should be kept, however the object is reset to `{item:undefined,axis:undefined}`.

### example of the problem
```js
var options = {
    timeAxis: {
        scale: 'hour',
        step: 1
    },
    orientation: 'top'
};
var timeline = new vis.Timeline($timeline.get(0), items, groups, options);
```
Orientation is now set to `{item:'top',axis:'top'}`

```js
timeline.setOptions({
    timeAxis: {
        scale: 'hour',
        step: 2
    }
});
```
Orientation is now set to `{item:undefined,axis:undefined}`, which is incorrect behaviour.