### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Install via bower:
 
     $ bower install vis
 
+Link via jsDelivr CDN:
+
+```
+<script src="https://cdn.jsdelivr.net/npm/vis@4/dist/vis.min.js"></script>
+```
+
 Link via cdnjs: http://cdnjs.com
 
 Or download the library from the github project:


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/vis) to your readme, so that people can use files directly without downloading them. jsDelivr is also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage.