### PR TITLE
Improve Item redraw and initial draw performance

### DIFF
--- a/examples/timeline/other/stressPerformance.html
+++ b/examples/timeline/other/stressPerformance.html
@@ -3,8 +3,8 @@
 <head>
   <title>Timeline | Performance example</title>
   <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
-  <script src="../../dist/vis.js"></script>
-  <link href="../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
+  <script src="../../../dist/vis.js"></script>
+  <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
   
 </head>
 <body>

--- a/examples/timeline/other/stressPerformance.html
+++ b/examples/timeline/other/stressPerformance.html
@@ -1,0 +1,78 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>Timeline | Performance example</title>
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
+  <script src="../../dist/vis.js"></script>
+  <link href="../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
+  
+</head>
+<body>
+    <div id="visualization"></div>
+</body>
+
+
+<script>
+    var now = moment();
+    var groupCount = 20;
+    var itemCount = 400;
+
+    function genName(length) {
+        var chars = [];
+        for (var i = 0; i<= length; i++) {
+        chars.push(String.fromCharCode(65 + (Math.random()*26)));
+        }
+        return chars.join('');
+    }
+
+    // create a data set with groups
+    var groups = new vis.DataSet();
+    for (var g = 0; g < groupCount; g++) {
+        groups.add({
+        id: g, 
+        content: genName(8)
+        });
+    }
+
+    var types = ['point', 'range', 'box', 'background']
+    // create a dataset with items
+    var items = new vis.DataSet();
+    for (var i = 0; i < itemCount; i++) {
+        var start = now.clone().add(Math.random() * 180, 'days');
+        var end = start.clone().add(Math.random() * 30, 'days');
+        var group = Math.floor(Math.random() * groupCount);
+        items.add({
+        id: i,
+        type: types[Math.floor(Math.random()*types.length)],
+        group: group,
+        content: ''+i,
+        start: start,
+        end: end
+        });
+    }
+
+    // create visualization
+    var container = document.getElementById('visualization');
+    var options = {
+        width: '100%',
+        //autoResize: true,
+        /*
+        margin: {
+        axis: 0,
+        item: 2
+        },
+        */
+        showCurrentTime: false,
+        //locale: 'en',
+        stack: true,
+        selectable: true,
+        editable: true,
+        //groupOrder: 'content',
+    };
+
+    var timeline = new vis.Timeline(container);
+    timeline.setOptions(options);
+    timeline.setGroups(groups);
+    timeline.setItems(items);
+  </script>
+</html>

--- a/examples/timeline/other/stressPerformance.html
+++ b/examples/timeline/other/stressPerformance.html
@@ -1,78 +1,66 @@
 <!DOCTYPE HTML>
+<!-- 
+  This example is used mainly for developers to test performance issues by controlling number of groups, 
+  number of items and their types.
+ -->
 <html>
+
 <head>
-  <title>Timeline | Performance example</title>
+  <title>Timeline | Stress Performance example</title>
   <script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
   <script src="../../../dist/vis.js"></script>
   <link href="../../../dist/vis-timeline-graph2d.min.css" rel="stylesheet" type="text/css" />
-  
 </head>
+
 <body>
-    <div id="visualization"></div>
+  <div id="visualization"></div>
 </body>
 
-
 <script>
-    var now = moment();
-    var groupCount = 20;
-    var itemCount = 400;
+  var now = moment();
+  var groupCount = 20;
+  var itemCount = 400;
 
-    function genName(length) {
-        var chars = [];
-        for (var i = 0; i<= length; i++) {
-        chars.push(String.fromCharCode(65 + (Math.random()*26)));
-        }
-        return chars.join('');
-    }
+  // create a data set with groups
+  var groups = new vis.DataSet();
+  for (var g = 0; g < groupCount; g++) {
+    groups.add({
+      id: g,
+      content: "group " + g
+    });
+  }
 
-    // create a data set with groups
-    var groups = new vis.DataSet();
-    for (var g = 0; g < groupCount; g++) {
-        groups.add({
-        id: g, 
-        content: genName(8)
-        });
-    }
+  var types = ['point', 'range', 'box', 'background']
+  // create a dataset with items
+  var items = new vis.DataSet();
+  for (var i = 0; i < itemCount; i++) {
+    var start = now.clone().add(Math.random() * 180, 'days');
+    var end = start.clone().add(Math.random() * 30, 'days');
+    var group = Math.floor(Math.random() * groupCount);
+    items.add({
+      id: i,
+      type: types[Math.floor(Math.random() * types.length)],
+      group: group,
+      content: '' + i,
+      start: start,
+      end: end
+    });
+  }
 
-    var types = ['point', 'range', 'box', 'background']
-    // create a dataset with items
-    var items = new vis.DataSet();
-    for (var i = 0; i < itemCount; i++) {
-        var start = now.clone().add(Math.random() * 180, 'days');
-        var end = start.clone().add(Math.random() * 30, 'days');
-        var group = Math.floor(Math.random() * groupCount);
-        items.add({
-        id: i,
-        type: types[Math.floor(Math.random()*types.length)],
-        group: group,
-        content: ''+i,
-        start: start,
-        end: end
-        });
-    }
+  // create visualization
+  var container = document.getElementById('visualization');
+  var options = {
+    width: '100%',
+    showCurrentTime: false,
+    stack: true,
+    selectable: true,
+    editable: true,
+  };
 
-    // create visualization
-    var container = document.getElementById('visualization');
-    var options = {
-        width: '100%',
-        //autoResize: true,
-        /*
-        margin: {
-        axis: 0,
-        item: 2
-        },
-        */
-        showCurrentTime: false,
-        //locale: 'en',
-        stack: true,
-        selectable: true,
-        editable: true,
-        //groupOrder: 'content',
-    };
+  var timeline = new vis.Timeline(container);
+  timeline.setOptions(options);
+  timeline.setGroups(groups);
+  timeline.setItems(items);
+</script>
 
-    var timeline = new vis.Timeline(container);
-    timeline.setOptions(options);
-    timeline.setGroups(groups);
-    timeline.setItems(items);
-  </script>
 </html>

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -469,13 +469,29 @@ Timeline.prototype.getItemRange = function () {
     }
     var factor = interval / this.props.center.width;
 
-    // calculate the date of the left side and right side of the items given
-    util.forEach(this.itemSet.items, function (item) {
-      if (item.groupShowing) {
-        item.show();
-        item.repositionX();
-      }
+    var redrawQueue = {};
+    var redrawQueueLength = 0;
 
+    // collect redraw functions
+    util.forEach(this.itemSet.items, function (item, key) {
+      if (item.groupShowing) {
+        var returnQueue = true;
+        redrawQueue[key] = item.redraw(returnQueue);
+        redrawQueueLength = redrawQueue[key].length;
+      }
+    })
+
+    if (redrawQueueLength) {
+      // redraw all regular items
+      for (var i = 0; i < redrawQueueLength; i++) {
+        util.forEach(redrawQueue, function (fns, key) {
+          fns[i]();
+        });
+      }
+    }
+
+     // calculate the date of the left side and right side of the items given
+    util.forEach(this.itemSet.items, function (item) {
       var start = getStart(item);
       var end = getEnd(item);
       var startSide;

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -481,7 +481,8 @@ Timeline.prototype.getItemRange = function () {
       }
     })
 
-    if (redrawQueueLength) {
+    var needRedraw = redrawQueueLength > 0;
+    if (needRedraw) {
       // redraw all regular items
       for (var i = 0; i < redrawQueueLength; i++) {
         util.forEach(redrawQueue, function (fns) {

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -484,7 +484,7 @@ Timeline.prototype.getItemRange = function () {
     if (redrawQueueLength) {
       // redraw all regular items
       for (var i = 0; i < redrawQueueLength; i++) {
-        util.forEach(redrawQueue, function (fns, key) {
+        util.forEach(redrawQueue, function (fns) {
           fns[i]();
         });
       }

--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -505,7 +505,6 @@ Timeline.prototype.getItemRange = function () {
         endSide = end   + (item.getWidthRight() + 10) * factor;
       }
 
-
       if (startSide < min) {
         min = startSide;
         minItem = item;

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -222,7 +222,8 @@ Group.prototype._didMarkerHeightChange = function() {
       }
     })
 
-    if (redrawQueueLength) {
+    var needRedraw = redrawQueueLength > 0;
+    if (needRedraw) {
       // redraw all regular items
       for (var i = 0; i < redrawQueueLength; i++) {
         util.forEach(redrawQueue, function (fns) {
@@ -230,10 +231,6 @@ Group.prototype._didMarkerHeightChange = function() {
         });
       }
     }
-    // util.forEach(this.items, function (item) {
-    //   item.dirty = true;
-    //   if (item.displayed) item.redraw();
-    // });
     return true;
   }
 }
@@ -271,8 +268,9 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
           me.visibleItems.push(item);
         }
       })
-  
-      if (redrawQueueLength) {
+
+      var needRedraw = redrawQueueLength > 0;
+      if (needRedraw) {
         // redraw all regular items
         for (var i = 0; i < redrawQueueLength; i++) {
           util.forEach(redrawQueue, function (fns) {
@@ -779,7 +777,8 @@ Group.prototype._updateItemsInRange = function(orderedItems, oldVisibleItems, ra
     }
   }
 
-  if (redrawQueueLength) {
+  var needRedraw = redrawQueueLength > 0;
+  if (needRedraw) {
     // redraw all regular items
     for (var j = 0; j < redrawQueueLength; j++) {
       util.forEach(redrawQueue, function (fns) {

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -281,9 +281,9 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
         }
       }
 
-      util.forEach(this.items, function (item) {
-        item.repositionX(limitSize);
-      });
+      for (var i = 0; i < this.items.length; i++) {
+        this.items[i].repositionX(limitSize);
+      }
 
       // order all items and force a restacking
       var customOrderedItems = this.orderedItems.byStart.slice().sort(function (a, b) {
@@ -766,27 +766,7 @@ Group.prototype._updateItemsInRange = function(orderedItems, oldVisibleItems, ra
       return (item.data.end < lowerBound || item.data.end > upperBound);
     });
   }
-
- // // finally, we reposition all the visible items.
-
-  // util.forEach(this.items, function (item, key) {
-  //   item.dirty = true;
-  //   if (item.displayed) {
-  //     var returnQueue = true;
-  //     redrawQueue[key] = item.redraw(returnQueue);
-  //     redrawQueueLength = redrawQueue[key].length;
-  //   }
-  // })
-
-  // if (redrawQueueLength) {
-  //   // redraw all regular items
-  //   for (var i = 0; i < redrawQueueLength; i++) {
-  //     util.forEach(redrawQueue, function (fns, key) {
-  //       fns[i]();
-  //     });
-  //   }
-  // }
-
+  
   var redrawQueue = {};
   var redrawQueueLength = 0;
 
@@ -807,10 +787,6 @@ Group.prototype._updateItemsInRange = function(orderedItems, oldVisibleItems, ra
     for (var j = 0; j < redrawQueueLength; j++) {
       util.forEach(redrawQueue, function (fns, key) {
         fns[j]();
-        // if (j == redrawQueueLength - 1) {
-        //   var item = visibleItems[key];
-        //   item.repositionX();
-        // }
       });
     }
   }

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -210,19 +210,41 @@ Group.prototype._didMarkerHeightChange = function() {
   var markerHeight = this.dom.marker.clientHeight;
   if (markerHeight != this.lastMarkerHeight) {
     this.lastMarkerHeight = markerHeight;
-    util.forEach(this.items, function (item) {
+    var redrawQueue = {};
+    var redrawQueueLength = 0;
+
+    util.forEach(this.items, function (item, key) {
       item.dirty = true;
-      if (item.displayed) item.redraw();
-    });
+      if (item.displayed) {
+        var returnQueue = true;
+        redrawQueue[key] = item.redraw(returnQueue);
+        redrawQueueLength = redrawQueue[key].length;
+      }
+    })
+
+    if (redrawQueueLength) {
+      // redraw all regular items
+      for (var i = 0; i < redrawQueueLength; i++) {
+        util.forEach(redrawQueue, function (fns, key) {
+          fns[i]();
+        });
+      }
+    }
+    // util.forEach(this.items, function (item) {
+    //   item.dirty = true;
+    //   if (item.displayed) item.redraw();
+    // });
     return true;
   }
 }
 
 Group.prototype._calculateGroupSizeAndPosition = function() {
-  var foreground = this.dom.foreground;
-  this.top = foreground.offsetTop;
-  this.right = foreground.offsetLeft;
-  this.width = foreground.offsetWidth;
+  var offsetTop = this.dom.foreground.offsetTop
+  var offsetLeft = this.dom.foreground.offsetLeft
+  var offsetWidth = this.dom.foreground.offsetWidth
+  this.top = offsetTop;
+  this.right = offsetLeft;
+  this.width = offsetWidth;
 }
 
 Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, range) {
@@ -237,11 +259,29 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
       // show all items
       var me = this;
       var limitSize = false;
-      util.forEach(this.items, function (item) {
+
+      var redrawQueue = {};
+      var redrawQueueLength = 0;
+
+      util.forEach(this.items, function (item, key) {
         if (!item.displayed) {
-          item.redraw();
+          var returnQueue = true;
+          redrawQueue[key] = item.redraw(returnQueue);
+          redrawQueueLength = redrawQueue[key].length;
           me.visibleItems.push(item);
         }
+      })
+  
+      if (redrawQueueLength) {
+        // redraw all regular items
+        for (var i = 0; i < redrawQueueLength; i++) {
+          util.forEach(redrawQueue, function (fns, key) {
+            fns[i]();
+          });
+        }
+      }
+
+      util.forEach(this.items, function (item) {
         item.repositionX(limitSize);
       });
 
@@ -727,11 +767,56 @@ Group.prototype._updateItemsInRange = function(orderedItems, oldVisibleItems, ra
     });
   }
 
-  // finally, we reposition all the visible items.
+ // // finally, we reposition all the visible items.
+
+  // util.forEach(this.items, function (item, key) {
+  //   item.dirty = true;
+  //   if (item.displayed) {
+  //     var returnQueue = true;
+  //     redrawQueue[key] = item.redraw(returnQueue);
+  //     redrawQueueLength = redrawQueue[key].length;
+  //   }
+  // })
+
+  // if (redrawQueueLength) {
+  //   // redraw all regular items
+  //   for (var i = 0; i < redrawQueueLength; i++) {
+  //     util.forEach(redrawQueue, function (fns, key) {
+  //       fns[i]();
+  //     });
+  //   }
+  // }
+
+  var redrawQueue = {};
+  var redrawQueueLength = 0;
+
   for (i = 0; i < visibleItems.length; i++) {
     var item = visibleItems[i];
-    if (!item.displayed) item.show();
+    if (!item.displayed) {
+      var returnQueue = true;
+      redrawQueue[i] = item.redraw(returnQueue);
+      redrawQueueLength = redrawQueue[i].length;
+    }
+    // item.show();
     // reposition item horizontally
+    // item.repositionX();
+  }
+
+  if (redrawQueueLength) {
+    // redraw all regular items
+    for (var j = 0; j < redrawQueueLength; j++) {
+      util.forEach(redrawQueue, function (fns, key) {
+        fns[j]();
+        // if (j == redrawQueueLength - 1) {
+        //   var item = visibleItems[key];
+        //   item.repositionX();
+        // }
+      });
+    }
+  }
+
+  for (i = 0; i < visibleItems.length; i++) {
+    var item = visibleItems[i];
     item.repositionX();
   }
   

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -225,7 +225,7 @@ Group.prototype._didMarkerHeightChange = function() {
     if (redrawQueueLength) {
       // redraw all regular items
       for (var i = 0; i < redrawQueueLength; i++) {
-        util.forEach(redrawQueue, function (fns, key) {
+        util.forEach(redrawQueue, function (fns) {
           fns[i]();
         });
       }
@@ -275,13 +275,13 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
       if (redrawQueueLength) {
         // redraw all regular items
         for (var i = 0; i < redrawQueueLength; i++) {
-          util.forEach(redrawQueue, function (fns, key) {
+          util.forEach(redrawQueue, function (fns) {
             fns[i]();
           });
         }
       }
 
-      for (var i = 0; i < this.items.length; i++) {
+      for (i = 0; i < this.items.length; i++) {
         this.items[i].repositionX(limitSize);
       }
 
@@ -766,7 +766,7 @@ Group.prototype._updateItemsInRange = function(orderedItems, oldVisibleItems, ra
       return (item.data.end < lowerBound || item.data.end > upperBound);
     });
   }
-  
+
   var redrawQueue = {};
   var redrawQueueLength = 0;
 
@@ -777,25 +777,20 @@ Group.prototype._updateItemsInRange = function(orderedItems, oldVisibleItems, ra
       redrawQueue[i] = item.redraw(returnQueue);
       redrawQueueLength = redrawQueue[i].length;
     }
-    // item.show();
-    // reposition item horizontally
-    // item.repositionX();
   }
 
   if (redrawQueueLength) {
     // redraw all regular items
     for (var j = 0; j < redrawQueueLength; j++) {
-      util.forEach(redrawQueue, function (fns, key) {
+      util.forEach(redrawQueue, function (fns) {
         fns[j]();
       });
     }
   }
 
   for (i = 0; i < visibleItems.length; i++) {
-    var item = visibleItems[i];
-    item.repositionX();
+    visibleItems[i].repositionX();
   }
-  
   return visibleItems;
 };
 

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -693,7 +693,8 @@ ItemSet.prototype.redraw = function() {
     redrawQueueLength = redrawQueue[key].length;
   });
 
-  if (redrawQueueLength) {
+  var needRedraw = redrawQueueLength > 0;
+  if (needRedraw) {
     var redrawResults = {};
 
     for (var i = 0; i < redrawQueueLength; i++) {

--- a/lib/timeline/component/item/BackgroundItem.js
+++ b/lib/timeline/component/item/BackgroundItem.js
@@ -90,11 +90,7 @@ BackgroundItem.prototype._appendDomElement = function() {
   this.displayed = true;
 }
 
-BackgroundItem.prototype._updateDirtyDom = function() {
-  // An item is marked dirty when:
-  // - the item is not yet rendered
-  // - the item's data is changed
-  // - the item is selected/deselected
+BackgroundItem.prototype._updateDirtyDomComponents = function() {
   if (this.dirty) {
     this._updateContents(this.dom.content);
     this._updateDataAttributes(this.dom.content);
@@ -107,9 +103,19 @@ BackgroundItem.prototype._updateDirtyDom = function() {
 
     // determine from css whether this box has overflow
     this.overflow = window.getComputedStyle(this.dom.content).overflow !== 'hidden';
-
+  }
+}
+BackgroundItem.prototype._getDomComponentsSizes = function() {
+  return {
+    content: {
+      width: this.dom.content.offsetWidth
+    }
+  }
+}
+BackgroundItem.prototype._updateDomComponentsSizes = function(sizes) {
+  if (this.dirty) {
     // recalculate size
-    this.props.content.width = this.dom.content.offsetWidth;
+    this.props.content.width = sizes.content.width;
     this.height = 0; // set height zero, so this item will be ignored when stacking items
 
     this.dirty = false;
@@ -119,13 +125,13 @@ BackgroundItem.prototype._updateDirtyDom = function() {
 BackgroundItem.prototype._repaintDomAdditionals = function() {
 }
 
-
 /**
  * Repaint the item
  * @param {boolean} [returnQueue=false]  return the queue
  * @return {boolean} the redraw queue if returnQueue=true
  */
 BackgroundItem.prototype.redraw = function(returnQueue) {
+  var sizes
   var queue = [
     // create item DOM
     this._createDomElement.bind(this),
@@ -133,8 +139,19 @@ BackgroundItem.prototype.redraw = function(returnQueue) {
     // append DOM to parent DOM
     this._appendDomElement.bind(this),
 
-    // update dirty DOM 
-    this._updateDirtyDom.bind(this),
+    // update dirty DOM. An item is marked dirty when:
+    // - the item is not yet rendered
+    // - the item's data is changed
+    // - the item is selected/deselected
+    this._updateDirtyDomComponents.bind(this),
+
+    (function() {
+      sizes = this._getDomComponentsSizes();
+    }).bind(this),
+
+    (function() {
+      this._updateDomComponentsSizes.bind(this)(sizes);
+    }).bind(this),
 
     // repaint DOM additionals
     this._repaintDomAdditionals.bind(this)

--- a/lib/timeline/component/item/BackgroundItem.js
+++ b/lib/timeline/component/item/BackgroundItem.js
@@ -49,51 +49,49 @@ BackgroundItem.prototype.isVisible = function(range) {
   return (this.data.start < range.end) && (this.data.end > range.start); 
 };
 
-/**
- * Repaint the item
- */
-BackgroundItem.prototype.redraw = function() {
-  var dom = this.dom;
-  if (!dom) {
+BackgroundItem.prototype._createDomElement = function() {
+  if (!this.dom) {
     // create DOM
     this.dom = {};
-    dom = this.dom;
 
     // background box
-    dom.box = document.createElement('div');
+    this.dom.box = document.createElement('div');
     // className is updated in redraw()
 
     // frame box (to prevent the item contents from overflowing
-    dom.frame = document.createElement('div');
-    dom.frame.className = 'vis-item-overflow';
-    dom.box.appendChild(dom.frame);
+    this.dom.frame = document.createElement('div');
+    this.dom.frame.className = 'vis-item-overflow';
+    this.dom.box.appendChild(this.dom.frame);
 
     // contents box
-    dom.content = document.createElement('div');
-    dom.content.className = 'vis-item-content';
-    dom.frame.appendChild(dom.content);
+    this.dom.content = document.createElement('div');
+    this.dom.content.className = 'vis-item-content';
+    this.dom.frame.appendChild(this.dom.content);
 
     // Note: we do NOT attach this item as attribute to the DOM,
     //       such that background items cannot be selected
-    //dom.box['timeline-item'] = this;
+    //this.dom.box['timeline-item'] = this;
 
     this.dirty = true;
   }
+}
 
-  // append DOM to parent DOM
+BackgroundItem.prototype._appendDomElement = function() {
   if (!this.parent) {
     throw new Error('Cannot redraw item: no parent attached');
   }
-  if (!dom.box.parentNode) {
+  if (!this.dom.box.parentNode) {
     var background = this.parent.dom.background;
     if (!background) {
       throw new Error('Cannot redraw item: parent has no background container element');
     }
-    background.appendChild(dom.box);
+    background.appendChild(this.dom.box);
   }
   this.displayed = true;
+}
 
-  // Update DOM when item is marked dirty. An item is marked dirty when:
+BackgroundItem.prototype._updateDirtyDom = function() {
+  // An item is marked dirty when:
   // - the item is not yet rendered
   // - the item's data is changed
   // - the item is selected/deselected
@@ -105,16 +103,51 @@ BackgroundItem.prototype.redraw = function() {
     // update class
     var className = (this.data.className ? (' ' + this.data.className) : '') +
         (this.selected ? ' vis-selected' : '');
-    dom.box.className = this.baseClassName + className;
+    this.dom.box.className = this.baseClassName + className;
 
     // determine from css whether this box has overflow
-    this.overflow = window.getComputedStyle(dom.content).overflow !== 'hidden';
+    this.overflow = window.getComputedStyle(this.dom.content).overflow !== 'hidden';
 
     // recalculate size
     this.props.content.width = this.dom.content.offsetWidth;
     this.height = 0; // set height zero, so this item will be ignored when stacking items
 
     this.dirty = false;
+  }
+}
+
+BackgroundItem.prototype._repaintDomAdditionals = function() {
+}
+
+
+/**
+ * Repaint the item
+ * @param {boolean} [returnQueue=false]  return the queue
+ * @return {boolean} the redraw queue if returnQueue=true
+ */
+BackgroundItem.prototype.redraw = function(returnQueue) {
+  var queue = [
+    // create item DOM
+    this._createDomElement.bind(this),
+
+    // append DOM to parent DOM
+    this._appendDomElement.bind(this),
+
+    // update dirty DOM 
+    this._updateDirtyDom.bind(this),
+
+    // repaint DOM additionals
+    this._repaintDomAdditionals.bind(this)
+  ];
+
+  if (returnQueue) {
+    return queue;
+  } else {
+    var result;
+    queue.forEach(function (fn) {
+      result = fn();
+    });
+    return result;
   }
 };
 

--- a/lib/timeline/component/item/BackgroundItem.js
+++ b/lib/timeline/component/item/BackgroundItem.js
@@ -37,6 +37,7 @@ function BackgroundItem (data, conversion, options) {
 BackgroundItem.prototype = new Item (null, null, null);
 
 BackgroundItem.prototype.baseClassName = 'vis-item vis-background';
+
 BackgroundItem.prototype.stack = false;
 
 /**
@@ -91,6 +92,10 @@ BackgroundItem.prototype._appendDomElement = function() {
 }
 
 BackgroundItem.prototype._updateDirtyDomComponents = function() {
+  // update dirty DOM. An item is marked dirty when:
+  // - the item is not yet rendered
+  // - the item's data is changed
+  // - the item is selected/deselected
   if (this.dirty) {
     this._updateContents(this.dom.content);
     this._updateDataAttributes(this.dom.content);
@@ -102,6 +107,7 @@ BackgroundItem.prototype._updateDirtyDomComponents = function() {
     this.dom.box.className = this.baseClassName + className;
   }
 }
+
 BackgroundItem.prototype._getDomComponentsSizes = function() {
   // determine from css whether this box has overflow
   this.overflow = window.getComputedStyle(this.dom.content).overflow !== 'hidden';
@@ -111,6 +117,7 @@ BackgroundItem.prototype._getDomComponentsSizes = function() {
     }
   }
 }
+
 BackgroundItem.prototype._updateDomComponentsSizes = function(sizes) {
   // recalculate size
   this.props.content.width = sizes.content.width;
@@ -125,7 +132,7 @@ BackgroundItem.prototype._repaintDomAdditionals = function() {
 /**
  * Repaint the item
  * @param {boolean} [returnQueue=false]  return the queue
- * @return {boolean} the redraw queue if returnQueue=true
+ * @return {boolean} the redraw result or the redraw queue if returnQueue=true
  */
 BackgroundItem.prototype.redraw = function(returnQueue) {
   var sizes
@@ -136,10 +143,6 @@ BackgroundItem.prototype.redraw = function(returnQueue) {
     // append DOM to parent DOM
     this._appendDomElement.bind(this),
 
-    // update dirty DOM. An item is marked dirty when:
-    // - the item is not yet rendered
-    // - the item's data is changed
-    // - the item is selected/deselected
     this._updateDirtyDomComponents.bind(this),
 
     (function() {

--- a/lib/timeline/component/item/BackgroundItem.js
+++ b/lib/timeline/component/item/BackgroundItem.js
@@ -112,13 +112,11 @@ BackgroundItem.prototype._getDomComponentsSizes = function() {
   }
 }
 BackgroundItem.prototype._updateDomComponentsSizes = function(sizes) {
-  if (this.dirty) {
-    // recalculate size
-    this.props.content.width = sizes.content.width;
-    this.height = 0; // set height zero, so this item will be ignored when stacking items
+  // recalculate size
+  this.props.content.width = sizes.content.width;
+  this.height = 0; // set height zero, so this item will be ignored when stacking items
 
-    this.dirty = false;
-  }
+  this.dirty = false;
 }
 
 BackgroundItem.prototype._repaintDomAdditionals = function() {
@@ -145,11 +143,15 @@ BackgroundItem.prototype.redraw = function(returnQueue) {
     this._updateDirtyDomComponents.bind(this),
 
     (function() {
-      sizes = this._getDomComponentsSizes.bind(this)();
+      if (this.dirty) {
+        sizes = this._getDomComponentsSizes.bind(this)();
+      }
     }).bind(this),
 
     (function() {
-      this._updateDomComponentsSizes.bind(this)(sizes);
+      if (this.dirty) {
+        this._updateDomComponentsSizes.bind(this)(sizes);
+      }
     }).bind(this),
 
     // repaint DOM additionals

--- a/lib/timeline/component/item/BackgroundItem.js
+++ b/lib/timeline/component/item/BackgroundItem.js
@@ -100,12 +100,11 @@ BackgroundItem.prototype._updateDirtyDomComponents = function() {
     var className = (this.data.className ? (' ' + this.data.className) : '') +
         (this.selected ? ' vis-selected' : '');
     this.dom.box.className = this.baseClassName + className;
-
-    // determine from css whether this box has overflow
-    this.overflow = window.getComputedStyle(this.dom.content).overflow !== 'hidden';
   }
 }
 BackgroundItem.prototype._getDomComponentsSizes = function() {
+  // determine from css whether this box has overflow
+  this.overflow = window.getComputedStyle(this.dom.content).overflow !== 'hidden';
   return {
     content: {
       width: this.dom.content.offsetWidth
@@ -146,7 +145,7 @@ BackgroundItem.prototype.redraw = function(returnQueue) {
     this._updateDirtyDomComponents.bind(this),
 
     (function() {
-      sizes = this._getDomComponentsSizes();
+      sizes = this._getDomComponentsSizes.bind(this)();
     }).bind(this),
 
     (function() {

--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -58,60 +58,58 @@ BoxItem.prototype.isVisible = function(range) {
   return isVisible;
 };
 
-/**
- * Repaint the item
- */
-BoxItem.prototype.redraw = function() {
-  var dom = this.dom;
-  if (!dom) {
+BoxItem.prototype._createDomElement = function() {
+  if (!this.dom) {
     // create DOM
     this.dom = {};
-    dom = this.dom;
 
     // create main box
-    dom.box = document.createElement('DIV');
+    this.dom.box = document.createElement('DIV');
 
     // contents box (inside the background box). used for making margins
-    dom.content = document.createElement('DIV');
-    dom.content.className = 'vis-item-content';
-    dom.box.appendChild(dom.content);
+    this.dom.content = document.createElement('DIV');
+    this.dom.content.className = 'vis-item-content';
+    this.dom.box.appendChild(this.dom.content);
 
     // line to axis
-    dom.line = document.createElement('DIV');
-    dom.line.className = 'vis-line';
+    this.dom.line = document.createElement('DIV');
+    this.dom.line.className = 'vis-line';
 
     // dot on axis
-    dom.dot = document.createElement('DIV');
-    dom.dot.className = 'vis-dot';
+    this.dom.dot = document.createElement('DIV');
+    this.dom.dot.className = 'vis-dot';
 
     // attach this item as attribute
-    dom.box['timeline-item'] = this;
+    this.dom.box['timeline-item'] = this;
 
     this.dirty = true;
   }
+}
 
-  // append DOM to parent DOM
+BoxItem.prototype._appendDomElement = function() {
   if (!this.parent) {
     throw new Error('Cannot redraw item: no parent attached');
   }
-  if (!dom.box.parentNode) {
+  if (!this.dom.box.parentNode) {
     var foreground = this.parent.dom.foreground;
     if (!foreground) throw new Error('Cannot redraw item: parent has no foreground container element');
-    foreground.appendChild(dom.box);
+    foreground.appendChild(this.dom.box);
   }
-  if (!dom.line.parentNode) {
+  if (!this.dom.line.parentNode) {
     var background = this.parent.dom.background;
     if (!background) throw new Error('Cannot redraw item: parent has no background container element');
-    background.appendChild(dom.line);
+    background.appendChild(this.dom.line);
   }
-  if (!dom.dot.parentNode) {
+  if (!this.dom.dot.parentNode) {
     var axis = this.parent.dom.axis;
     if (!background) throw new Error('Cannot redraw item: parent has no axis container element');
-    axis.appendChild(dom.dot);
+    axis.appendChild(this.dom.dot);
   }
   this.displayed = true;
+}
 
-  // Update DOM when item is marked dirty. An item is marked dirty when:
+BoxItem.prototype._updateDirtyDom = function() {
+  // An item is marked dirty when:
   // - the item is not yet rendered
   // - the item's data is changed
   // - the item is selected/deselected
@@ -126,41 +124,75 @@ BoxItem.prototype.redraw = function() {
     var className = (this.data.className? ' ' + this.data.className : '') +
         (this.selected ? ' vis-selected' : '') +
         (editable ? ' vis-editable' : ' vis-readonly');
-    dom.box.className = 'vis-item vis-box' + className;
-    dom.line.className = 'vis-item vis-line' + className;
-    dom.dot.className  = 'vis-item vis-dot' + className;
+    this.dom.box.className = 'vis-item vis-box' + className;
+    this.dom.line.className = 'vis-item vis-line' + className;
+    this.dom.dot.className  = 'vis-item vis-dot' + className;
 
     // set initial position in the visible range of the grid so that the
     // rendered box size can be determinated correctly, even the content
     // has a dynamic width (fixes #2032).
-    var previousRight = dom.box.style.right;
-    var previousLeft = dom.box.style.left;
+    var previousRight = this.dom.box.style.right;
+    var previousLeft = this.dom.box.style.left;
     if (this.options.rtl) {
-      dom.box.style.right = "0px";
+      this.dom.box.style.right = "0px";
     } else {
-      dom.box.style.left = "0px";
+      this.dom.box.style.left = "0px";
     }
 
     // recalculate size
-    this.props.dot.height = dom.dot.offsetHeight;
-    this.props.dot.width = dom.dot.offsetWidth;
-    this.props.line.width = dom.line.offsetWidth;
-    this.width = dom.box.offsetWidth;
-    this.height = dom.box.offsetHeight;
+    this.props.dot.height = this.dom.dot.offsetHeight;
+    this.props.dot.width = this.dom.dot.offsetWidth;
+    this.props.line.width = this.dom.line.offsetWidth;
+    this.width = this.dom.box.offsetWidth;
+    this.height = this.dom.box.offsetHeight;
 
     // restore previous position
     if (this.options.rtl) {
-      dom.box.style.right = previousRight;
+      this.dom.box.style.right = previousRight;
     } else {
-      dom.box.style.left = previousLeft;
+      this.dom.box.style.left = previousLeft;
     }
 
     this.dirty = false;
   }
+}
 
-  this._repaintOnItemUpdateTimeTooltip(dom.box);
+BoxItem.prototype._repaintDomAdditionals = function() {
+  this._repaintOnItemUpdateTimeTooltip(this.dom.box);
   this._repaintDragCenter();
-  this._repaintDeleteButton(dom.box);
+  this._repaintDeleteButton(this.dom.box);
+}
+
+
+/**
+ * Repaint the item
+ * @param {boolean} [returnQueue=false]  return the queue
+ * @return {boolean} the redraw queue if returnQueue=true
+ */
+BoxItem.prototype.redraw = function(returnQueue) {
+  var queue = [
+    // create item DOM
+    this._createDomElement.bind(this),
+
+    // append DOM to parent DOM
+    this._appendDomElement.bind(this),
+
+    // update dirty DOM 
+    this._updateDirtyDom.bind(this),
+
+    // repaint DOM additionals
+    this._repaintDomAdditionals.bind(this)
+  ];
+
+  if (returnQueue) {
+    return queue;
+  } else {
+    var result;
+    queue.forEach(function (fn) {
+      result = fn();
+    });
+    return result;
+  }
 };
 
 /**

--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -108,11 +108,7 @@ BoxItem.prototype._appendDomElement = function() {
   this.displayed = true;
 }
 
-BoxItem.prototype._updateDirtyDom = function() {
-  // An item is marked dirty when:
-  // - the item is not yet rendered
-  // - the item's data is changed
-  // - the item is selected/deselected
+BoxItem.prototype._updateDirtyDomComponents = function() {
   if (this.dirty) {
     this._updateContents(this.dom.content);
     this._updateDataAttributes(this.dom.box);
@@ -127,12 +123,31 @@ BoxItem.prototype._updateDirtyDom = function() {
     this.dom.box.className = 'vis-item vis-box' + className;
     this.dom.line.className = 'vis-item vis-line' + className;
     this.dom.dot.className  = 'vis-item vis-dot' + className;
+  }
+}
 
-    // set initial position in the visible range of the grid so that the
-    // rendered box size can be determinated correctly, even the content
-    // has a dynamic width (fixes #2032).
-    var previousRight = this.dom.box.style.right;
-    var previousLeft = this.dom.box.style.left;
+BoxItem.prototype._getDomComponentsSizes = function() {
+  return {
+    previous: {
+      right: this.dom.box.style.right,
+      left: this.dom.box.style.left
+    },
+    dot: {
+      height: this.dom.dot.offsetHeight,
+      width: this.dom.dot.offsetWidth
+    },
+    line: {
+      width: this.dom.line.offsetWidth
+    },
+    box: {
+      width: this.dom.box.offsetWidth,
+      height: this.dom.box.offsetHeight
+    }
+  }
+}
+
+BoxItem.prototype._updateDomComponentsSizes = function(sizes) {
+  if (this.dirty) {
     if (this.options.rtl) {
       this.dom.box.style.right = "0px";
     } else {
@@ -140,17 +155,17 @@ BoxItem.prototype._updateDirtyDom = function() {
     }
 
     // recalculate size
-    this.props.dot.height = this.dom.dot.offsetHeight;
-    this.props.dot.width = this.dom.dot.offsetWidth;
-    this.props.line.width = this.dom.line.offsetWidth;
-    this.width = this.dom.box.offsetWidth;
-    this.height = this.dom.box.offsetHeight;
+    this.props.dot.height = sizes.dot.height;
+    this.props.dot.width = sizes.dot.width;
+    this.props.line.width = sizes.line.width;
+    this.width = sizes.box.width;
+    this.height = sizes.box.height;
 
     // restore previous position
     if (this.options.rtl) {
-      this.dom.box.style.right = previousRight;
+      this.dom.box.style.right = sizes.previous.right;
     } else {
-      this.dom.box.style.left = previousLeft;
+      this.dom.box.style.left = sizes.previous.left;
     }
 
     this.dirty = false;
@@ -163,13 +178,13 @@ BoxItem.prototype._repaintDomAdditionals = function() {
   this._repaintDeleteButton(this.dom.box);
 }
 
-
 /**
  * Repaint the item
  * @param {boolean} [returnQueue=false]  return the queue
  * @return {boolean} the redraw queue if returnQueue=true
  */
 BoxItem.prototype.redraw = function(returnQueue) {
+  var sizes
   var queue = [
     // create item DOM
     this._createDomElement.bind(this),
@@ -177,8 +192,19 @@ BoxItem.prototype.redraw = function(returnQueue) {
     // append DOM to parent DOM
     this._appendDomElement.bind(this),
 
-    // update dirty DOM 
-    this._updateDirtyDom.bind(this),
+    // update dirty DOM. An item is marked dirty when:
+    // - the item is not yet rendered
+    // - the item's data is changed
+    // - the item is selected/deselected
+    this._updateDirtyDomComponents.bind(this),
+
+    (function() {
+      sizes = this._getDomComponentsSizes();
+    }).bind(this),
+
+    (function() {
+      this._updateDomComponentsSizes.bind(this)(sizes);
+    }).bind(this),
 
     // repaint DOM additionals
     this._repaintDomAdditionals.bind(this)

--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -109,6 +109,10 @@ BoxItem.prototype._appendDomElement = function() {
 }
 
 BoxItem.prototype._updateDirtyDomComponents = function() {
+  // An item is marked dirty when:
+  // - the item is not yet rendered
+  // - the item's data is changed
+  // - the item is selected/deselected
   if (this.dirty) {
     this._updateContents(this.dom.content);
     this._updateDataAttributes(this.dom.box);
@@ -190,10 +194,7 @@ BoxItem.prototype.redraw = function(returnQueue) {
     // append DOM to parent DOM
     this._appendDomElement.bind(this),
 
-    // update dirty DOM. An item is marked dirty when:
-    // - the item is not yet rendered
-    // - the item's data is changed
-    // - the item is selected/deselected
+    // update dirty DOM
     this._updateDirtyDomComponents.bind(this),
 
     (function() {

--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -147,29 +147,27 @@ BoxItem.prototype._getDomComponentsSizes = function() {
 }
 
 BoxItem.prototype._updateDomComponentsSizes = function(sizes) {
-  if (this.dirty) {
-    if (this.options.rtl) {
-      this.dom.box.style.right = "0px";
-    } else {
-      this.dom.box.style.left = "0px";
-    }
-
-    // recalculate size
-    this.props.dot.height = sizes.dot.height;
-    this.props.dot.width = sizes.dot.width;
-    this.props.line.width = sizes.line.width;
-    this.width = sizes.box.width;
-    this.height = sizes.box.height;
-
-    // restore previous position
-    if (this.options.rtl) {
-      this.dom.box.style.right = sizes.previous.right;
-    } else {
-      this.dom.box.style.left = sizes.previous.left;
-    }
-
-    this.dirty = false;
+  if (this.options.rtl) {
+    this.dom.box.style.right = "0px";
+  } else {
+    this.dom.box.style.left = "0px";
   }
+
+  // recalculate size
+  this.props.dot.height = sizes.dot.height;
+  this.props.dot.width = sizes.dot.width;
+  this.props.line.width = sizes.line.width;
+  this.width = sizes.box.width;
+  this.height = sizes.box.height;
+
+  // restore previous position
+  if (this.options.rtl) {
+    this.dom.box.style.right = sizes.previous.right;
+  } else {
+    this.dom.box.style.left = sizes.previous.left;
+  }
+
+  this.dirty = false;
 }
 
 BoxItem.prototype._repaintDomAdditionals = function() {
@@ -199,11 +197,15 @@ BoxItem.prototype.redraw = function(returnQueue) {
     this._updateDirtyDomComponents.bind(this),
 
     (function() {
-      sizes = this._getDomComponentsSizes();
+      if (this.dirty) {
+        sizes = this._getDomComponentsSizes();
+      }
     }).bind(this),
 
     (function() {
-      this._updateDomComponentsSizes.bind(this)(sizes);
+      if (this.dirty) {
+        this._updateDomComponentsSizes.bind(this)(sizes);
+      }
     }).bind(this),
 
     // repaint DOM additionals

--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -187,34 +187,32 @@ PointItem.prototype._getDomComponentsSizes = function() {
 }
 
 PointItem.prototype._updateDomComponentsSizes = function(sizes) {
-  if (this.dirty) {
-    // recalculate size of dot and contents
-    this.props.dot.width = sizes.dot.width;
-    this.props.dot.height = sizes.dot.height;
-    this.props.content.height = sizes.content.height;
+  // recalculate size of dot and contents
+  this.props.dot.width = sizes.dot.width;
+  this.props.dot.height = sizes.dot.height;
+  this.props.content.height = sizes.content.height;
 
-    // resize contents
-    if (this.options.rtl) {
-      this.dom.content.style.marginRight = 2 * this.props.dot.width + 'px';
-    } else {
-      this.dom.content.style.marginLeft = 2 * this.props.dot.width + 'px';
-    }
-    //this.dom.content.style.marginRight = ... + 'px'; // TODO: margin right
-
-    // recalculate size
-    this.width = sizes.point.width;
-    this.height = sizes.point.height;
-
-    // reposition the dot
-    this.dom.dot.style.top = ((this.height - this.props.dot.height) / 2) + 'px';
-    if (this.options.rtl) {
-      this.dom.dot.style.right = (this.props.dot.width / 2) + 'px';
-    } else {
-      this.dom.dot.style.left = (this.props.dot.width / 2) + 'px';
-    }
-
-    this.dirty = false;
+  // resize contents
+  if (this.options.rtl) {
+    this.dom.content.style.marginRight = 2 * this.props.dot.width + 'px';
+  } else {
+    this.dom.content.style.marginLeft = 2 * this.props.dot.width + 'px';
   }
+  //this.dom.content.style.marginRight = ... + 'px'; // TODO: margin right
+
+  // recalculate size
+  this.width = sizes.point.width;
+  this.height = sizes.point.height;
+
+  // reposition the dot
+  this.dom.dot.style.top = ((this.height - this.props.dot.height) / 2) + 'px';
+  if (this.options.rtl) {
+    this.dom.dot.style.right = (this.props.dot.width / 2) + 'px';
+  } else {
+    this.dom.dot.style.left = (this.props.dot.width / 2) + 'px';
+  }
+
+  this.dirty = false;
 }
 
 PointItem.prototype._repaintDomAdditionals = function() {
@@ -244,11 +242,15 @@ PointItem.prototype.redraw = function(returnQueue) {
     this._updateDirtyDomComponents.bind(this),
 
     (function() {
-      sizes = this._getDomComponentsSizes();
+      if (this.dirty) {
+        sizes = this._getDomComponentsSizes();
+      }
     }).bind(this),
 
     (function() {
-      this._updateDomComponentsSizes.bind(this)(sizes);
+      if (this.dirty) {
+        this._updateDomComponentsSizes.bind(this)(sizes);
+      }
     }).bind(this),
 
     // repaint DOM additionals

--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -88,7 +88,68 @@ PointItem.prototype._appendDomElement = function() {
   this.displayed = true;
 }
 
-PointItem.prototype._updateDirtyDom = function() {
+// PointItem.prototype._updateDirtyDom = function() {
+//   // An item is marked dirty when:
+//   // - the item is not yet rendered
+//   // - the item's data is changed
+//   // - the item is selected/deselected
+//   if (this.dirty) {
+//     this._updateContents(this.dom.content);
+//     this._updateDataAttributes(this.dom.point);
+//     this._updateStyle(this.dom.point);
+
+//     var editable = (this.editable.updateTime || this.editable.updateGroup);
+//     // update class
+//     var className = (this.data.className ? ' ' + this.data.className : '') +
+//         (this.selected ? ' vis-selected' : '') +
+//         (editable ? ' vis-editable' : ' vis-readonly');
+//     this.dom.point.className  = 'vis-item vis-point' + className;
+//     this.dom.dot.className  = 'vis-item vis-dot' + className;
+
+//     var dotOffset = {
+//       width: this.dom.dot.offsetWidth,
+//       height: this.dom.dot.offsetHeight
+//     }
+
+//     var contentOffset = {
+//       width: this.dom.content.offsetWidth,
+//       height: this.dom.content.offsetHeight
+//     }
+
+//     var pointOffset = {
+//       width: this.dom.point.offsetWidth,
+//       height: this.dom.point.offsetHeight
+//     }
+//     // recalculate size of dot and contents
+//     this.props.dot.width = dotOffset.width;
+//     this.props.dot.height = dotOffset.height;
+//     this.props.content.height = contentOffset.height;
+
+//     // resize contents
+//     if (this.options.rtl) {
+//       this.dom.content.style.marginRight = 2 * this.props.dot.width + 'px';
+//     } else {
+//       this.dom.content.style.marginLeft = 2 * this.props.dot.width + 'px';
+//     }
+//     //this.dom.content.style.marginRight = ... + 'px'; // TODO: margin right
+
+//     // recalculate size
+//     this.width = pointOffset.width;
+//     this.height = pointOffset.height;
+
+//     // reposition the dot
+//     this.dom.dot.style.top = ((this.height - this.props.dot.height) / 2) + 'px';
+//     if (this.options.rtl) {
+//       this.dom.dot.style.right = (this.props.dot.width / 2) + 'px';
+//     } else {
+//       this.dom.dot.style.left = (this.props.dot.width / 2) + 'px';
+//     }
+
+//     this.dirty = false;
+//   }
+// }
+
+PointItem.prototype._updateDirtyDomComponents = function() {
   // An item is marked dirty when:
   // - the item is not yet rendered
   // - the item's data is changed
@@ -105,11 +166,32 @@ PointItem.prototype._updateDirtyDom = function() {
         (editable ? ' vis-editable' : ' vis-readonly');
     this.dom.point.className  = 'vis-item vis-point' + className;
     this.dom.dot.className  = 'vis-item vis-dot' + className;
+  }
+}
 
+PointItem.prototype._getDomComponentsSizes = function() {
+  return {
+    dot:  {
+      width: this.dom.dot.offsetWidth,
+      height: this.dom.dot.offsetHeight
+    },
+    content: {
+      width: this.dom.content.offsetWidth,
+      height: this.dom.content.offsetHeight
+    },
+    point: {
+      width: this.dom.point.offsetWidth,
+      height: this.dom.point.offsetHeight
+    }
+  }
+}
+
+PointItem.prototype._updateDomComponentsSizes = function(sizes) {
+  if (this.dirty) {
     // recalculate size of dot and contents
-    this.props.dot.width = this.dom.dot.offsetWidth;
-    this.props.dot.height = this.dom.dot.offsetHeight;
-    this.props.content.height = this.dom.content.offsetHeight;
+    this.props.dot.width = sizes.dot.width;
+    this.props.dot.height = sizes.dot.height;
+    this.props.content.height = sizes.content.height;
 
     // resize contents
     if (this.options.rtl) {
@@ -120,8 +202,8 @@ PointItem.prototype._updateDirtyDom = function() {
     //this.dom.content.style.marginRight = ... + 'px'; // TODO: margin right
 
     // recalculate size
-    this.width = this.dom.point.offsetWidth;
-    this.height = this.dom.point.offsetHeight;
+    this.width = sizes.point.width;
+    this.height = sizes.point.height;
 
     // reposition the dot
     this.dom.dot.style.top = ((this.height - this.props.dot.height) / 2) + 'px';
@@ -147,6 +229,7 @@ PointItem.prototype._repaintDomAdditionals = function() {
  * @return {boolean} the redraw queue if returnQueue=true
  */
 PointItem.prototype.redraw = function(returnQueue) {
+  var sizes
   var queue = [
     // create item DOM
     this._createDomElement.bind(this),
@@ -154,8 +237,19 @@ PointItem.prototype.redraw = function(returnQueue) {
     // append DOM to parent DOM
     this._appendDomElement.bind(this),
 
-    // update dirty DOM 
-    this._updateDirtyDom.bind(this),
+    // update dirty DOM. An item is marked dirty when:
+    // - the item is not yet rendered
+    // - the item's data is changed
+    // - the item is selected/deselected
+    this._updateDirtyDomComponents.bind(this),
+
+    (function() {
+      sizes = this._getDomComponentsSizes();
+    }).bind(this),
+
+    (function() {
+      this._updateDomComponentsSizes.bind(this)(sizes);
+    }).bind(this),
 
     // repaint DOM additionals
     this._repaintDomAdditionals.bind(this)

--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -88,67 +88,6 @@ PointItem.prototype._appendDomElement = function() {
   this.displayed = true;
 }
 
-// PointItem.prototype._updateDirtyDom = function() {
-//   // An item is marked dirty when:
-//   // - the item is not yet rendered
-//   // - the item's data is changed
-//   // - the item is selected/deselected
-//   if (this.dirty) {
-//     this._updateContents(this.dom.content);
-//     this._updateDataAttributes(this.dom.point);
-//     this._updateStyle(this.dom.point);
-
-//     var editable = (this.editable.updateTime || this.editable.updateGroup);
-//     // update class
-//     var className = (this.data.className ? ' ' + this.data.className : '') +
-//         (this.selected ? ' vis-selected' : '') +
-//         (editable ? ' vis-editable' : ' vis-readonly');
-//     this.dom.point.className  = 'vis-item vis-point' + className;
-//     this.dom.dot.className  = 'vis-item vis-dot' + className;
-
-//     var dotOffset = {
-//       width: this.dom.dot.offsetWidth,
-//       height: this.dom.dot.offsetHeight
-//     }
-
-//     var contentOffset = {
-//       width: this.dom.content.offsetWidth,
-//       height: this.dom.content.offsetHeight
-//     }
-
-//     var pointOffset = {
-//       width: this.dom.point.offsetWidth,
-//       height: this.dom.point.offsetHeight
-//     }
-//     // recalculate size of dot and contents
-//     this.props.dot.width = dotOffset.width;
-//     this.props.dot.height = dotOffset.height;
-//     this.props.content.height = contentOffset.height;
-
-//     // resize contents
-//     if (this.options.rtl) {
-//       this.dom.content.style.marginRight = 2 * this.props.dot.width + 'px';
-//     } else {
-//       this.dom.content.style.marginLeft = 2 * this.props.dot.width + 'px';
-//     }
-//     //this.dom.content.style.marginRight = ... + 'px'; // TODO: margin right
-
-//     // recalculate size
-//     this.width = pointOffset.width;
-//     this.height = pointOffset.height;
-
-//     // reposition the dot
-//     this.dom.dot.style.top = ((this.height - this.props.dot.height) / 2) + 'px';
-//     if (this.options.rtl) {
-//       this.dom.dot.style.right = (this.props.dot.width / 2) + 'px';
-//     } else {
-//       this.dom.dot.style.left = (this.props.dot.width / 2) + 'px';
-//     }
-
-//     this.dirty = false;
-//   }
-// }
-
 PointItem.prototype._updateDirtyDomComponents = function() {
   // An item is marked dirty when:
   // - the item is not yet rendered
@@ -235,10 +174,7 @@ PointItem.prototype.redraw = function(returnQueue) {
     // append DOM to parent DOM
     this._appendDomElement.bind(this),
 
-    // update dirty DOM. An item is marked dirty when:
-    // - the item is not yet rendered
-    // - the item's data is changed
-    // - the item is selected/deselected
+    // update dirty DOM
     this._updateDirtyDomComponents.bind(this),
 
     (function() {

--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -48,49 +48,48 @@ PointItem.prototype.isVisible = function(range) {
   return (this.data.start.getTime() + widthInMs > range.start ) && (this.data.start < range.end);
 };
 
-/**
- * Repaint the item
- */
-PointItem.prototype.redraw = function() {
-  var dom = this.dom;
-  if (!dom) {
+
+PointItem.prototype._createDomElement = function() {
+  if (!this.dom) {
     // create DOM
     this.dom = {};
-    dom = this.dom;
 
     // background box
-    dom.point = document.createElement('div');
+    this.dom.point = document.createElement('div');
     // className is updated in redraw()
 
     // contents box, right from the dot
-    dom.content = document.createElement('div');
-    dom.content.className = 'vis-item-content';
-    dom.point.appendChild(dom.content);
+    this.dom.content = document.createElement('div');
+    this.dom.content.className = 'vis-item-content';
+    this.dom.point.appendChild(this.dom.content);
 
     // dot at start
-    dom.dot = document.createElement('div');
-    dom.point.appendChild(dom.dot);
+    this.dom.dot = document.createElement('div');
+    this.dom.point.appendChild(this.dom.dot);
 
     // attach this item as attribute
-    dom.point['timeline-item'] = this;
+    this.dom.point['timeline-item'] = this;
 
     this.dirty = true;
   }
+}
 
-  // append DOM to parent DOM
+PointItem.prototype._appendDomElement = function() {
   if (!this.parent) {
     throw new Error('Cannot redraw item: no parent attached');
   }
-  if (!dom.point.parentNode) {
+  if (!this.dom.point.parentNode) {
     var foreground = this.parent.dom.foreground;
     if (!foreground) {
       throw new Error('Cannot redraw item: parent has no foreground container element');
     }
-    foreground.appendChild(dom.point);
+    foreground.appendChild(this.dom.point);
   }
   this.displayed = true;
+}
 
-  // Update DOM when item is marked dirty. An item is marked dirty when:
+PointItem.prototype._updateDirtyDom = function() {
+  // An item is marked dirty when:
   // - the item is not yet rendered
   // - the item's data is changed
   // - the item is selected/deselected
@@ -104,40 +103,73 @@ PointItem.prototype.redraw = function() {
     var className = (this.data.className ? ' ' + this.data.className : '') +
         (this.selected ? ' vis-selected' : '') +
         (editable ? ' vis-editable' : ' vis-readonly');
-    dom.point.className  = 'vis-item vis-point' + className;
-    dom.dot.className  = 'vis-item vis-dot' + className;
+    this.dom.point.className  = 'vis-item vis-point' + className;
+    this.dom.dot.className  = 'vis-item vis-dot' + className;
 
     // recalculate size of dot and contents
-    this.props.dot.width = dom.dot.offsetWidth;
-    this.props.dot.height = dom.dot.offsetHeight;
-    this.props.content.height = dom.content.offsetHeight;
+    this.props.dot.width = this.dom.dot.offsetWidth;
+    this.props.dot.height = this.dom.dot.offsetHeight;
+    this.props.content.height = this.dom.content.offsetHeight;
 
     // resize contents
     if (this.options.rtl) {
-      dom.content.style.marginRight = 2 * this.props.dot.width + 'px';
+      this.dom.content.style.marginRight = 2 * this.props.dot.width + 'px';
     } else {
-      dom.content.style.marginLeft = 2 * this.props.dot.width + 'px';
+      this.dom.content.style.marginLeft = 2 * this.props.dot.width + 'px';
     }
-    //dom.content.style.marginRight = ... + 'px'; // TODO: margin right
+    //this.dom.content.style.marginRight = ... + 'px'; // TODO: margin right
 
     // recalculate size
-    this.width = dom.point.offsetWidth;
-    this.height = dom.point.offsetHeight;
+    this.width = this.dom.point.offsetWidth;
+    this.height = this.dom.point.offsetHeight;
 
     // reposition the dot
-    dom.dot.style.top = ((this.height - this.props.dot.height) / 2) + 'px';
+    this.dom.dot.style.top = ((this.height - this.props.dot.height) / 2) + 'px';
     if (this.options.rtl) {
-      dom.dot.style.right = (this.props.dot.width / 2) + 'px';
+      this.dom.dot.style.right = (this.props.dot.width / 2) + 'px';
     } else {
-      dom.dot.style.left = (this.props.dot.width / 2) + 'px';
+      this.dom.dot.style.left = (this.props.dot.width / 2) + 'px';
     }
 
     this.dirty = false;
   }
-  
-  this._repaintOnItemUpdateTimeTooltip(dom.point);
+}
+
+PointItem.prototype._repaintDomAdditionals = function() {
+  this._repaintOnItemUpdateTimeTooltip(this.dom.point);
   this._repaintDragCenter();
-  this._repaintDeleteButton(dom.point);
+  this._repaintDeleteButton(this.dom.point);
+}
+
+/**
+ * Repaint the item
+ * @param {boolean} [returnQueue=false]  return the queue
+ * @return {boolean} the redraw queue if returnQueue=true
+ */
+PointItem.prototype.redraw = function(returnQueue) {
+  var queue = [
+    // create item DOM
+    this._createDomElement.bind(this),
+
+    // append DOM to parent DOM
+    this._appendDomElement.bind(this),
+
+    // update dirty DOM 
+    this._updateDirtyDom.bind(this),
+
+    // repaint DOM additionals
+    this._repaintDomAdditionals.bind(this)
+  ];
+
+  if (returnQueue) {
+    return queue;
+  } else {
+    var result;
+    queue.forEach(function (fn) {
+      result = fn();
+    });
+    return result;
+  }
 };
 
 /**

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -92,11 +92,7 @@ RangeItem.prototype._appendDomElement = function() {
   this.displayed = true;
 }
 
-RangeItem.prototype._updateDirtyDom = function() {
-  // An item is marked dirty when:
-  // - the item is not yet rendered
-  // - the item's data is changed
-  // - the item is selected/deselected
+RangeItem.prototype._updateDirtyDomComponents = function() {
   if (this.dirty) {
     this._updateContents(this.dom.content);
     this._updateDataAttributes(this.dom.box);
@@ -113,14 +109,28 @@ RangeItem.prototype._updateDirtyDom = function() {
     // determine from css whether this box has overflow
     this.overflow = window.getComputedStyle(this.dom.frame).overflow !== 'hidden';
 
-    // recalculate size
     // turn off max-width to be able to calculate the real width
     // this causes an extra browser repaint/reflow, but so be it
     this.dom.content.style.maxWidth = 'none';
-    this.props.content.width = this.dom.content.offsetWidth;
-    this.height = this.dom.box.offsetHeight;
-    this.dom.content.style.maxWidth = '';
+  }
+}
 
+RangeItem.prototype._getDomComponentsSizes = function() {
+  return {
+    content: {
+      width: this.dom.content.offsetWidth,
+    },
+    box: {
+      height: this.dom.box.offsetHeight
+    }
+  }
+}
+
+RangeItem.prototype._updateDomComponentsSizes = function(sizes) {
+  if (this.dirty) {
+    this.props.content.width = sizes.content.width;
+    this.height = sizes.box.height;
+    this.dom.content.style.maxWidth = '';
     this.dirty = false;
   }
 }
@@ -140,6 +150,7 @@ RangeItem.prototype._repaintDomAdditionals = function() {
  * @return {boolean} the redraw queue if returnQueue=true
  */
 RangeItem.prototype.redraw = function(returnQueue) {
+  var sizes
   var queue = [
     // create item DOM
     this._createDomElement.bind(this),
@@ -147,8 +158,22 @@ RangeItem.prototype.redraw = function(returnQueue) {
     // append DOM to parent DOM
     this._appendDomElement.bind(this),
 
-    // update dirty DOM 
-    this._updateDirtyDom.bind(this),
+    // // update dirty DOM 
+    // this._updateDirtyDom.bind(this),
+
+    // update dirty DOM. An item is marked dirty when:
+    // - the item is not yet rendered
+    // - the item's data is changed
+    // - the item is selected/deselected
+    this._updateDirtyDomComponents.bind(this),
+
+    (function() {
+      sizes = this._getDomComponentsSizes();
+    }).bind(this),
+
+    (function() {
+      this._updateDomComponentsSizes.bind(this)(sizes);
+    }).bind(this),
 
     // repaint DOM additionals
     this._repaintDomAdditionals.bind(this)

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -106,9 +106,6 @@ RangeItem.prototype._updateDirtyDomComponents = function() {
         (editable ? ' vis-editable' : ' vis-readonly');
     this.dom.box.className = this.baseClassName + className;
 
-    // determine from css whether this box has overflow
-    this.overflow = window.getComputedStyle(this.dom.frame).overflow !== 'hidden';
-
     // turn off max-width to be able to calculate the real width
     // this causes an extra browser repaint/reflow, but so be it
     this.dom.content.style.maxWidth = 'none';
@@ -116,6 +113,8 @@ RangeItem.prototype._updateDirtyDomComponents = function() {
 }
 
 RangeItem.prototype._getDomComponentsSizes = function() {
+  // determine from css whether this box has overflow
+  this.overflow = window.getComputedStyle(this.dom.frame).overflow !== 'hidden';
   return {
     content: {
       width: this.dom.content.offsetWidth,
@@ -168,7 +167,7 @@ RangeItem.prototype.redraw = function(returnQueue) {
     this._updateDirtyDomComponents.bind(this),
 
     (function() {
-      sizes = this._getDomComponentsSizes();
+      sizes = this._getDomComponentsSizes.bind(this)();
     }).bind(this),
 
     (function() {

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -93,6 +93,10 @@ RangeItem.prototype._appendDomElement = function() {
 }
 
 RangeItem.prototype._updateDirtyDomComponents = function() {
+  // update dirty DOM. An item is marked dirty when:
+  // - the item is not yet rendered
+  // - the item's data is changed
+  // - the item is selected/deselected
   if (this.dirty) {
     this._updateContents(this.dom.content);
     this._updateDataAttributes(this.dom.box);
@@ -140,14 +144,13 @@ RangeItem.prototype._repaintDomAdditionals = function() {
   this._repaintDragRight();
 }
 
-
 /**
  * Repaint the item
  * @param {boolean} [returnQueue=false]  return the queue
  * @return {boolean} the redraw queue if returnQueue=true
  */
 RangeItem.prototype.redraw = function(returnQueue) {
-  var sizes
+  var sizes;
   var queue = [
     // create item DOM
     this._createDomElement.bind(this),
@@ -155,13 +158,7 @@ RangeItem.prototype.redraw = function(returnQueue) {
     // append DOM to parent DOM
     this._appendDomElement.bind(this),
 
-    // // update dirty DOM 
-    // this._updateDirtyDom.bind(this),
-
-    // update dirty DOM. An item is marked dirty when:
-    // - the item is not yet rendered
-    // - the item's data is changed
-    // - the item is selected/deselected
+    // update dirty DOM 
     this._updateDirtyDomComponents.bind(this),
 
     (function() {

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -126,12 +126,10 @@ RangeItem.prototype._getDomComponentsSizes = function() {
 }
 
 RangeItem.prototype._updateDomComponentsSizes = function(sizes) {
-  if (this.dirty) {
-    this.props.content.width = sizes.content.width;
-    this.height = sizes.box.height;
-    this.dom.content.style.maxWidth = '';
-    this.dirty = false;
-  }
+  this.props.content.width = sizes.content.width;
+  this.height = sizes.box.height;
+  this.dom.content.style.maxWidth = '';
+  this.dirty = false;
 }
 
 RangeItem.prototype._repaintDomAdditionals = function() {
@@ -167,11 +165,15 @@ RangeItem.prototype.redraw = function(returnQueue) {
     this._updateDirtyDomComponents.bind(this),
 
     (function() {
-      sizes = this._getDomComponentsSizes.bind(this)();
+      if (this.dirty) {
+        sizes = this._getDomComponentsSizes.bind(this)();
+      }
     }).bind(this),
 
     (function() {
-      this._updateDomComponentsSizes.bind(this)(sizes);
+      if (this.dirty) {
+        this._updateDomComponentsSizes.bind(this)(sizes);
+      }
     }).bind(this),
 
     // repaint DOM additionals

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -46,55 +46,54 @@ RangeItem.prototype.isVisible = function(range) {
   return (this.data.start < range.end) && (this.data.end > range.start);
 };
 
-/**
- * Repaint the item
- */
-RangeItem.prototype.redraw = function() {
-  var dom = this.dom;
-  if (!dom) {
+RangeItem.prototype._createDomElement = function() {
+  if (!this.dom) {
     // create DOM
     this.dom = {};
-    dom = this.dom;
 
       // background box
-    dom.box = document.createElement('div');
+    this.dom.box = document.createElement('div');
     // className is updated in redraw()
 
     // frame box (to prevent the item contents from overflowing)
-    dom.frame = document.createElement('div');
-    dom.frame.className = 'vis-item-overflow';
-    dom.box.appendChild(dom.frame);
+    this.dom.frame = document.createElement('div');
+    this.dom.frame.className = 'vis-item-overflow';
+    this.dom.box.appendChild(this.dom.frame);
   
     // visible frame box (showing the frame that is always visible)
-    dom.visibleFrame = document.createElement('div');
-    dom.visibleFrame.className = 'vis-item-visible-frame';
-    dom.box.appendChild(dom.visibleFrame);
+    this.dom.visibleFrame = document.createElement('div');
+    this.dom.visibleFrame.className = 'vis-item-visible-frame';
+    this.dom.box.appendChild(this.dom.visibleFrame);
 
     // contents box
-    dom.content = document.createElement('div');
-    dom.content.className = 'vis-item-content';
-    dom.frame.appendChild(dom.content);
+    this.dom.content = document.createElement('div');
+    this.dom.content.className = 'vis-item-content';
+    this.dom.frame.appendChild(this.dom.content);
 
     // attach this item as attribute
-    dom.box['timeline-item'] = this;
+    this.dom.box['timeline-item'] = this;
 
     this.dirty = true;
   }
 
-  // append DOM to parent DOM
+}
+
+RangeItem.prototype._appendDomElement = function() {
   if (!this.parent) {
     throw new Error('Cannot redraw item: no parent attached');
   }
-  if (!dom.box.parentNode) {
+  if (!this.dom.box.parentNode) {
     var foreground = this.parent.dom.foreground;
     if (!foreground) {
       throw new Error('Cannot redraw item: parent has no foreground container element');
     }
-    foreground.appendChild(dom.box);
+    foreground.appendChild(this.dom.box);
   }
   this.displayed = true;
+}
 
-  // Update DOM when item is marked dirty. An item is marked dirty when:
+RangeItem.prototype._updateDirtyDom = function() {
+  // An item is marked dirty when:
   // - the item is not yet rendered
   // - the item's data is changed
   // - the item is selected/deselected
@@ -109,10 +108,10 @@ RangeItem.prototype.redraw = function() {
     var className = (this.data.className ? (' ' + this.data.className) : '') +
         (this.selected ? ' vis-selected' : '') + 
         (editable ? ' vis-editable' : ' vis-readonly');
-    dom.box.className = this.baseClassName + className;
+    this.dom.box.className = this.baseClassName + className;
 
     // determine from css whether this box has overflow
-    this.overflow = window.getComputedStyle(dom.frame).overflow !== 'hidden';
+    this.overflow = window.getComputedStyle(this.dom.frame).overflow !== 'hidden';
 
     // recalculate size
     // turn off max-width to be able to calculate the real width
@@ -124,12 +123,46 @@ RangeItem.prototype.redraw = function() {
 
     this.dirty = false;
   }
+}
 
-  this._repaintOnItemUpdateTimeTooltip(dom.box);
-  this._repaintDeleteButton(dom.box);
+RangeItem.prototype._repaintDomAdditionals = function() {
+  this._repaintOnItemUpdateTimeTooltip(this.dom.box);
+  this._repaintDeleteButton(this.dom.box);
   this._repaintDragCenter();
   this._repaintDragLeft();
   this._repaintDragRight();
+}
+
+
+/**
+ * Repaint the item
+ * @param {boolean} [returnQueue=false]  return the queue
+ * @return {boolean} the redraw queue if returnQueue=true
+ */
+RangeItem.prototype.redraw = function(returnQueue) {
+  var queue = [
+    // create item DOM
+    this._createDomElement.bind(this),
+
+    // append DOM to parent DOM
+    this._appendDomElement.bind(this),
+
+    // update dirty DOM 
+    this._updateDirtyDom.bind(this),
+
+    // repaint DOM additionals
+    this._repaintDomAdditionals.bind(this)
+  ];
+
+  if (returnQueue) {
+    return queue;
+  } else {
+    var result;
+    queue.forEach(function (fn) {
+      result = fn();
+    });
+    return result;
+  }
 };
 
 /**


### PR DESCRIPTION
Based on the work done in #3409, I've improved the performance of the timeline redraw time by 2-5 times faster! Initial draw has been reduced to less than 1 seconds for 1,000 items across 10 groups.
![default](https://user-images.githubusercontent.com/4319928/30747016-8a3f33b6-9fb4-11e7-864b-153cb4565c5b.PNG)

This PR includes parallel redrawing of items in the same group avoiding "read,write,read,write" reflow/repaint delays of the browser, reducing it to a single repaint per all items' action in redrawing queue.
 
Further work needs to been done for:
- parallel redrawing of items across different groups.
- move the redraw queue of each item type to a general redraw function under the `Item.js` file (since the redraw function is identical to all.)
- Improve even more unneeded repaints occurring in initial drawing of the timeline and redraws called in events preceding initial draw.
