### PR TITLE
Group redraw performance

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -214,109 +214,149 @@ Group.prototype.getLabelWidth = function() {
  * @param {boolean} [forceRestack=false]  Force restacking of all items
  * @return {boolean} Returns true if the group is resized
  */
-Group.prototype.redraw = function(range, margin, forceRestack) {
-  var resized = false;
- 
-  // force recalculation of the height of the items when the marker height changed
-  // (due to the Timeline being attached to the DOM or changed from display:none to visible)
-  var markerHeight = this.dom.marker.clientHeight;
-  if (markerHeight != this.lastMarkerHeight) {
-    this.lastMarkerHeight = markerHeight;
-    util.forEach(this.items, function (item) {
-      item.dirty = true;
-      if (item.displayed) item.redraw();
-    });
+Group.prototype.redraw = function(range, margin, forceRestack, returnQueue) {
+  var queue = [];
 
-    forceRestack = true;
-  }  
-  
-  // recalculate the height of the subgroups
-  this._calculateSubGroupHeights(margin);
+    queue.push((function () {
+      // force recalculation of the height of the items when the marker height changed
+      // (due to the Timeline being attached to the DOM or changed from display:none to visible)
+      var markerHeight = this.dom.marker.clientHeight;
+      if (markerHeight != this.lastMarkerHeight) {
+        this.lastMarkerHeight = markerHeight;
+        util.forEach(this.items, function (item) {
+          item.dirty = true;
+          if (item.displayed) item.redraw();
+        });
 
-  // calculate actual size and position
-  var foreground = this.dom.foreground;
-  this.top = foreground.offsetTop;
-  this.right = foreground.offsetLeft;
-  this.width = foreground.offsetWidth;
+        forceRestack = true;
+      }
+    }).bind(this));
 
-  var lastIsVisible = this.isVisible;
-  this.isVisible = this._isGroupVisible(range, margin);
-  
-  var restack = forceRestack || this.stackDirty || (this.isVisible && !lastIsVisible);
+    queue.push((function () {
+      // recalculate the height of the subgroups
+      this._updateSubGroupHeights(margin);
+    }).bind(this));
 
-  this._updateSubgroupsSizes();
-  // if restacking, reposition visible items vertically 
-  if(restack) {
-    if (typeof this.itemSet.options.order === 'function') {
-      // a custom order function
-      // brute force restack of all items
+    queue.push((function () {
+      // calculate actual size and position
+      var foreground = this.dom.foreground;
+      this.top = foreground.offsetTop;
+      this.right = foreground.offsetLeft;
+      this.width = foreground.offsetWidth;
+    }).bind(this));
 
-      // show all items
-      var me = this;
-      var limitSize = false;
-      util.forEach(this.items, function (item) {
-        if (!item.dom) { // If this item has never been displayed then the dom property will not be defined, this means we need to measure the size
-          item.redraw();
-          me.visibleItems.push(item);
+    var resized;
+    var lastIsVisible;
+
+    queue.push((function () {
+      resized = false;
+      lastIsVisible = this.isVisible;
+      this.isVisible = this._isGroupVisible(range, margin);
+    }).bind(this));
+
+    queue.push((function () {
+      var restack = forceRestack || this.stackDirty || this.isVisible && !lastIsVisible;
+
+      // if restacking, reposition visible items vertically
+      if (restack) {
+        if (typeof this.itemSet.options.order === 'function') {
+          // a custom order function
+          // brute force restack of all items
+
+          // show all items
+          var me = this;
+          var limitSize = false;
+          util.forEach(this.items, function (item) {
+            if (!item.displayed) {
+              item.redraw();
+              me.visibleItems.push(item);
+            }
+            item.repositionX(limitSize);
+          });
+
+          // order all items and force a restacking
+          var customOrderedItems = this.orderedItems.byStart.slice().sort(function (a, b) {
+            return me.itemSet.options.order(a.data, b.data);
+          });
+          stack.stack(customOrderedItems, margin, true /* restack=true */);
+          this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
+        } else {
+          // no custom order function, lazy stacking
+          this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
+
+          if (this.itemSet.options.stack) {
+            // TODO: ugly way to access options...
+            stack.stack(this.visibleItems, margin, true /* restack=true */);
+          } else {
+            // no stacking
+            stack.nostack(this.visibleItems, margin, this.subgroups, this.itemSet.options.stackSubgroups);
+          }
         }
-        item.repositionX(limitSize);
-      });
 
-      // order all items and force a restacking
-      var customOrderedItems = this.orderedItems.byStart.slice().sort(function (a, b) {
-        return me.itemSet.options.order(a.data, b.data);
-      });
-      stack.stack(customOrderedItems, margin, true /* restack=true */);
-      this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
-
-    }
-    else {
-      // no custom order function, lazy stacking
-      this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
-
-      if (this.itemSet.options.stack) { // TODO: ugly way to access options...
-        stack.stack(this.visibleItems, margin,  true /* restack=true */);
+        this.stackDirty = false;
       }
-      else { // no stacking
-        stack.nostack(this.visibleItems, margin, this.subgroups, this.itemSet.options.stackSubgroups);
+    }).bind(this));
+
+    var height;
+
+    queue.push((function () {
+      this._updateSubgroupsSizes();
+    }).bind(this));
+
+    queue.push((function () {
+      // recalculate the height of the group
+      height = this._calculateHeight(margin);
+    }).bind(this));
+
+    queue.push((function () {
+      // calculate actual size and position
+      var foreground = this.dom.foreground;
+      this.top = foreground.offsetTop;
+      this.right = foreground.offsetLeft;
+      this.width = foreground.offsetWidth;
+    }).bind(this));
+
+    queue.push((function () {
+      resized = util.updateProperty(this, 'height', height) || resized;
+      // recalculate size of label
+      resized = util.updateProperty(this.props.label, 'width', this.dom.inner.clientWidth) || resized;
+      resized = util.updateProperty(this.props.label, 'height', this.dom.inner.clientHeight) || resized;
+    }).bind(this));
+
+    queue.push((function () {
+      // apply new height
+      this.dom.background.style.height = height + 'px';
+      this.dom.foreground.style.height = height + 'px';
+      this.dom.label.style.height = height + 'px';
+    }).bind(this));
+
+    queue.push((function () {
+      // update vertical position of items after they are re-stacked and the height of the group is calculated
+      for (var i = 0, ii = this.visibleItems.length; i < ii; i++) {
+        var item = this.visibleItems[i];
+        item.repositionY(margin);
+        if (!this.isVisible && this.groupId != "__background__") {
+          if (item.displayed) item.hide();
+        }
       }
+
+      if (!this.isVisible && this.height) {
+        return resized = false;
+      }
+
+      return resized;
+    }).bind(this));
+
+    if (returnQueue) {
+      return queue;
+    } else {
+      var result;
+      queue.forEach(function (fn) {
+        result = fn();
+      });
+      return result;
     }
-    
-    this.stackDirty = false;
-  }
-  // recalculate the height of the group
-  var height = this._calculateHeight(margin);
-
-  // calculate actual size and position
-  foreground = this.dom.foreground;
-  this.top = foreground.offsetTop;
-  this.right = foreground.offsetLeft;
-  this.width = foreground.offsetWidth;
-  resized = util.updateProperty(this, 'height', height) || resized;
-  // recalculate size of label
-  resized = util.updateProperty(this.props.label, 'width', this.dom.inner.clientWidth) || resized;
-  resized = util.updateProperty(this.props.label, 'height', this.dom.inner.clientHeight) || resized;
-
-  // apply new height
-  this.dom.background.style.height  = height + 'px';
-  this.dom.foreground.style.height  = height + 'px';
-  this.dom.label.style.height = height + 'px';
-
-  // update vertical position of items after they are re-stacked and the height of the group is calculated
-  for (var i = 0, ii = this.visibleItems.length; i < ii; i++) {
-    var item = this.visibleItems[i];
-    item.repositionY(margin);
-    if (!this.isVisible && this.groupId != "__background__") {
-      if (item.displayed) item.hide();
-    }
-  }
-
-  if (!this.isVisible && this.height) {
-    return resized = false;
-  }
-
-  return resized;
-};
+  };
 
 /**
  * recalculate the height of the subgroups
@@ -324,7 +364,7 @@ Group.prototype.redraw = function(range, margin, forceRestack) {
  * @param {{item: vis.Item}} margin
  * @private
  */
-Group.prototype._calculateSubGroupHeights = function (margin) {
+Group.prototype._updateSubGroupHeights = function (margin) {
   if (Object.keys(this.subgroups).length > 0) {
     var me = this;
 

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -220,8 +220,8 @@ Group.prototype._didMarkerHeightChange = function() {
       item.dirty = true;
       if (item.displayed) item.redraw();
     });
+    return true;
   }
-  return true;
 }
 
 Group.prototype._calculateGroupSizeAndPosition = function() {

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -275,7 +275,7 @@ Group.prototype._didResize = function(resized, height) {
   var labelHeight = this.dom.inner.clientHeight;
   resized = util.updateProperty(this.props.label, 'width', labelWidth) || resized;
   resized = util.updateProperty(this.props.label, 'height', labelHeight) || resized;
-  return resized
+  return resized;
 }
 
 Group.prototype._applyGroupHeight = function(height) {
@@ -284,8 +284,8 @@ Group.prototype._applyGroupHeight = function(height) {
   this.dom.label.style.height = height + 'px';
 }
 
+// update vertical position of items after they are re-stacked and the height of the group is calculated
 Group.prototype._updateItemsVerticalPosition = function(resized, margin) {
-  // update vertical position of items after they are re-stacked and the height of the group is calculated
   for (var i = 0, ii = this.visibleItems.length; i < ii; i++) {
     var item = this.visibleItems[i];
     item.repositionY(margin);
@@ -295,7 +295,7 @@ Group.prototype._updateItemsVerticalPosition = function(resized, margin) {
   }
 
   if (!this.isVisible && this.height) {
-    return resized = false;
+    return false;
   }
 
   return resized;

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -207,157 +207,177 @@ Group.prototype.getLabelWidth = function() {
 };
 
 
+
+
+/************************************************************************/
+
+
+Group.prototype._didMarkerHeightChange = function() {
+  var markerHeight = this.dom.marker.clientHeight;
+  if (markerHeight != this.lastMarkerHeight) {
+    this.lastMarkerHeight = markerHeight;
+    util.forEach(this.items, function (item) {
+      item.dirty = true;
+      if (item.displayed) item.redraw();
+    });
+  }
+  return true;
+}
+
+Group.prototype._calculateGroupSizeAndPosition = function() {
+  var foreground = this.dom.foreground;
+  this.top = foreground.offsetTop;
+  this.right = foreground.offsetLeft;
+  this.width = foreground.offsetWidth;
+}
+
+Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, range) {
+  var restack = forceRestack || this.stackDirty || this.isVisible && !lastIsVisible;
+
+  // if restacking, reposition visible items vertically
+  if (restack) {
+    if (typeof this.itemSet.options.order === 'function') {
+      // a custom order function
+      // brute force restack of all items
+
+      // show all items
+      var me = this;
+      var limitSize = false;
+      util.forEach(this.items, function (item) {
+        if (!item.displayed) {
+          item.redraw();
+          me.visibleItems.push(item);
+        }
+        item.repositionX(limitSize);
+      });
+
+      // order all items and force a restacking
+      var customOrderedItems = this.orderedItems.byStart.slice().sort(function (a, b) {
+        return me.itemSet.options.order(a.data, b.data);
+      });
+      stack.stack(customOrderedItems, margin, true /* restack=true */);
+      this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
+    } else {
+      // no custom order function, lazy stacking
+      this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
+
+      if (this.itemSet.options.stack) {
+        // TODO: ugly way to access options...
+        stack.stack(this.visibleItems, margin, true /* restack=true */);
+      } else {
+        // no stacking
+        stack.nostack(this.visibleItems, margin, this.subgroups, this.itemSet.options.stackSubgroups);
+      }
+    }
+
+    this.stackDirty = false;
+  }
+}
+
+Group.prototype._didResize = function(resized, height) {
+  resized = util.updateProperty(this, 'height', height) || resized;
+  // recalculate size of label
+  resized = util.updateProperty(this.props.label, 'width', this.dom.inner.clientWidth) || resized;
+  resized = util.updateProperty(this.props.label, 'height', this.dom.inner.clientHeight) || resized;
+  return resized
+}
+
+Group.prototype._applyGroupHeight = function(height) {
+  this.dom.background.style.height = height + 'px';
+  this.dom.foreground.style.height = height + 'px';
+  this.dom.label.style.height = height + 'px';
+}
+
+Group.prototype._updateItemsVerticalPosition = function(resized, margin) {
+  // update vertical position of items after they are re-stacked and the height of the group is calculated
+  for (var i = 0, ii = this.visibleItems.length; i < ii; i++) {
+    var item = this.visibleItems[i];
+    item.repositionY(margin);
+    if (!this.isVisible && this.groupId != "__background__") {
+      if (item.displayed) item.hide();
+    }
+  }
+
+  if (!this.isVisible && this.height) {
+    return resized = false;
+  }
+
+  return resized;
+}
+
 /**
  * Repaint this group
  * @param {{start: number, end: number}} range
  * @param {{item: {horizontal: number, vertical: number}, axis: number}} margin
  * @param {boolean} [forceRestack=false]  Force restacking of all items
- * @param {boolean} [returnQueue=false]  return the queue or the result 
+ * @param {boolean} [returnQueue=false]  return the queue or if the group resized
  * @return {boolean} Returns true if the group is resized or the redraw queue if returnQueue=true
  */
 Group.prototype.redraw = function(range, margin, forceRestack, returnQueue) {
-  var queue = [];
+  var resized = false;
+  var lastIsVisible = this.isVisible;
+  var height;
 
-    queue.push((function () {
-      // force recalculation of the height of the items when the marker height changed
-      // (due to the Timeline being attached to the DOM or changed from display:none to visible)
-      var markerHeight = this.dom.marker.clientHeight;
-      if (markerHeight != this.lastMarkerHeight) {
-        this.lastMarkerHeight = markerHeight;
-        util.forEach(this.items, function (item) {
-          item.dirty = true;
-          if (item.displayed) item.redraw();
-        });
+  var queue = [
+    // force recalculation of the height of the items when the marker height changed
+    // (due to the Timeline being attached to the DOM or changed from display:none to visible)
+    (function () {
+      forceRestack = this._didMarkerHeightChange.bind(this);
+    }).bind(this),
 
-        forceRestack = true;
-      }
-    }).bind(this));
+    // recalculate the height of the subgroups
+    this._updateSubGroupHeights.bind(this, margin),
 
-    queue.push((function () {
-      // recalculate the height of the subgroups
-      this._updateSubGroupHeights(margin);
-    }).bind(this));
+    // calculate actual size and position
+    this._calculateGroupSizeAndPosition.bind(this),
 
-    queue.push((function () {
-      // calculate actual size and position
-      var foreground = this.dom.foreground;
-      this.top = foreground.offsetTop;
-      this.right = foreground.offsetLeft;
-      this.width = foreground.offsetWidth;
-    }).bind(this));
+    // check if group is visible
+    (function() {
+      this.isVisible = this._isGroupVisible.bind(this)(range, margin);
+    }).bind(this),
 
-    var resized;
-    var lastIsVisible;
+    // redraw Items if needed
+    (function() {
+      this._redrawItems.bind(this)(forceRestack, lastIsVisible, margin, range)
+    }).bind(this),
 
-    queue.push((function () {
-      resized = false;
-      lastIsVisible = this.isVisible;
-      this.isVisible = this._isGroupVisible(range, margin);
-    }).bind(this));
+    // update subgroups
+    this._updateSubgroupsSizes.bind(this),
 
-    queue.push((function () {
-      var restack = forceRestack || this.stackDirty || this.isVisible && !lastIsVisible;
+    // recalculate the height of the group
+    (function() {
+      height = this._calculateHeight.bind(this)(margin);
+    }).bind(this),
 
-      // if restacking, reposition visible items vertically
-      if (restack) {
-        if (typeof this.itemSet.options.order === 'function') {
-          // a custom order function
-          // brute force restack of all items
+    // calculate actual size and position again
+    this._calculateGroupSizeAndPosition.bind(this),
 
-          // show all items
-          var me = this;
-          var limitSize = false;
-          util.forEach(this.items, function (item) {
-            if (!item.displayed) {
-              item.redraw();
-              me.visibleItems.push(item);
-            }
-            item.repositionX(limitSize);
-          });
+    // check if resized
+    (function() {
+      resized = this._didResize.bind(this)(resized, height)
+    }).bind(this),
 
-          // order all items and force a restacking
-          var customOrderedItems = this.orderedItems.byStart.slice().sort(function (a, b) {
-            return me.itemSet.options.order(a.data, b.data);
-          });
-          stack.stack(customOrderedItems, margin, true /* restack=true */);
-          this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
-        } else {
-          // no custom order function, lazy stacking
-          this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
+    // apply group height
+    (function() {
+      this._applyGroupHeight.bind(this)(height)
+    }).bind(this),
 
-          if (this.itemSet.options.stack) {
-            // TODO: ugly way to access options...
-            stack.stack(this.visibleItems, margin, true /* restack=true */);
-          } else {
-            // no stacking
-            stack.nostack(this.visibleItems, margin, this.subgroups, this.itemSet.options.stackSubgroups);
-          }
-        }
+    // update vertical position of items after they are re-stacked and the height of the group is calculated
+    (function() {
+      return resized = this._updateItemsVerticalPosition.bind(this)(resized, margin)
+    }).bind(this)
+  ]
 
-        this.stackDirty = false;
-      }
-    }).bind(this));
-
-    var height;
-
-    queue.push((function () {
-      this._updateSubgroupsSizes();
-    }).bind(this));
-
-    queue.push((function () {
-      // recalculate the height of the group
-      height = this._calculateHeight(margin);
-    }).bind(this));
-
-    queue.push((function () {
-      // calculate actual size and position
-      var foreground = this.dom.foreground;
-      this.top = foreground.offsetTop;
-      this.right = foreground.offsetLeft;
-      this.width = foreground.offsetWidth;
-    }).bind(this));
-
-    queue.push((function () {
-      resized = util.updateProperty(this, 'height', height) || resized;
-      // recalculate size of label
-      resized = util.updateProperty(this.props.label, 'width', this.dom.inner.clientWidth) || resized;
-      resized = util.updateProperty(this.props.label, 'height', this.dom.inner.clientHeight) || resized;
-    }).bind(this));
-
-    queue.push((function () {
-      // apply new height
-      this.dom.background.style.height = height + 'px';
-      this.dom.foreground.style.height = height + 'px';
-      this.dom.label.style.height = height + 'px';
-    }).bind(this));
-
-    queue.push((function () {
-      // update vertical position of items after they are re-stacked and the height of the group is calculated
-      for (var i = 0, ii = this.visibleItems.length; i < ii; i++) {
-        var item = this.visibleItems[i];
-        item.repositionY(margin);
-        if (!this.isVisible && this.groupId != "__background__") {
-          if (item.displayed) item.hide();
-        }
-      }
-
-      if (!this.isVisible && this.height) {
-        return resized = false;
-      }
-
-      return resized;
-    }).bind(this));
-
-    if (returnQueue) {
-      return queue;
-    } else {
-      var result;
-      queue.forEach(function (fn) {
-        result = fn();
-      });
-      return result;
-    }
-  };
+  if (returnQueue) {
+    return queue;
+  } else {
+    var result;
+    queue.forEach(function (fn) {
+      result = fn();
+    });
+    return result;
+  }
+};
 
 /**
  * recalculate the height of the subgroups

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -206,12 +206,6 @@ Group.prototype.getLabelWidth = function() {
   return this.props.label.width;
 };
 
-
-
-
-/************************************************************************/
-
-
 Group.prototype._didMarkerHeightChange = function() {
   var markerHeight = this.dom.marker.clientHeight;
   if (markerHeight != this.lastMarkerHeight) {
@@ -277,8 +271,10 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
 Group.prototype._didResize = function(resized, height) {
   resized = util.updateProperty(this, 'height', height) || resized;
   // recalculate size of label
-  resized = util.updateProperty(this.props.label, 'width', this.dom.inner.clientWidth) || resized;
-  resized = util.updateProperty(this.props.label, 'height', this.dom.inner.clientHeight) || resized;
+  var labelWidth = this.dom.inner.clientWidth;
+  var labelHeight = this.dom.inner.clientHeight;
+  resized = util.updateProperty(this.props.label, 'width', labelWidth) || resized;
+  resized = util.updateProperty(this.props.label, 'height', labelHeight) || resized;
   return resized
 }
 

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -212,7 +212,8 @@ Group.prototype.getLabelWidth = function() {
  * @param {{start: number, end: number}} range
  * @param {{item: {horizontal: number, vertical: number}, axis: number}} margin
  * @param {boolean} [forceRestack=false]  Force restacking of all items
- * @return {boolean} Returns true if the group is resized
+ * @param {boolean} [returnQueue=false]  return the queue or the result 
+ * @return {boolean} Returns true if the group is resized or the redraw queue if returnQueue=true
  */
 Group.prototype.redraw = function(range, margin, forceRestack, returnQueue) {
   var queue = [];

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1,4 +1,5 @@
 var Hammer = require('../../module/hammer');
+var Fastdom = require('fastdom');
 var util = require('../../util');
 var DataSet = require('../../DataSet');
 var DataView = require('../../DataView');
@@ -682,12 +683,44 @@ ItemSet.prototype.redraw = function() {
   this.groups[BACKGROUND].redraw(range, nonFirstMargin, forceRestack);
 
   // redraw all regular groups
-  util.forEach(this.groups, function (group) {
-    var groupMargin = (group == firstGroup) ? firstMargin : nonFirstMargin;
-    var groupResized = group.redraw(range, groupMargin, forceRestack);
-    resized = groupResized || resized;
-    height += group.height;
+  // util.forEach(this.groups, function (group) {
+  //   var groupMargin = (group == firstGroup) ? firstMargin : nonFirstMargin;
+  //   var groupResized = group.redraw(range, groupMargin, forceRestack);
+  //   resized = groupResized || resized;
+  //   height += group.height;
+  // });
+
+  var redrawQueue = {};
+  var redrawQueueLength = 0;
+
+  // collect redraw functions
+  util.forEach(this.groups, function (group, key) {
+    if (key === BACKGROUND) return;
+    var groupMargin = group == firstGroup ? firstMargin : nonFirstMargin;
+    var returnQueue = true;
+    redrawQueue[key] = group.redraw(range, groupMargin, forceRestack, returnQueue);
+    redrawQueueLength = redrawQueue[key].length;
   });
+
+  if (redrawQueueLength) {
+    var redrawResults = {};
+
+    for (var i = 0; i < redrawQueueLength; i++) {
+      util.forEach(redrawQueue, function (fns, key) {
+        redrawResults[key] = fns[i]();
+      });
+    }
+
+    // redraw all regular groups
+    util.forEach(this.groups, function (group, key) {
+      if (key === BACKGROUND) return;
+      var groupResized = redrawResults[key];
+      resized = groupResized || resized;
+      height += group.height;
+    });
+    height = Math.max(height, minHeight);
+  }
+
   height = Math.max(height, minHeight);
 
   // update frame height

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -682,14 +682,6 @@ ItemSet.prototype.redraw = function() {
   // redraw the background group
   this.groups[BACKGROUND].redraw(range, nonFirstMargin, forceRestack);
 
-  // redraw all regular groups
-  // util.forEach(this.groups, function (group) {
-  //   var groupMargin = (group == firstGroup) ? firstMargin : nonFirstMargin;
-  //   var groupResized = group.redraw(range, groupMargin, forceRestack);
-  //   resized = groupResized || resized;
-  //   height += group.height;
-  // });
-
   var redrawQueue = {};
   var redrawQueueLength = 0;
 

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1,5 +1,4 @@
 var Hammer = require('../../module/hammer');
-var Fastdom = require('fastdom');
 var util = require('../../util');
 var DataSet = require('../../DataSet');
 var DataView = require('../../DataView');


### PR DESCRIPTION
Addressing some of the group performance issues and implementation of discussion from #3248 (using gist https://gist.github.com/grimalschi/df9a44ac12b5420e0cc6f2d42f1febed/revisions#diff-32e31f368549caca635e81cdb8a0a82dR21132)
This is the best implementation in the meantime - I've tried using fasdom and some other methods but concluded that it's not what we need. Fastdom allows prioritization of "read" operations over "write" operations, whilst our problem has to do with paralleling the operations done in a group redraw for all groups. 
Further analysis that will be done:
- The exact operations done in the group redraw - we might be able to use fasdom/combining "reads" and "writes" to fewer operations for every redraw queue. 
- Implementation like this should also be done in items' redraws.

Shout out to @grimalschi for supplying the solution.
