### PR TITLE
Network: Adjust documentation for arrows.middle.scaleFactor

### DIFF
--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -285,7 +285,9 @@ network.setOptions(options);
             <td class="indent">arrows.middle</td>
             <td>Object or Boolean</td>
             <td><code>Object</code></td>
-            <td>Exactly the same as the to object but with an arrowhead in the center of the edge.</td>
+            <td>In general, the same as the to object but with an arrowhead in the center of the edge.
+                The only difference is that the direction of the arrow can be flipped by using a negative
+                value for <code>arrows.middle.scaleFactor</code>.</td>
         </tr>
         <tr parent="arrows" class="hidden">
             <td class="indent">arrows.from</td>

--- a/docs/network/edges.html
+++ b/docs/network/edges.html
@@ -285,9 +285,7 @@ network.setOptions(options);
             <td class="indent">arrows.middle</td>
             <td>Object or Boolean</td>
             <td><code>Object</code></td>
-            <td>In general, the same as the to object but with an arrowhead in the center of the edge.
-                The only difference is that the direction of the arrow can be flipped by using a negative
-                value for <code>arrows.middle.scaleFactor</code>.</td>
+            <td>Similar to the 'to' object, but with an arrowhead in the center of the edge. The direction of the arrow can be flipped by using a negative value for <code>arrows.middle.scaleFactor</code>.</td>
         </tr>
         <tr parent="arrows" class="hidden">
             <td class="indent">arrows.from</td>


### PR DESCRIPTION
Addendum to #3474.

Updated the documentation, so that users can know about flipping the middle arrow with a negative scale factor.
