### PR TITLE
Network: Handle null data gracefully

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -154,6 +154,10 @@ Emitter(Network.prototype);
  * @param {Object} options
  */
 Network.prototype.setOptions = function (options) {
+  if (options === null) {
+    options = undefined;  // This ensures that options handling doesn't crash in the handling
+  }
+
   if (options !== undefined) {
     let errorFound = Validator.validate(options, allOptions);
     if (errorFound === true) {

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -146,19 +146,20 @@ class Node {
   /**
    * Load the images from the options, for the nodes that need them.
    *
-   * TODO: The imageObj members should be moved to CircularImageBase.
-   *       It's the only place where they are required.
+   * Images are always loaded, even if they are not used in the current shape.
+   * The user may switch to an image shape later on.
    *
    * @private
    */
   _load_images() {
-    // Don't bother loading for nodes without images
-    if (this.options.shape !== 'circularImage' && this.options.shape !== 'image') {
-      return;
+    if (this.options.shape === 'circularImage' || this.options.shape === 'image') {
+      if (this.options.image === undefined) {
+        throw new Error("Option image must be defined for node type '" + this.options.shape + "'");
+      }
     }
 
     if (this.options.image === undefined) {
-      throw new Error("Option image must be defined for node type '" + this.options.shape + "'");
+      return;
     }
 
     if (this.imagelist === undefined) {

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -395,6 +395,25 @@ describe('Network', function () {
     createSampleNetwork(options);
   });
 
+
+  it('can deal with null data', function() {
+    // While we're at it, try out other silly values as well
+    // All the following are wrong, but none should lead to a crash
+    var awkwardData = [
+      null,
+      [1,2,3],
+      42,
+      'meow'
+    ];
+
+    var container = document.getElementById('mynetwork');
+
+    for (var n = 0; n < awkwardData.length; ++n) {
+      var network = new vis.Network(container, awkwardData[n], {});  // Should not throw
+    }
+  });
+
+
 describe('Node', function () {
 
   it('has known font options', function () {


### PR DESCRIPTION
During testing I discovered that passing `null` for network data leads to a thrown error.
This adds a guard to prevent it, plus unit tests for regression.
