### PR TITLE
Timeline: Added describe-sections to PointItem unit tests

### DIFF
--- a/test/PointItem.test.js
+++ b/test/PointItem.test.js
@@ -59,7 +59,10 @@ describe('Timeline PointItem', function () {
     assert(pointItem.isVisible(range));
   });
 
-  it('should redraw() and then not be dirty', function() {
+
+describe('should redraw() and then', function () {
+
+  it('not be dirty', function() {
     var pointItem = new PointItem({start: now.toDate()}, null, {editable: false});
     pointItem.setParent(TestSupport.buildMockItemSet());
     assert(pointItem.dirty);
@@ -67,7 +70,8 @@ describe('Timeline PointItem', function () {
     assert(!pointItem.dirty);
   });
 
-  it('should redraw() and then have point attached to its parent', function() {
+
+  it('have point attached to its parent', function() {
     var pointItem = new PointItem({start: now.toDate()}, null, {editable: false});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -76,7 +80,10 @@ describe('Timeline PointItem', function () {
     assert(parent.dom.foreground.hasChildNodes());
   });
 
-  it('should redraw() and then have the correct classname for a non-editable item', function() {
+
+describe('have the correct classname for', function() {
+
+  it('a non-editable item', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: false}, null, {editable: false});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -85,7 +92,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-readonly");
   });
 
-  it('should redraw() and then have the correct classname for an editable item (with object option)', function() {
+  it('an editable item (with object option)', function() {
     var pointItem = new PointItem({start: now.toDate()}, null, {editable: {updateTime: true, updateGroup: false}});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -94,7 +101,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-editable");
   });
 
-  it('should redraw() and then have the correct classname for an editable item (with boolean option)', function() {
+  it('an editable item (with boolean option)', function() {
     var pointItem = new PointItem({start: now.toDate()}, null, {editable: true});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -103,7 +110,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-editable");
   });
 
-  it('should redraw() and then have the correct classname for an editable:false override item (with boolean option)', function() {
+  it('an editable:false override item (with boolean option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: false}, null, {editable: true});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -112,7 +119,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-readonly");
   });
 
-  it('should redraw() and then have the correct classname for an editable:true override item (with boolean option)', function() {
+  it('an editable:true override item (with boolean option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: true}, null, {editable: false});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -121,7 +128,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-editable");
   });
 
-  it('should redraw() and then have the correct classname for an editable:false override item (with object option)', function() {
+  it('an editable:false override item (with object option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: false}, null, {editable: {updateTime: true, updateGroup: false}});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -130,7 +137,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-readonly");
   });
 
-  it('should redraw() and then have the correct classname for an editable:false override item (with object option for group change)', function() {
+  it('an editable:false override item (with object option for group change)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: false}, null, {editable: {updateTime: false, updateGroup: true}});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -139,7 +146,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-readonly");
   });
 
-  it('should redraw() and then have the correct classname for an editable:true override item (with object option)', function() {
+  it('an editable:true override item (with object option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: true}, null, {editable: {updateTime: false, updateGroup: false}});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -148,7 +155,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-editable");
   });
 
-  it('should redraw() and then have the correct classname for an editable:true non-override item (with object option)', function() {
+  it('an editable:true non-override item (with object option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: true}, null, {editable: {updateTime: false, updateGroup: false, overrideItems: true}});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -157,7 +164,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-readonly");
   });
 
-  it('should redraw() and then have the correct classname for an editable:false non-override item (with object option)', function() {
+  it('an editable:false non-override item (with object option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: false}, null, {editable: {updateTime: true, updateGroup: false, overrideItems: true}});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -166,7 +173,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.dom.point.className, "vis-item vis-point vis-editable");
   });
 
-  it('should redraw() and then have the correct property for an editable: {updateTime} override item (with boolean option)', function() {
+  it('an editable: {updateTime} override item (with boolean option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {updateTime: true}}, null, {editable: true});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -176,7 +183,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, undefined);
   });
 
-  it('should redraw() and then have the correct property for an editable: {updateTime} override item (with boolean option false)', function() {
+  it('an editable: {updateTime} override item (with boolean option false)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {updateTime: true}}, null, {editable: false});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -186,7 +193,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, undefined);
   });
 
-  it('should redraw() and then have the correct property for an editable: {updateGroup} override item (with boolean option)', function() {
+  it('an editable: {updateGroup} override item (with boolean option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {updateGroup: true}}, null, {editable: true});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -196,7 +203,12 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, undefined);
   });
 
-  it('should redraw() and then have the correct property for an editable: {updateGroup} override item (with boolean option false)', function() {
+}); // have the correct classname for
+
+
+describe('have the correct property for', function() {
+
+  it('an editable: {updateGroup} override item (with boolean option false)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {updateGroup: true}}, null, {editable: false});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -206,7 +218,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, undefined);
   });
 
-  it('should redraw() and then have the correct property for an editable: {remove} override item (with boolean option)', function() {
+  it('an editable: {remove} override item (with boolean option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {remove: true}}, null, {editable: true});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -216,7 +228,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, true);
   });
 
-  it('should redraw() and then have the correct property for an editable: {remove} override item (with boolean option false)', function() {
+  it('an editable: {remove} override item (with boolean option false)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {remove: true}}, null, {editable: false});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -226,7 +238,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, true);
   });
 
-  it('should redraw() and then have the correct property for an editable: {updateTime, remove} override item (with boolean option)', function() {
+  it('an editable: {updateTime, remove} override item (with boolean option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {updateTime: true, remove: true}}, null, {editable: true});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -236,7 +248,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, true);
   });
 
-  it('should redraw() and then have the correct property for an editable: {updateTime, remove} override item (with boolean option false)', function() {
+  it('an editable: {updateTime, remove} override item (with boolean option false)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {updateTime: true, remove: true}}, null, {editable: false});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -246,7 +258,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, true);
   });
 
-  it('should redraw() and then have the correct property for an editable: {updateTime, updateGroup, remove} override item (with boolean option)', function() {
+  it('an editable: {updateTime, updateGroup, remove} override item (with boolean option)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {updateTime: true, updateGroup: true, remove: true}}, null, {editable: true});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -256,7 +268,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.remove, true);
   });
 
-  it('should redraw() and then have the correct property for an editable: {updateTime, updateGroup, remove} override item (with boolean option false)', function() {
+  it('an editable: {updateTime, updateGroup, remove} override item (with boolean option false)', function() {
     var pointItem = new PointItem({start: now.toDate(), editable: {updateTime: true, updateGroup: true, remove: true}}, null, {editable: false});
     var parent = TestSupport.buildMockItemSet();
     pointItem.setParent(parent);
@@ -265,4 +277,7 @@ describe('Timeline PointItem', function () {
     assert.equal(pointItem.editable.updateGroup, true);
     assert.equal(pointItem.editable.remove, true);
   });
-});
+
+}); // have the correct property for
+});  // should redraw() and then
+});  // Timeline PointItem


### PR DESCRIPTION
Small fix on the unit tests for better output layout. Before the fix:

```
 Timeline PointItem
    ✓ should initialize with minimal data
    ✓ should have a default width of 0
    ✓ should error if there is missing data
    ✓ should be visible if the range is during
    ✓ should not be visible if the range is after
    ✓ should not be visible if the range is before
    ✓ should be visible for a "now" point with a default range
    ✓ should redraw() and then not be dirty
    ✓ should redraw() and then have point attached to its parent
    ✓ should redraw() and then have the correct classname for a non-editable item
    ✓ should redraw() and then have the correct classname for an editable item (with object option)
    ✓ should redraw() and then have the correct classname for an editable item (with boolean option)
    ✓ should redraw() and then have the correct classname for an editable:false override item (with boolean option)
    ✓ should redraw() and then have the correct classname for an editable:true override item (with boolean option)
    ✓ should redraw() and then have the correct classname for an editable:false override item (with object option)
    ✓ should redraw() and then have the correct classname for an editable:false override item (with object option for group change)
    ✓ should redraw() and then have the correct classname for an editable:true override item (with object option)
    ✓ should redraw() and then have the correct classname for an editable:true non-override item (with object option)
    ✓ should redraw() and then have the correct classname for an editable:false non-override item (with object option)
    ✓ should redraw() and then have the correct property for an editable: {updateTime} override item (with boolean option)
    ✓ should redraw() and then have the correct property for an editable: {updateTime} override item (with boolean option false)
    ✓ should redraw() and then have the correct property for an editable: {updateGroup} override item (with boolean option)
    ✓ should redraw() and then have the correct property for an editable: {updateGroup} override item (with boolean option false)
    ✓ should redraw() and then have the correct property for an editable: {remove} override item (with boolean option)
    ✓ should redraw() and then have the correct property for an editable: {remove} override item (with boolean option false)
    ✓ should redraw() and then have the correct property for an editable: {updateTime, remove} override item (with boolean option)
    ✓ should redraw() and then have the correct property for an editable: {updateTime, remove} override item (with boolean option false)
    ✓ should redraw() and then have the correct property for an editable: {updateTime, updateGroup, remove} override item (with boolean option)
    ✓ should redraw() and then have the correct property for an editable: {updateTime, updateGroup, remove} override item (with boolean option false)
```

With this fix:

```
Timeline PointItem
    ✓ should initialize with minimal data
    ✓ should have a default width of 0
    ✓ should error if there is missing data
    ✓ should be visible if the range is during
    ✓ should not be visible if the range is after
    ✓ should not be visible if the range is before
    ✓ should be visible for a "now" point with a default range
    should redraw() and then
      ✓ not be dirty
      ✓ have point attached to its parent
      have the correct classname for
        ✓ a non-editable item
        ✓ an editable item (with object option)
        ✓ an editable item (with boolean option)
        ✓ an editable:false override item (with boolean option)
        ✓ an editable:true override item (with boolean option)
        ✓ an editable:false override item (with object option)
        ✓ an editable:false override item (with object option for group change)
        ✓ an editable:true override item (with object option)
        ✓ an editable:true non-override item (with object option)
        ✓ an editable:false non-override item (with object option)
        ✓ an editable: {updateTime} override item (with boolean option)
        ✓ an editable: {updateTime} override item (with boolean option false)
        ✓ an editable: {updateGroup} override item (with boolean option)
      have the correct property for
        ✓ an editable: {updateGroup} override item (with boolean option false)
        ✓ an editable: {remove} override item (with boolean option)
        ✓ an editable: {remove} override item (with boolean option false)
        ✓ an editable: {updateTime, remove} override item (with boolean option)
        ✓ an editable: {updateTime, remove} override item (with boolean option false)
        ✓ an editable: {updateTime, updateGroup, remove} override item (with boolean option)
        ✓ an editable: {updateTime, updateGroup, remove} override item (with boolean option false)
```