### PR TITLE
Network: fit() should not change the passed options

### DIFF
--- a/lib/network/modules/View.js
+++ b/lib/network/modules/View.js
@@ -49,6 +49,7 @@ class View {
   fit(options = {nodes:[]}, initialZoom = false) {
     let range;
     let zoomLevel;
+    options = Object.assign({}, options);
     if (options.nodes === undefined || options.nodes.length === 0) {
       options.nodes = this.body.nodeIndices;
     }

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -352,6 +352,23 @@ describe('Network', function () {
   });
 
 
+  /**
+   * This is a fix on one issue (#3543), but in fact **all* options for all API calls should
+   * remain unchanged.
+   * TODO: extend test for all API calls with options, see #3548
+   */
+  it('does not change the options object passed to fit()', function() {
+    var [network, data, numNodes, numEdges] = createSampleNetwork({});
+    var options = {};
+    network.fit(options);
+
+    // options should still be empty
+    for (var prop in options) {
+      assert(!options.hasOwnProperty(prop), 'No properties should be present in options, detected property: ' + prop);
+    }
+  });
+
+
 describe('Node', function () {
 
   it('has known font options', function () {


### PR DESCRIPTION
Fixes #3543.

None of the options passed in any of the API calls should change the options. This has been registered with issue #3548.
