### PR TITLE
Fixes issue #3428 - Adds locale for Chinese (cn)

### DIFF
--- a/lib/network/locales.js
+++ b/lib/network/locales.js
@@ -127,3 +127,21 @@ exports['ru'] = {
   editClusterError: 'Кластеры недоступны для редактирования.'
 };
 exports['ru_RU'] = exports['ru'];
+
+// Chinese
+exports['cn'] = {
+edit: '编辑',
+del: '删除选定',
+back: '返回',
+addNode: '添加节点',
+addEdge: '添加连接线',
+editNode: '编辑节点',
+editEdge: '编辑连接线',
+addDescription: '单击空白处放置新节点。',
+edgeDescription: '单击某个节点并将该连接线拖动到另一个节点以连接它们。',
+editEdgeDescription: '单击控制节点并将它们拖到节点上连接。',
+createEdgeError: '无法将连接线连接到群集。',
+deleteClusterError: '无法删除群集。',
+editClusterError: '无法编辑群集。'
+};
+exports['zh_CN'] = exports['cn'];

--- a/lib/network/locales.js
+++ b/lib/network/locales.js
@@ -130,18 +130,18 @@ exports['ru_RU'] = exports['ru'];
 
 // Chinese
 exports['cn'] = {
-edit: '编辑',
-del: '删除选定',
-back: '返回',
-addNode: '添加节点',
-addEdge: '添加连接线',
-editNode: '编辑节点',
-editEdge: '编辑连接线',
-addDescription: '单击空白处放置新节点。',
-edgeDescription: '单击某个节点并将该连接线拖动到另一个节点以连接它们。',
-editEdgeDescription: '单击控制节点并将它们拖到节点上连接。',
-createEdgeError: '无法将连接线连接到群集。',
-deleteClusterError: '无法删除群集。',
-editClusterError: '无法编辑群集。'
+  edit: '编辑',
+  del: '删除选定',
+  back: '返回',
+  addNode: '添加节点',
+  addEdge: '添加连接线',
+  editNode: '编辑节点',
+  editEdge: '编辑连接线',
+  addDescription: '单击空白处放置新节点。',
+  edgeDescription: '单击某个节点并将该连接线拖动到另一个节点以连接它们。',
+  editEdgeDescription: '单击控制节点并将它们拖到节点上连接。',
+  createEdgeError: '无法将连接线连接到群集。',
+  deleteClusterError: '无法删除群集。',
+  editClusterError: '无法编辑群集。'
 };
 exports['zh_CN'] = exports['cn'];


### PR DESCRIPTION
I ran all of these through google translate and they all look correct, assuming that `cable` is a synonym for `edge` in cn.

R: @yotamberk 