### PR TITLE
Item Redraw Performance - Bug Fix

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -300,7 +300,7 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
         }
       }
 
-      util.forEach(this.items, function (item, key) {
+      util.forEach(this.items, function (item) {
         item.repositionX(limitSize);
       });
 

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -300,9 +300,9 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
         }
       }
 
-      for (i = 0; i < this.items.length; i++) {
-        this.items[i].repositionX(limitSize);
-      }
+      util.forEach(this.items, function (item, key) {
+        item.repositionX(limitSize);
+      });
 
       if (this.doInnerStack && this.itemSet.options.stackSubgroups) {
         // Order the items within each subgroup


### PR DESCRIPTION
This is in reference to #3475, specifically my comment made on 10/1/2017 regarding the performance enhancement causing the vertical position of items to jump around while scrolling horizontally. The issue was due to the calls being made to `repositionX` on each item not happening. The `item` collection on the `Group` class are an object, not an array, so the normal `for` loop wasn't doing anything. Changed it to use the utility `forEach` method which seems to have resolved the issue.