### PR TITLE
Network: Prevent image loading for hidden cluster nodes

### DIFF
--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -561,13 +561,32 @@ class LayoutEngine {
       if (positionDefined < 0.5 * indices.length) {
         let MAX_LEVELS = 10;
         let level = 0;
-        let clusterThreshold = 150;
-        // Performance enhancement, during clustering edges need only be simple straight lines.
+        let clusterThreshold = 150;  // TODO add this to options
+
+        //
+        // Define the options for the hidden cluster nodes
         // These options don't propagate outside the clustering phase.
+        //
+        // Some options are explicitly disabled, because they may be set in group or default node options.
+        // The clusters are never displayed, so most explicit settings here serve as performance optimizations.
+        //
+        // The explicit setting of 'shape' is to avoid `shape: 'image'`; images are not passed to the hidden
+        // cluster nodes, leading to an exception on creation.
+        //
+        // All settings here are performance related, except when noted otherwise.
+        //
         let clusterOptions = {
+          clusterNodeProperties:{
+            shape: 'ellipse',       // Bugfix: avoid type 'image', no images supplied
+            label: '',              // avoid label handling
+            group: '',              // avoid group handling
+            font: {multi: false},   // avoid font propagation
+          },
           clusterEdgeProperties:{
+            label: '',              // avoid label handling
+            font: {multi: false},   // avoid font propagation
             smooth: {
-              enabled: false
+              enabled: false        // avoid drawing penalty for complex edges
             }
           }
         };

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -35,7 +35,7 @@ class Label {
     // The node options have to mirror the globals when they are not overruled.
     this.fontOptions = util.deepExtend({},options.font, true);
 
-    if (options.label !== undefined) {
+    if (options.label !== undefined && options.label !== null && options.label !== '') {
       this.labelDirty = true;
     }
 


### PR DESCRIPTION
Fixes #3483.

If `shape: 'image'` was defined as option, this was used for initializing hidden cluster nodes during layout initialization. However, because no images were being passed, this led to an exception.

This fix prevents shape `image` from being used for hidden cluster nodes. In addition, some extra fields for these nodes are now overridden for some performance improvement.
