### PR TITLE
Vertical Focus - Bugfix on Final Vertical Scroll Position

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -428,32 +428,38 @@ Timeline.prototype.focus = function(id, options) {
       }
     };
     
+    // Enforces the final vertical scroll position
+    var setFinalVerticalPosition = function() {
+      var finalVerticalScroll = getItemVerticalScroll(me, item);
+
+      if (finalVerticalScroll.shouldScroll && finalVerticalScroll.itemTop != initialVerticalScroll.itemTop) {
+        me._setScrollTop(-finalVerticalScroll.scrollOffset);
+        me._redraw();
+      }
+    };
+
     // Perform one last check at the end to make sure the final vertical
     // position is correct
     var finalVerticalCallback = function() {
-      var finalVerticalScroll = getItemVerticalScroll(me, item);
+      // Double check we ended at the proper scroll position
+      setFinalVerticalPosition();
 
-      if(finalVerticalScroll.shouldScroll && finalVerticalScroll.itemTop != initialVerticalScroll.itemTop) {              
-        me._setScrollTop(-finalVerticalScroll.scrollOffset);
-        me._redraw();        
-      }
+      // Let the redraw settle and finalize the position.      
+      setTimeout(setFinalVerticalPosition, 100);
     };
 
     // calculate the new middle and interval for the window
     var middle = (start + end) / 2;
-    var interval = Math.max((this.range.end - this.range.start), (end - start) * 1.1);
+    var interval = Math.max(this.range.end - this.range.start, (end - start) * 1.1);
 
-    var animation = (options && options.animation !== undefined) ? options.animation : true;
+    var animation = options && options.animation !== undefined ? options.animation : true;
 
-    if(!animation) {
+    if (!animation) {
       // We aren't animating so set a default so that the final callback forces the vertical location
-      initialVerticalScroll = {shouldScroll: false, scrollOffset: -1, itemTop: -1};    
+      initialVerticalScroll = { shouldScroll: false, scrollOffset: -1, itemTop: -1 };
     }
 
-    this.range.setRange(middle - interval / 2, middle + interval / 2, { animation: animation }, finalVerticalCallback, verticalAnimationFrame);
-
-    // Let the redraw settle and finalize the position
-    setTimeout(finalVerticalCallback, 100);
+    this.range.setRange(middle - interval / 2, middle + interval / 2, { animation: animation }, finalVerticalCallback, verticalAnimationFrame);  
   }
 };
 


### PR DESCRIPTION
Bugfix for #3504.

@yotamberk Sorry for the quick second pull request on this. I realized once I put everything back together that I made an error with where the `setTimeout` was located for ensuring the final scroll position. It works fine in the example, but a more complex timeline with a heavier redraw (like the one I have in my own project) needs to have this in the proper location.