### PR TITLE
Network: Relax condition for adding already clustered nodes to cluster

### DIFF
--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -524,20 +524,25 @@ class ClusterEngine {
   * @private
   */
   _cluster(childNodesObj, childEdgesObj, options, refreshData = true) {
+    // Remove nodes which are already clustered
+    var tmpNodesToRemove = []
+    for (let nodeId in childNodesObj) {
+      if (childNodesObj.hasOwnProperty(nodeId)) {
+        if (this.clusteredNodes[nodeId] !== undefined) {
+          tmpNodesToRemove.push(nodeId);
+        }
+      }
+    }
+
+    for (var n = 0; n < tmpNodesToRemove.length; ++n) {
+      delete childNodesObj[tmpNodesToRemove[n]];
+    }
+
     // kill condition: no nodes don't bother
     if (Object.keys(childNodesObj).length == 0) {return;}
 
     // allow clusters of 1 if options allow
     if (Object.keys(childNodesObj).length == 1 && options.clusterNodeProperties.allowSingleNodeCluster != true) {return;}
-
-    // check if this cluster call is not trying to cluster anything that is in another cluster.
-    for (let nodeId in childNodesObj) {
-      if (childNodesObj.hasOwnProperty(nodeId)) {
-        if (this.clusteredNodes[nodeId] !== undefined) {
-          return;
-        }
-      }
-    }
 
     let clusterNodeProperties = util.deepExtend({},options.clusterNodeProperties);
 


### PR DESCRIPTION
Previous condition was too strict: if *any* node for the cluster was already clustered, the clustering would abort.

Current fix removes already clustered nodes and proceeds to cluster with what is left.
