### PR TITLE
Network: Add extra check on null value during label handling

### DIFF
--- a/lib/network/modules/components/Edge.js
+++ b/lib/network/modules/components/Edge.js
@@ -1,11 +1,11 @@
 var util = require('../../../util');
-
 var Label = require('./shared/Label').default;
 var ComponentUtil = require('./shared/ComponentUtil').default;
 var CubicBezierEdge = require('./edges/CubicBezierEdge').default;
 var BezierEdgeDynamic = require('./edges/BezierEdgeDynamic').default;
 var BezierEdgeStatic = require('./edges/BezierEdgeStatic').default;
 var StraightEdge = require('./edges/StraightEdge').default;
+
 
 /**
  * An edge connects two nodes and has a specific direction.
@@ -118,7 +118,6 @@ class Edge {
       'from',
       'hidden',
       'hoverWidth',
-      'label',
       'labelHighlightBold',
       'length',
       'line',
@@ -137,6 +136,13 @@ class Edge {
 
     // only deep extend the items in the field array. These do not have shorthand.
     util.selectiveDeepExtend(fields, parentOptions, newOptions, allowDeletion);
+
+    // Only copy label if it's a legal value.
+    if (ComponentUtil.isValidLabel(newOptions.label)) {
+      parentOptions.label = newOptions.label;
+    } else {
+      parentOptions.label = undefined;
+    }
 
     util.mergeOptions(parentOptions, newOptions, 'smooth', globalOptions);
     util.mergeOptions(parentOptions, newOptions, 'shadow', globalOptions);

--- a/lib/network/modules/components/shared/ComponentUtil.js
+++ b/lib/network/modules/components/shared/ComponentUtil.js
@@ -131,11 +131,8 @@ class ComponentUtil {
    * @returns {boolean} true if valid label value, false otherwise
    */
   static isValidLabel(text) {
-    if (text === undefined || text === "" || text === null || typeof text !== 'string') {
-      return false;
-    }
-
-    return true;
+    // Note that this is quite strict: types that *might* be converted to string are disallowed
+    return  (typeof text === 'string' && text !== '');
   }
 }
 

--- a/lib/network/modules/components/shared/ComponentUtil.js
+++ b/lib/network/modules/components/shared/ComponentUtil.js
@@ -122,6 +122,21 @@ class ComponentUtil {
       bottom    > point.y
     );
   }
+
+
+  /**
+   * Check if given value is acceptable as a label text.
+   *
+   * @param {*} text value to check; can be anything at this point
+   * @returns {boolean} true if valid label value, false otherwise
+   */
+  static isValidLabel(text) {
+    if (text === undefined || text === "" || text === null || typeof text !== 'string') {
+      return false;
+    }
+
+    return true;
+  }
 }
 
 export default ComponentUtil;

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -64,8 +64,11 @@ class Label {
 
     this.initFontOptions(options.font);
 
-    if (options.label !== undefined && options.label !== null && options.label !== '') {
+    if (ComponentUtil.isValidLabel(options.label)) {
       this.labelDirty = true;
+    } else {
+      // Bad label! Change the option value to prevent bad stuff happening
+      options.label = '';
     }
 
     if (options.font !== undefined && options.font !== null) { // font options can be deleted at various levels

--- a/lib/network/modules/components/shared/LabelSplitter.js
+++ b/lib/network/modules/components/shared/LabelSplitter.js
@@ -1,4 +1,5 @@
 let LabelAccumulator = require('./LabelAccumulator').default;
+let ComponentUtil = require('./ComponentUtil').default;
 
 
 /**
@@ -67,7 +68,7 @@ class LabelSplitter {
    * @returns {Array<line>}
    */
   process(text) {
-    if (text === undefined || text === "") {
+    if (!ComponentUtil.isValidLabel(text)) {
       return this.lines.finalize();
     }
 

--- a/test/Label.test.js
+++ b/test/Label.test.js
@@ -1326,7 +1326,6 @@ describe('Shorthand Font Options', function() {
 
     done();
   });
-
 });  // Multi-Fonts
 
 
@@ -1404,6 +1403,76 @@ describe('Shorthand Font Options', function() {
     options.font.multi = true;
     var label = new Label({}, options);
     checkProcessedLabels(label, text, expected);
+
+    done();
+  });
+
+
+  it('deals with null labels and other awkward values', function (done) {
+    var ctx = new DummyContext();
+    var options = getOptions({});
+
+    var nodes = [
+      {id:1},
+      {id:2, label: null},
+      {id:3, label: undefined},
+      {id:4, label: {a: 42}},
+      {id:5, label: [ 'an', 'array']},
+    ];
+
+    var edges = [
+      {from: 1, to: 2, label: null},
+      {from: 1, to: 3, label: undefined},
+      {from: 1, to: 4, label: {a: 42}},
+      {from: 1, to: 4, label: ['an', 'array']},
+    ];
+
+    // Isolate the specific call where a problem with null-label was detected
+    // Following loops should plain not throw
+
+
+    // Node labels
+    for (let i = 0; i < nodes.length; ++i) {
+      let label = new Label(null, nodes[i], false);
+      assert.doesNotThrow(() => {label.getTextSize(ctx, false, false)}, "Unexpected throw for node " + i);
+      //label.getTextSize(ctx, false, false);  // Use this to determine the error thrown
+
+      // There should not be a label for any of the cases
+      // 
+      let labelVal = label.elementOptions.label;
+      let notEmptyLabel = (typeof labelVal === 'string' && labelVal !== '');
+      assert(!notEmptyLabel, "Unexpected label value '" + labelVal+ "' for node " + i);
+    }
+
+
+    // Edge labels
+    for (let i = 0; i < edges.length; ++i) {
+      let label = new Label(null, edges[i], true);
+      assert.doesNotThrow(() => {label.getTextSize(ctx, false, false)}, "Unexpected throw for edge " + i);
+      //label.getTextSize(ctx, false, false);  // Use this to determine the error thrown
+
+      // There should not be a label for any of the cases
+      // 
+      let labelVal = label.elementOptions.label;
+      let notEmptyLabel = (typeof labelVal === 'string' && labelVal !== '');
+      assert(!notEmptyLabel, "Unexpected label value '" + labelVal+ "' for edge " + i);
+    }
+
+
+    //
+    // Following extracted from example 'nodeLegend', where the problem was detected.
+    // 
+    // In the example, only `label:null` was present. The weird thing is that it fails
+    // in the example, but succeeds in the unit tests.
+    // Kept in for regression testing.
+    var container = document.getElementById('mynetwork');
+    var data = {
+      nodes: new vis.DataSet(nodes),
+      edges: new vis.DataSet(edges)
+    };
+
+    var options = {};
+    var network = new vis.Network(container, data, options);
 
     done();
   });

--- a/test/Label.test.js
+++ b/test/Label.test.js
@@ -1412,19 +1412,34 @@ describe('Shorthand Font Options', function() {
     var ctx = new DummyContext();
     var options = getOptions({});
 
+    var checkHandling = (label, index, text) => {
+      assert.doesNotThrow(() => {label.getTextSize(ctx, false, false)}, "Unexpected throw for " + text + " " + index);
+      //label.getTextSize(ctx, false, false);  // Use this to determine the error thrown
+
+      // There should not be a label for any of the cases
+      // 
+      let labelVal = label.elementOptions.label;
+      let validLabel = (typeof labelVal === 'string' && labelVal !== '');
+      assert(!validLabel, "Unexpected label value '" + labelVal+ "' for " + text +" " + index);
+    };
+
     var nodes = [
-      {id:1},
-      {id:2, label: null},
-      {id:3, label: undefined},
-      {id:4, label: {a: 42}},
-      {id:5, label: [ 'an', 'array']},
+      {id: 1},
+      {id: 2, label: null},
+      {id: 3, label: undefined},
+      {id: 4, label: {a: 42}},
+      {id: 5, label: [ 'an', 'array']},
+      {id: 6, label: true},
+      {id: 7, label: 3.419},
     ];
 
     var edges = [
       {from: 1, to: 2, label: null},
       {from: 1, to: 3, label: undefined},
       {from: 1, to: 4, label: {a: 42}},
-      {from: 1, to: 4, label: ['an', 'array']},
+      {from: 1, to: 5, label: ['an', 'array']},
+      {from: 1, to: 6, label: false},
+      {from: 1, to: 7, label: 2.71828},
     ];
 
     // Isolate the specific call where a problem with null-label was detected
@@ -1434,28 +1449,14 @@ describe('Shorthand Font Options', function() {
     // Node labels
     for (let i = 0; i < nodes.length; ++i) {
       let label = new Label(null, nodes[i], false);
-      assert.doesNotThrow(() => {label.getTextSize(ctx, false, false)}, "Unexpected throw for node " + i);
-      //label.getTextSize(ctx, false, false);  // Use this to determine the error thrown
-
-      // There should not be a label for any of the cases
-      // 
-      let labelVal = label.elementOptions.label;
-      let notEmptyLabel = (typeof labelVal === 'string' && labelVal !== '');
-      assert(!notEmptyLabel, "Unexpected label value '" + labelVal+ "' for node " + i);
+      checkHandling(label, i, 'node');
     }
 
 
     // Edge labels
     for (let i = 0; i < edges.length; ++i) {
       let label = new Label(null, edges[i], true);
-      assert.doesNotThrow(() => {label.getTextSize(ctx, false, false)}, "Unexpected throw for edge " + i);
-      //label.getTextSize(ctx, false, false);  // Use this to determine the error thrown
-
-      // There should not be a label for any of the cases
-      // 
-      let labelVal = label.elementOptions.label;
-      let notEmptyLabel = (typeof labelVal === 'string' && labelVal !== '');
-      assert(!notEmptyLabel, "Unexpected label value '" + labelVal+ "' for edge " + i);
+      checkHandling(label, i, 'edge');
     }
 
 


### PR DESCRIPTION
This fixes an oversight in #3486.
Also added unit tests, not only for null labels, but for all weird label values I could thing of.
