### PR TITLE
Eliminate possibility of 'window is undefined' during travis test

### DIFF
--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -149,17 +149,20 @@ class CanvasRenderer {
     //
     // This is not something that will happen in normal operation, but we still need
     // to take it into account.
-    if (window === undefined) return;
+    //
+    var myWindow = window;  // Grab a reference to reduce the possibility that 'window' is reset
+                            // while running this method.
+    if (myWindow === undefined) return;
 
     let timer;
 
     if (this.requiresTimeout === true) {
       // wait given number of milliseconds and perform the animation step function
-      timer = window.setTimeout(callback, delay);
+      timer = myWindow.setTimeout(callback, delay);
     }
     else {
-      if (window.requestAnimationFrame) {
-        timer = window.requestAnimationFrame(callback);
+      if (myWindow.requestAnimationFrame) {
+        timer = myWindow.requestAnimationFrame(callback);
       }
     }
 


### PR DESCRIPTION
A recurring problem during travis tests is that global variable `window` can get reset while `Network` tests using a mock canvas object are running.
This issue has been adressed several times, but it still happens. This PR reduces the possibility of it happening again to a minimum.

PR's affected by this issue should be merged with this fix and re-submitted. At time of writing, these are:
- #3402
- #3405
- #3399

Chances are it will occur sporadically for other PR's as well.
Labelling this `PRIORITY` because it indrectly affects unrelated PR's.
