### PR TITLE
Network: Prevent crash when dataChanged is triggered during initialization

### DIFF
--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -463,8 +463,7 @@ class EdgesHandler {
   _addMissingEdges() {
      let edgesData = this.body.data.edges;
      if (edgesData === undefined || edgesData === null) {
-       // No edges DataSet yet; can happen on processing options
-       return;
+       return;  // No edges DataSet yet; can happen on startup 
      }
 
      let edges = this.body.edges;

--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -461,8 +461,13 @@ class EdgesHandler {
    * @private
    */ 
   _addMissingEdges() {
-     let edges = this.body.edges;
      let edgesData = this.body.data.edges;
+     if (edgesData === undefined || edgesData === null) {
+       // No edges DataSet yet; can happen on processing options
+       return;
+     }
+
+     let edges = this.body.edges;
      let addIds = [];
 
      edgesData.forEach((edgeData, edgeId) => {

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -369,6 +369,27 @@ describe('Network', function () {
   });
 
 
+  it('does not crash when dataChanged is triggered when setting options on first initialization ', function() {
+    // The init should succeed without an error thrown.
+    var options = {
+      nodes: {
+        physics: false   // any value here triggered the error 
+      }
+    };
+    createSampleNetwork(options);
+
+    // Do the other values as well that can cause this./
+    // 'any values' applies here as well, expecting no throw
+    options = {edges: {physics: false}};
+    createSampleNetwork(options);
+
+    options = {nodes: {hidden: false}};
+    createSampleNetwork(options);
+
+    options = {edges: {hidden: false}};
+    createSampleNetwork(options);
+  });
+
 describe('Node', function () {
 
   it('has known font options', function () {


### PR DESCRIPTION
Fixes #3562.

Options `hidden` and `physics` can emit a `_dataChanged` event within `setOptions()`.
If this happens when setting options during the initialization of the `Network` instance, this leads
to an error thrown, because there is no DataSet instance  connected yet to the instance.

This bug was introduced in `v4.21.0`. Unit tests have been added for this case.