### PR TITLE
Network: preload images in options for all shape types

### DIFF
--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -146,19 +146,20 @@ class Node {
   /**
    * Load the images from the options, for the nodes that need them.
    *
-   * TODO: The imageObj members should be moved to CircularImageBase.
-   *       It's the only place where they are required.
+   * Images are always loaded, even if they are not used in the current shape.
+   * The user may switch to an image shape later on.
    *
    * @private
    */
   _load_images() {
-    // Don't bother loading for nodes without images
-    if (this.options.shape !== 'circularImage' && this.options.shape !== 'image') {
-      return;
+    if (this.options.shape === 'circularImage' || this.options.shape === 'image') {
+      if (this.options.image === undefined) {
+        throw new Error("Option image must be defined for node type '" + this.options.shape + "'");
+      }
     }
 
     if (this.options.image === undefined) {
-      throw new Error("Option image must be defined for node type '" + this.options.shape + "'");
+      return;
     }
 
     if (this.imagelist === undefined) {


### PR DESCRIPTION
Fixes #3532.

If the `image` option is set, preload it, even if the node shape is not `image` or `circularImage`.
This needs to be done because the user can switch to an image shape later, as is happening in the issue.
Option `image` is only mandatory for the image shapes.

There is no unit test for this, because it would need a mock object for `Image` and I didn't succeed in creating/finding one.
