### PR TITLE
IE performance improvements #3425

### DIFF
--- a/lib/network/CachedImage.js
+++ b/lib/network/CachedImage.js
@@ -11,7 +11,6 @@
  * @param {Image} image
  */
 class CachedImage {
-  constructor() {  // eslint-disable-line no-unused-vars
   /**
    * @ignore
    */  

--- a/lib/network/CachedImage.js
+++ b/lib/network/CachedImage.js
@@ -11,6 +11,7 @@
  * @param {Image} image
  */
 class CachedImage {
+  constructor() {  // eslint-disable-line no-unused-vars
   /**
    * @ignore
    */  

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -393,7 +393,7 @@ class InteractionHandler {
         let diffY = pointer.y - this.drag.pointer.y;
 
         this.body.view.translation = {x:this.drag.translation.x + diffX, y:this.drag.translation.y + diffY};
-        this.body.emitter.emit('_redraw');
+        this.body.emitter.emit('_requestRedraw');
       }
     }
   }

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -354,6 +354,8 @@ class Label {
   /**
    * Draws the label background
    * @param {CanvasRenderingContext2D} ctx
+   * @param {number} x
+   * @param {number} y
    * @private
    */
   _drawBackground(ctx, x, y) {
@@ -387,11 +389,10 @@ class Label {
   /**
    *
    * @param {CanvasRenderingContext2D} ctx
-   * @param {boolean} selected
-   * @param {boolean} hover
    * @param {number} x
    * @param {number} y
    * @param {string} [baseline='middle']
+   * @param {number} viewFontSize 
    * @private
    */
   _drawText(ctx, x, y, baseline = 'middle', viewFontSize) {

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -342,7 +342,7 @@ class Label {
     this.calculateLabelSize(ctx, selected, hover, x, y, baseline);
 
     this._drawBackground(ctx);  // create the fontfill background
-    this._drawText(ctx, selected, hover, x, y, baseline);
+    this._drawText(ctx, x, y, baseline, viewFontSize);
   }
 
 
@@ -389,15 +389,12 @@ class Label {
    * @param {string} [baseline='middle']
    * @private
    */
-  _drawText(ctx, selected, hover, x, y, baseline = 'middle') {
-    let fontSize = this.fontOptions.size;
-    let viewFontSize = fontSize * this.body.view.scale;
-
+  _drawText(ctx, x, y, baseline = 'middle', viewFontSize) {
+ 
     // This ensures that there will not be HUGE letters on screen
     // by setting an upper limit on the visible text size (regardless of zoomLevel)
     if (viewFontSize >= this.elementOptions.scaling.label.maxVisible) {
-      // TODO: Does this actually do anything?
-      fontSize = Number(this.elementOptions.scaling.label.maxVisible) / this.body.view.scale;
+      viewFontSize = Number(this.elementOptions.scaling.label.maxVisible) / this.body.view.scale;
     }
 
     let yLine = this.size.yLine;
@@ -416,15 +413,16 @@ class Label {
 
     // draw the text
     for (let i = 0; i < this.lineCount; i++) {
-      if (this.lines[i] && this.lines[i].blocks) {
+      let line = this.lines[i];
+      if (line && line.blocks) {
         let width = 0;
         if (this.isEdgeLabel || this.fontOptions.align === 'center') {
-          width += (this.size.width - this.lines[i].width) / 2
+          width += (this.size.width - line.width) / 2
         } else if (this.fontOptions.align === 'right') {
-          width += (this.size.width - this.lines[i].width)
+          width += (this.size.width - line.width)
         }
-        for (let j = 0; j < this.lines[i].blocks.length; j++) {
-          let block = this.lines[i].blocks[j];
+        for (let j = 0; j < line.blocks.length; j++) {
+          let block = line.blocks[j];
           ctx.font = block.font;
           let [fontColor, strokeColor] = this._getColor(block.color, viewFontSize, block.strokeColor);
           if (block.strokeWidth > 0) {
@@ -440,7 +438,7 @@ class Label {
           ctx.fillText(block.text, x + width, yLine + block.vadjust);
           width += block.width;
         }
-        yLine += this.lines[i].height;
+        yLine += line.height;
       }
     }
   }
@@ -528,9 +526,7 @@ class Label {
    * @param {'middle'|'hanging'} [baseline='middle']
    */
   calculateLabelSize(ctx, selected, hover, x = 0, y = 0, baseline = 'middle') {
-    if (this.labelDirty === true) {
-      this._processLabel(ctx, selected, hover);
-    }
+    this._processLabel(ctx, selected, hover);
     this.size.left = x - this.size.width * 0.5;
     this.size.top = y - this.size.height * 0.5;
     this.size.yLine = y + (1 - this.lineCount) * 0.5 * this.fontOptions.size;
@@ -539,7 +535,6 @@ class Label {
       this.size.top += 4;   // distance from node, required because we use hanging. Hanging has less difference between browsers
       this.size.yLine += 4; // distance from node
     }
-    this.labelDirty = false;
   }
 
 
@@ -598,7 +593,7 @@ class Label {
    * @returns {boolean}
    */
   differentState(selected, hover) {
-    return ((selected !== this.fontOptions.selectedState) && (hover !== this.fontOptions.hoverState));
+    return ((selected !== this.selectedState) || (hover !== this.hoverState));
   }
    
 
@@ -626,6 +621,10 @@ class Label {
    * @private
    */
   _processLabel(ctx, selected, hover) {
+
+    if(this.labelDirty === false && !this.differentState(selected,hover))
+      return;
+    
     let state = this._processLabelText(ctx, selected, hover, this.elementOptions.label);
 
     if ((this.fontOptions.minWdt > 0) && (state.width < this.fontOptions.minWdt)) {
@@ -643,6 +642,8 @@ class Label {
     this.size.height = state.height;
     this.selectedState = selected;
     this.hoverState = hover;
+
+    this.labelDirty = false;
   }
 }
 

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -338,20 +338,25 @@ class Label {
     if (this.elementOptions.label && viewFontSize < this.elementOptions.scaling.label.drawThreshold - 1)
       return;
 
+    // This ensures that there will not be HUGE letters on screen
+    // by setting an upper limit on the visible text size (regardless of zoomLevel)
+    if (viewFontSize >= this.elementOptions.scaling.label.maxVisible) {
+      viewFontSize = Number(this.elementOptions.scaling.label.maxVisible) / this.body.view.scale;
+    }
+
     // update the size cache if required
     this.calculateLabelSize(ctx, selected, hover, x, y, baseline);
+    this._drawBackground(ctx, this.size.left, this.size.top);
+    this._drawText(ctx, x, this.size.yLine, baseline, viewFontSize);
 
-    this._drawBackground(ctx);  // create the fontfill background
-    this._drawText(ctx, x, y, baseline, viewFontSize);
   }
-
 
   /**
    * Draws the label background
    * @param {CanvasRenderingContext2D} ctx
    * @private
    */
-  _drawBackground(ctx) {
+  _drawBackground(ctx, x, y) {
     if (this.fontOptions.background !== undefined && this.fontOptions.background !== "none") {
       ctx.fillStyle = this.fontOptions.background;
 
@@ -369,11 +374,11 @@ class Label {
             ctx.fillRect(-this.size.width * 0.5, lineMargin, this.size.width, this.size.height);
             break;
           default:
-            ctx.fillRect(this.size.left, this.size.top - 0.5*lineMargin, this.size.width, this.size.height);
+            ctx.fillRect(x, y - 0.5*lineMargin, this.size.width, this.size.height);
             break;
         }
       } else {
-        ctx.fillRect(this.size.left, this.size.top - 0.5*lineMargin, this.size.width, this.size.height);
+        ctx.fillRect(x, y - 0.5*lineMargin, this.size.width, this.size.height);
       }
     }
   }
@@ -390,24 +395,17 @@ class Label {
    * @private
    */
   _drawText(ctx, x, y, baseline = 'middle', viewFontSize) {
- 
-    // This ensures that there will not be HUGE letters on screen
-    // by setting an upper limit on the visible text size (regardless of zoomLevel)
-    if (viewFontSize >= this.elementOptions.scaling.label.maxVisible) {
-      viewFontSize = Number(this.elementOptions.scaling.label.maxVisible) / this.body.view.scale;
-    }
 
-    let yLine = this.size.yLine;
-    [x, yLine] = this._setAlignment(ctx, x, yLine, baseline);
+    [x, y] = this._setAlignment(ctx, x, y, baseline);
 
     ctx.textAlign = 'left';
     x = x - this.size.width / 2; // Shift label 1/2-distance to the left
     if ((this.fontOptions.valign) && (this.size.height > this.size.labelHeight)) {
       if (this.fontOptions.valign === 'top') {
-        yLine -= (this.size.height - this.size.labelHeight) / 2;
+        y -= (this.size.height - this.size.labelHeight) / 2;
       }
       if (this.fontOptions.valign === 'bottom') {
-        yLine += (this.size.height - this.size.labelHeight) / 2;
+        y += (this.size.height - this.size.labelHeight) / 2;
       }
     }
 
@@ -433,12 +431,12 @@ class Label {
           ctx.fillStyle = fontColor;
 
           if (block.strokeWidth > 0) {
-            ctx.strokeText(block.text, x + width, yLine + block.vadjust);
+            ctx.strokeText(block.text, x + width, y + block.vadjust);
           }
-          ctx.fillText(block.text, x + width, yLine + block.vadjust);
+          ctx.fillText(block.text, x + width, y + block.vadjust);
           width += block.width;
         }
-        yLine += line.height;
+        y += line.height;
       }
     }
   }
@@ -447,26 +445,26 @@ class Label {
    *
    * @param {CanvasRenderingContext2D} ctx
    * @param {number} x
-   * @param {number} yLine
+   * @param {number} y
    * @param {string} baseline
    * @returns {Array.<number>}
    * @private
    */
-  _setAlignment(ctx, x, yLine, baseline) {
+  _setAlignment(ctx, x, y, baseline) {
     // check for label alignment (for edges)
     // TODO: make alignment for nodes
     if (this.isEdgeLabel && this.fontOptions.align !== 'horizontal' && this.pointToSelf === false) {
       x = 0;
-      yLine = 0;
+      y = 0;
 
       let lineMargin = 2;
       if (this.fontOptions.align === 'top') {
         ctx.textBaseline = 'alphabetic';
-        yLine -= 2 * lineMargin; // distance from edge, required because we use alphabetic. Alphabetic has less difference between browsers
+        y -= 2 * lineMargin; // distance from edge, required because we use alphabetic. Alphabetic has less difference between browsers
       }
       else if (this.fontOptions.align === 'bottom') {
         ctx.textBaseline = 'hanging';
-        yLine += 2 * lineMargin;// distance from edge, required because we use hanging. Hanging has less difference between browsers
+        y += 2 * lineMargin;// distance from edge, required because we use hanging. Hanging has less difference between browsers
       }
       else {
         ctx.textBaseline = 'middle';
@@ -475,7 +473,7 @@ class Label {
     else {
       ctx.textBaseline = baseline;
     }
-    return [x,yLine];
+    return [x,y];
   }
 
   /**


### PR DESCRIPTION
So the main issue with #3425 is onDrag was calling the synchronous _redraw instead of the aysnc _requestRedraw like the other interaction events. This didn't seem to be issue in Chrome but in IE it destroyed frame rate when dragging the view around.

The reason it didn't not cause an issue when physic simulation was still running is because the _redraw handler in CanvasRenderer does not actually call redraw if rendering is active.

The other changes to Label.js improve performance across the board based on profiling in IE and Chrome, which is where I started with the issue. I also cleaned up some code that was simply not correct and made it a little better for possible further optimizations in the future.