### PR TITLE
Network: Set version of FontAwesome to latest stable 4.7.0

### DIFF
--- a/examples/network/nodeStyles/customGroups.html
+++ b/examples/network/nodeStyles/customGroups.html
@@ -20,7 +20,7 @@
 
     <script type="text/javascript" src="../../../dist/vis.js"></script>
     <link href="../../../dist/vis-network.min.css" rel="stylesheet" type="text/css"/>
-    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 
     
 </head>

--- a/examples/network/nodeStyles/icons.html
+++ b/examples/network/nodeStyles/icons.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 
 <head>
@@ -8,7 +8,7 @@
   <script type="text/javascript" src="../../../dist/vis.js"></script>
   <link href="../../../dist/vis-network.min.css" rel="stylesheet" type="text/css" />
 
-  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="http://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
 
   <style>


### PR DESCRIPTION
Bumped up the version number in the examples using `FontAwesome`, in order to avoid confusion about missing (new) icons as in #3408.
