### PR TITLE
Fix jittering border top

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -884,7 +884,7 @@ Core.prototype._redraw = function() {
   // calculate border widths
   props.border.left   = (dom.centerContainer.offsetWidth - dom.centerContainer.clientWidth) / 2;
   props.border.right  = props.border.left;
-  props.border.top    = (dom.centerContainer.offsetHeight - dom.centerContainer.clientHeight) / 2;
+  props.border.top    = Math.ceil((dom.centerContainer.offsetHeight - dom.centerContainer.clientHeight) / 2);
   props.border.bottom = props.border.top;
   props.borderRootHeight= dom.root.offsetHeight - dom.root.clientHeight;
   props.borderRootWidth = dom.root.offsetWidth - dom.root.clientWidth;


### PR DESCRIPTION
There was a jittering top border occurring due to using a 0.5 px causing a render to jitter. 
I'm not opening an issue to this because it's a really small bug and a really easy solution. 