### PR TITLE
Week scale - enhance and add to auto-scaling

### DIFF
--- a/examples/timeline/styling/weekStyling.html
+++ b/examples/timeline/styling/weekStyling.html
@@ -26,7 +26,21 @@
     of moment.js including locales.</p>
 <p>To set a locale for the timeline, specify the option
     <code>{locale: STRING}</code>.</p>
-<p>To set the scale to use week numbers, use for example <code>{scale: 'week', step: 1}</code>.</p>
+<p>
+  To set the scale to use week numbers, use the following options:
+  <code>
+    {
+      timeAxis: {
+        scale: 'week',
+        step: 1
+      },
+      format: {
+        minorLabels: {week: 'w'}
+      }
+    }
+  </code>
+</p>
+
 <p>The following timeline is initialized with the 'de' locale and items are added with locally localized moment.js
     objects. The timeline locale can be switched to another locale at runtime. If you choose the 'en' locale, the week
     numbers will be calculated according to the US week calendar numbering scheme.</p>
@@ -93,7 +107,16 @@
     }
 
     // Configuration for the Timeline
-    var options = {timeAxis: {scale: 'week', step: 1}, locale: 'de'};
+    var options = {
+      locale: 'de',
+      timeAxis: {
+        scale: 'week',
+        step: 1
+      },
+      format: {
+        minorLabels: {week: 'w'}
+      }
+    };
 
     // Create a Timeline
     var timeline = new vis.Timeline(container, items, groups, options);

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -73,7 +73,7 @@ TimeStep.FORMAT = {
     hour:       'HH:mm',
     weekday:    'ddd D',
     day:        'D',
-    week:       'w',
+    week:       'D',
     month:      'MMM',
     year:       'YYYY'
   },
@@ -324,7 +324,7 @@ TimeStep.prototype.setMinimumStep = function(minimumStep) {
   if (stepYear > minimumStep)             {this.scale = 'year';        this.step = 1;}
   if (stepMonth*3 > minimumStep)          {this.scale = 'month';       this.step = 3;}
   if (stepMonth > minimumStep)            {this.scale = 'month';       this.step = 1;}
-  if (stepDay*5 > minimumStep)            {this.scale = 'day';         this.step = 5;}
+  if (stepDay*5 > minimumStep)            {this.scale = 'week';        this.step = 1;}
   if (stepDay*2 > minimumStep)            {this.scale = 'day';         this.step = 2;}
   if (stepDay > minimumStep)              {this.scale = 'day';         this.step = 1;}
   if (stepDay/2 > minimumStep)            {this.scale = 'weekday';     this.step = 1;}

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -222,7 +222,23 @@ TimeStep.prototype.next = function() {
       break;
     case 'weekday':      // intentional fall through
     case 'day':          this.current.add(this.step, 'day'); break;
-    case 'week':         this.current.add(this.step, 'week'); break;
+    case 'week':
+      if (this.current.weekday() !== 0){ // we had a month break not correlating with a week's start before
+        this.current.weekday(0); // switch back to week cycles
+        this.current.add(this.step, 'week');
+      } else if(this.options.showMajorLabels === false) {
+        this.current.add(this.step, 'week'); // the default case
+      } else { // first day of the week
+        var nextWeek = this.current.clone();
+        nextWeek.add(1, 'week');
+        if(nextWeek.isSame(this.current, 'month')){ // is the first day of the next week in the same month?
+          this.current.add(this.step, 'week'); // the default case
+        } else { // inject a step at each first day of the month
+          this.current.add(this.step, 'week');
+          this.current.date(1);
+        }
+      }
+      break;
     case 'month':        this.current.add(this.step, 'month'); break;
     case 'year':         this.current.add(this.step, 'year'); break;
     default: break;
@@ -532,7 +548,7 @@ TimeStep.prototype.isMajor = function() {
     case 'day':
       return (date.date() == 1);
     case 'week':
-      return (Math.ceil(date.date() / 7) == 1); // is 1st week in the month?
+      return (date.date() == 1);
     case 'month':
       return (date.month() == 0);
     case 'year':

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -340,7 +340,7 @@ TimeStep.prototype.setMinimumStep = function(minimumStep) {
   if (stepYear > minimumStep)             {this.scale = 'year';        this.step = 1;}
   if (stepMonth*3 > minimumStep)          {this.scale = 'month';       this.step = 3;}
   if (stepMonth > minimumStep)            {this.scale = 'month';       this.step = 1;}
-  if (stepDay*5 > minimumStep)            {this.scale = 'week';        this.step = 1;}
+  if (stepDay*7 > minimumStep)            {this.scale = 'week';        this.step = 1;}
   if (stepDay*2 > minimumStep)            {this.scale = 'day';         this.step = 2;}
   if (stepDay > minimumStep)              {this.scale = 'day';         this.step = 1;}
   if (stepDay/2 > minimumStep)            {this.scale = 'weekday';     this.step = 1;}

--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -222,23 +222,7 @@ TimeStep.prototype.next = function() {
       break;
     case 'weekday':      // intentional fall through
     case 'day':          this.current.add(this.step, 'day'); break;
-    case 'week':
-      if (this.current.weekday() !== 0){ // we had a month break not correlating with a week's start before
-        this.current.weekday(0); // switch back to week cycles
-        this.current.add(this.step, 'week');
-      } else if(this.options.showMajorLabels === false) {
-        this.current.add(this.step, 'week'); // the default case
-      } else { // first day of the week
-        var nextWeek = this.current.clone();
-        nextWeek.add(1, 'week');
-        if(nextWeek.isSame(this.current, 'month')){ // is the first day of the next week in the same month?
-          this.current.add(this.step, 'week'); // the default case
-        } else { // inject a step at each first day of the month
-          this.current.add(this.step, 'week');
-          this.current.date(1);
-        }
-      }
-      break;
+    case 'week':         this.current.add(this.step, 'week'); break;
     case 'month':        this.current.add(this.step, 'month'); break;
     case 'year':         this.current.add(this.step, 'year'); break;
     default: break;
@@ -548,7 +532,7 @@ TimeStep.prototype.isMajor = function() {
     case 'day':
       return (date.date() == 1);
     case 'week':
-      return (date.date() == 1);
+      return (Math.ceil(date.date() / 7) == 1); // is 1st week in the month?
     case 'month':
       return (date.month() == 0);
     case 'year':


### PR DESCRIPTION
**Changes:**
* ~~Makes the week scale more consistent and removes clutter:~~
  * ~~next() always adds 1 week to current date~~
  * ~~move majorLabels to the 1st week in the month~~
* Add week to auto-scaling (zooming)
  * replaces 5 days scale

**Screenshots:**
Before this PR: (**keep this behavior**)
![week_scale_orig](https://user-images.githubusercontent.com/3659829/31429865-72b981c8-ae6f-11e7-9ac0-67c7f5ad2c76.png)

~~After this PR:~~ (**reverted**)
![week_scale_new](https://user-images.githubusercontent.com/3659829/31429947-b4f626d6-ae6f-11e7-804a-4ec39bb2abeb.png)

**Live examples:**
* [weekStyling](http://rawgit.com/knokit/vis/feature/week-scale-dist/examples/timeline/styling/weekStyling.html)
* [basicUsage](http://rawgit.com/knokit/vis/feature/week-scale-dist/examples/timeline/basicUsage.html) - zoom can be tested with this example
