### PR TITLE
The next fix on Travis unit test failure

### DIFF
--- a/lib/network/modules/Canvas.js
+++ b/lib/network/modules/Canvas.js
@@ -373,11 +373,19 @@ class Canvas {
      throw new Error("Could not get canvax context");
     }
 
-    return (window.devicePixelRatio || 1) / (ctx.webkitBackingStorePixelRatio ||
+    var numerator = 1;
+    if(typeof window !== 'undefined') {  // (window !== undefined) doesn't work here!
+      // Protection during unit tests, where 'window' can be missing
+      numerator = (window.devicePixelRatio || 1);
+    }
+
+    var denominator = (ctx.webkitBackingStorePixelRatio ||
       ctx.mozBackingStorePixelRatio ||
       ctx.msBackingStorePixelRatio  ||
       ctx.oBackingStorePixelRatio   ||
       ctx.backingStorePixelRatio    || 1);
+
+    return numerator / denominator;
   }
 
   /**

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -149,19 +149,31 @@ class CanvasRenderer {
     // This is not something that will happen in normal operation, but we still need
     // to take it into account.
     //
-    var myWindow = window;  // Grab a reference to reduce the possibility that 'window' is reset
-                            // while running this method.
-    if (myWindow === undefined) return;
+   let timer;
 
-    let timer;
+    try {
+      if(typeof window === 'undefined') {  // (window === undefined) doesn't work here!
+        return;
+      }
 
-    if (this.requiresTimeout === true) {
-      // wait given number of milliseconds and perform the animation step function
-      timer = myWindow.setTimeout(callback, delay);
-    }
-    else {
-      if (myWindow.requestAnimationFrame) {
-        timer = myWindow.requestAnimationFrame(callback);
+      var myWindow = window;  // Grab a reference to reduce the possibility that 'window' is reset
+                              // while running this method.
+
+      if (this.requiresTimeout === true) {
+        // wait given number of milliseconds and perform the animation step function
+        timer = myWindow.setTimeout(callback, delay);
+      } else {
+        if (myWindow.requestAnimationFrame) {
+          timer = myWindow.requestAnimationFrame(callback);
+        }
+      }
+    } catch(e) {
+      var msg = e.message;
+      //console.warn("Got exception with message: '" + msg + "'");
+      if (msg === 'window is not defined') {
+        console.warn("CanvasRenderer._requestNextFrame: error '" + msg + "' happened again");
+      } else {
+        throw e;
       }
     }
 

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -242,6 +242,7 @@ describe('Network', function () {
 
 describe('Node', function () {
 
+
   /**
    * NOTE: choosify tests of Node and Edge are parallel
    * TODO: consolidate this is necessary
@@ -1142,15 +1143,16 @@ describe('runs example ', function () {
   });
 
 
-  it('WorlCup2014', function () {
+  it('WorlCup2014', function (done) {
     // This is a huge example (which is why it's tested here!), so it takes a long time to load.
-    this.timeout(10000);
+    this.timeout(15000);
 
     var network = loadExample('./examples/network/datasources/WorldCup2014.js', true);
 
     // Count in following also contains the helper nodes for dynamic edges
     assert.equal(Object.keys(network.body.nodes).length, 9964);
     assert.equal(Object.keys(network.body.edges).length, 9228);
+		done();
   });
 
 


### PR DESCRIPTION
 This is the next escalation on the war against the Travis unit tests failing (which came into being by yours truly). By accident, I could recreate the unit test failure on my development machine. This led to a more directed effort to squash the bug.
    
The insight here is that test `(window === undefined)` fails, but `(typeof window === 'undefined')` succeeds. This undoubtedly has to do with the special status `window` has as a global object.
    
Changes:
    
- Added catch-clause in `CanvasRenderer._requestNextFrame()`, fixed local source errors
- Added test on presence `window` in `Canvas._determinePixelRatio()`
- small fix: raised timeout for the network `worldCup2014` unit test
