### PR TITLE
Timeline: Fix for majorLabels showing wrong dates

### DIFF
--- a/lib/timeline/TimeStep.js
+++ b/lib/timeline/TimeStep.js
@@ -279,7 +279,7 @@ TimeStep.prototype.next = function() {
  * @return {Moment}  current The current date
  */
 TimeStep.prototype.getCurrent = function() {
-  return this.current;
+  return this.current.clone();
 };
 
 /**

--- a/lib/timeline/component/TimeAxis.js
+++ b/lib/timeline/component/TimeAxis.js
@@ -222,16 +222,14 @@ TimeAxis.prototype._repaintLabels = function () {
   dom.majorTexts = [];
   dom.minorTexts = [];
 
-  var current;  // eslint-disable-line no-unused-vars
+  var current;
   var next;
   var x;
   var xNext;
   var isMajor;
-  var nextIsMajor;  // eslint-disable-line no-unused-vars
   var showMinorGrid;
   var width = 0, prevWidth;
   var line;
-  var labelMinor;
   var xFirstMajorLabel = undefined;
   var count = 0;
   const MAX = 1000;
@@ -245,14 +243,12 @@ TimeAxis.prototype._repaintLabels = function () {
 
     isMajor = step.isMajor();
     className = step.getClassName();
-    labelMinor = step.getLabelMinor();
 
     current = next;
     x = xNext;
 
     step.next();
     next = step.getCurrent();
-    nextIsMajor = step.isMajor();
     xNext = this.body.util.toScreen(next);
 
     prevWidth = width;
@@ -263,7 +259,7 @@ TimeAxis.prototype._repaintLabels = function () {
     }
 
     if (this.options.showMinorLabels && showMinorGrid) {
-      var label = this._repaintMinorText(x, labelMinor, orientation, className);
+      var label = this._repaintMinorText(x, step.getLabelMinor(current), orientation, className);
       label.style.width = width + 'px'; // set width to prevent overflow
     }
 
@@ -272,7 +268,7 @@ TimeAxis.prototype._repaintLabels = function () {
         if (xFirstMajorLabel == undefined) {
           xFirstMajorLabel = x;
         }
-        label = this._repaintMajorText(x, step.getLabelMajor(), orientation, className);
+        label = this._repaintMajorText(x, step.getLabelMajor(current), orientation, className);
       }
       line = this._repaintMajorLine(x, width, orientation, className);
     }
@@ -427,7 +423,7 @@ TimeAxis.prototype._repaintMinorLine = function (x, width, orientation, classNam
   }
   line.style.width = width + 'px';
 
-  
+
 
   return line;
 };


### PR DESCRIPTION
_majorLabels_ were being rendered with wrong date (rendered date of the next step in the scale).

**Screenshot of the issue:** (check it live [here](https://jsfiddle.net/knokit/4y30hrjb/))
![timeline_majorlabels](https://user-images.githubusercontent.com/3659829/31574286-9c7bc89a-b0cc-11e7-95d2-5074651ecfb8.png)

**Changes:**
* ``TimeStep.getCurrent()`` returns a clone of current date, in order to avoid accidental modifications outside of TimeStep class
* Removed some unused variables from ``TimeAxis._repaintLabels()`` and render ``majorLabels`` with the correct date