### PR TITLE
Adds code coverage report the output of `npm test` and adds detailed …

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "main": "./dist/vis.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register",
+    "test": "nyc mocha --compilers js:babel-core/register",
+    "test-cov": "nyc --reporter=html mocha --compilers js:babel-core/register",
     "build": "gulp",
     "lint": "gulp lint",
     "watch": "gulp watch",
@@ -63,6 +64,7 @@
     "merge-stream": "^1.0.1",
     "mocha": "^3.4.2",
     "mocha-jsdom": "^1.1.0",
+    "nyc": "^11.2.1",
     "rimraf": "^2.6.1",
     "test-console": "^1.0.0",
     "uglify-js": "^2.8.29",

--- a/test/DataSet.test.js
+++ b/test/DataSet.test.js
@@ -1,8 +1,8 @@
 var assert = require('assert');
-var vis = require('../dist/vis');
-var moment = vis.moment;
-var DataSet = vis.DataSet;
-var Queue = vis.Queue;
+
+var DataSet = require('../lib/DataSet');
+var Queue = require('../lib/Queue');
+
 // TODO: test the source code immediately, but this is ES6
 
 var now = new Date();

--- a/test/DataView.test.js
+++ b/test/DataView.test.js
@@ -1,8 +1,7 @@
 var assert = require('assert');
-var vis = require('../dist/vis');
-var moment = vis.moment;
-var DataSet = vis.DataSet;
-var DataView = vis.DataView;
+
+var DataSet = require('../lib/DataSet');
+var DataView = require('../lib/DataView');
 // TODO: test the source code immediately, but this is ES6
 
 // TODO: improve DataView tests, split up in one test per function

--- a/test/Graph3d.test.js
+++ b/test/Graph3d.test.js
@@ -1,6 +1,5 @@
 var assert = require('assert');
-var vis = require('../dist/vis');
-var Graph3d = vis.Graph3d;
+var Graph3d = require('../lib/graph3d/Graph3d');
 var jsdom_global = require('jsdom-global');
 var canvasMockify = require('./canvas-mock');
 var stdout = require('test-console').stdout;
@@ -56,7 +55,7 @@ describe('Graph3d', function () {
       style: 'dot'
     };
 
-    var graph = new vis.Graph3d(this.container, data, options);
+    var graph = new Graph3d(this.container, data, options);
     assert.equal(graph.style, DOT_STYLE, "Style not set to expected 'dot'");
 
     graph.setOptions({ style: 'bar'});  // Call should just work, no exception thrown

--- a/test/Label.test.js
+++ b/test/Label.test.js
@@ -8,14 +8,14 @@
  *   Currently, only "size[px] name color" is valid, always 3 items with this exact spacing.
  *   All other combinations should either be rejected as error or handled gracefully.
  */
-var assert = require('assert')
+var assert = require('assert');
 var Label = require('../lib/network/modules/components/shared/Label').default;
 var NodesHandler = require('../lib/network/modules/NodesHandler').default;
 var util = require('../lib/util');
 var jsdom_global = require('jsdom-global');
 var canvasMockify = require('./canvas-mock');
-var vis = require('../dist/vis');
-var Network = vis.network;
+var DataSet = require('../lib/DataSet');
+var Network = require('../lib/network/Network');
 
 
 /**************************************************************
@@ -477,7 +477,7 @@ describe('Node Labels', function() {
     // create a network
     var container = document.getElementById('mynetwork');
     var data = {
-        nodes: new vis.DataSet(dataNodes),
+        nodes: new DataSet(dataNodes),
         edges: []
     };
   
@@ -501,7 +501,7 @@ describe('Node Labels', function() {
       util.deepExtend(options, newOptions);
     }
   
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
     return [network, data, options];
   }
 
@@ -678,8 +678,8 @@ describe('Edge Labels', function() {
     // create a network
     var container = document.getElementById('mynetwork');
     var data = {
-        nodes: new vis.DataSet(dataNodes),
-        edges: new vis.DataSet(dataEdges),
+        nodes: new DataSet(dataNodes),
+        edges: new DataSet(dataEdges),
     };
   
     var options = {
@@ -694,7 +694,7 @@ describe('Edge Labels', function() {
       util.deepExtend(options, newOptions);
     }
   
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
     return [network, data, options];
   }
 
@@ -823,8 +823,8 @@ describe('Shorthand Font Options', function() {
     // create a network
     var container = document.getElementById('mynetwork');
     var data = {
-        nodes: new vis.DataSet(dataNodes),
-        edges: new vis.DataSet(dataEdges),
+        nodes: new DataSet(dataNodes),
+        edges: new DataSet(dataEdges),
     };
 
     var options = {
@@ -847,7 +847,7 @@ describe('Shorthand Font Options', function() {
       }
     };
   
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
     return [network, data];
   }
 
@@ -1114,7 +1114,7 @@ describe('Shorthand Font Options', function() {
     // create a network
     var container = document.getElementById('mynetwork');
     var data = {
-        nodes: new vis.DataSet(dataNodes),
+        nodes: new DataSet(dataNodes),
         edges: []
     };
   
@@ -1145,7 +1145,7 @@ describe('Shorthand Font Options', function() {
       },
     };
   
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
 
     assert.equal(modBold(1).color, 'red');  // Group value
     assert(fontOption(1).multi);            // Group value
@@ -1487,7 +1487,7 @@ describe('Shorthand Font Options', function() {
         enabled: false
       }
     };
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
 
     var nodes_expected = [
       { nodeId: 100, minWdt:  -1, maxWdt: 200, minHgt:  -1, valign: 'middle'},
@@ -1614,12 +1614,12 @@ describe('Shorthand Font Options', function() {
     // Kept in for regression testing.
     var container = document.getElementById('mynetwork');
     var data = {
-      nodes: new vis.DataSet(nodes),
-      edges: new vis.DataSet(edges)
+      nodes: new DataSet(nodes),
+      edges: new DataSet(edges)
     };
 
     var options = {};
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
 
     done();
   });

--- a/test/Network.test.js
+++ b/test/Network.test.js
@@ -12,8 +12,8 @@
  */
 var fs = require('fs');
 var assert = require('assert');
-var vis = require('../dist/vis');
-var Network = vis.network;
+var DataSet = require('../lib/DataSet');
+var Network = require('../lib/network/Network');
 var stdout = require('test-console').stdout;
 var Validator = require("./../lib/shared/Validator").default;
 var jsdom_global = require('jsdom-global');
@@ -78,7 +78,7 @@ function createSampleNetwork(options) {
   var NumInitialNodes = 8;
   var NumInitialEdges = 6;
 
-  var nodes = new vis.DataSet([
+  var nodes = new DataSet([
       {id: 1, label: '1'},
       {id: 2, label: '2'},
       {id: 3, label: '3'},
@@ -88,7 +88,7 @@ function createSampleNetwork(options) {
       {id: 13, label: '13'},
       {id: 14, label: '14'},
   ]);
-  var edges = new vis.DataSet([
+  var edges = new DataSet([
       {from: 1, to: 2},
       {from: 2, to: 3},
       {from: 3, to: 4},
@@ -117,7 +117,7 @@ function createSampleNetwork(options) {
 
   options = merge(defaultOptions, options);
 
-  var network = new vis.Network(container, data, options);
+  var network = new Network(container, data, options);
 
   assertNumNodes(network, NumInitialNodes);
   assertNumEdges(network, NumInitialEdges);
@@ -409,7 +409,7 @@ describe('Network', function () {
     var container = document.getElementById('mynetwork');
 
     for (var n = 0; n < awkwardData.length; ++n) {
-      var network = new vis.Network(container, awkwardData[n], {});  // Should not throw
+      var network = new Network(container, awkwardData[n], {});  // Should not throw
     }
   });
 
@@ -517,14 +517,14 @@ describe('Edge', function () {
    * Support routine for next unit test
    */
   function createDataforColorChange() {
-    var nodes = new vis.DataSet([
+    var nodes = new DataSet([
       {id: 1, label: 'Node 1' }, // group:'Group1'},
       {id: 2, label: 'Node 2', group:'Group2'},
       {id: 3, label: 'Node 3'},
     ]);
 
     // create an array with edges
-    var edges = new vis.DataSet([
+    var edges = new DataSet([
       {id: 1, from: 1, to: 2},
       {id: 2, from: 1, to: 3, color: { inherit: 'to'}},
       {id: 3, from: 3, to: 3, color: { color: '#00FF00'}},
@@ -556,7 +556,7 @@ describe('Edge', function () {
     };
 
     // Test passing options on init.
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
     var edges = network.body.edges;
     assert.equal(edges[1].options.color.inherit, 'to');   // new default
     assert.equal(edges[2].options.color.inherit, 'to');   // set in edge
@@ -574,7 +574,7 @@ describe('Edge', function () {
     assert.equal(edges[4].options.color.inherit, 'from');  // set in edge
 
     // Check no options
-    network = new vis.Network(container, data, {});
+    network = new Network(container, data, {});
     edges = network.body.edges;
     assert.equal(edges[1].options.color.inherit, 'from');  // default
     assert.equal(edges[2].options.color.inherit, 'to');    // set in edge
@@ -605,7 +605,7 @@ describe('Edge', function () {
     var data =  createDataforColorChange();
 
     // Check no options
-    var network = new vis.Network(container, data, {});
+    var network = new Network(container, data, {});
     var edges = network.body.edges;
     assert.equal(edges[1].options.color.inherit, 'from');  // default
     assert.equal(edges[2].options.color.inherit, 'to');    // set in edge
@@ -636,7 +636,7 @@ describe('Edge', function () {
     };
 
     // Test passing options on init.
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
     var edges = network.body.edges;
     assert.equal(edges[1].options.color.color, color);
     assert.equal(edges[1].options.color.inherit, false);  // Explicit color, so no inherit
@@ -655,7 +655,7 @@ describe('Edge', function () {
     assert.equal(edges[4].options.color.color, defaultColor);
 
     // Check no options
-    network = new vis.Network(container, data, {});
+    network = new Network(container, data, {});
     edges = network.body.edges;
     // At this point, color has not changed yet
     assert.equal(edges[1].options.color.color, defaultColor);
@@ -680,10 +680,10 @@ describe('Edge', function () {
   it('has reconnected edges', function () {
     var node1 = {id:1, label:"test1"};
     var node2 = {id:2, label:"test2"};
-    var nodes = new vis.DataSet([node1, node2]);
+    var nodes = new DataSet([node1, node2]);
   
     var edge = {id:1, from: 1, to:2};
-    var edges = new vis.DataSet([edge]);
+    var edges = new DataSet([edge]);
 
     var data = {
         nodes: nodes,
@@ -691,7 +691,7 @@ describe('Edge', function () {
     };    
 
     var container = document.getElementById('mynetwork');
-    var network = new vis.Network(container, data);
+    var network = new Network(container, data);
 
     //remove node causing edge to become disconnected
     nodes.remove(node2.id);
@@ -893,7 +893,7 @@ describe('Clustering', function () {
    */
   function createOutlierGraph() {
     // create an array with nodes
-    var nodes = new vis.DataSet([
+    var nodes = new DataSet([
       {id: 1, label: '1', group:'Group1'},
       {id: 2, label: '2', group:'Group2'},
       {id: 3, label: '3', group:'Group3'},
@@ -902,7 +902,7 @@ describe('Clustering', function () {
     ]);
 
     // create an array with edges
-    var edges = new vis.DataSet([
+    var edges = new DataSet([
       {from: 1, to: 3},
       {from: 1, to: 2},
       {from: 2, to: 4},
@@ -924,7 +924,7 @@ describe('Clustering', function () {
       }
     };
 
-    var network = new vis.Network (container, data, options);
+    var network = new Network (container, data, options);
 
     return network;
   }
@@ -1320,8 +1320,8 @@ describe('runs example ', function () {
 
     // create a network
     var data = {
-      nodes: new vis.DataSet(nodes),
-      edges: new vis.DataSet(edges)
+      nodes: new DataSet(nodes),
+      edges: new DataSet(edges)
     };
 
     if (noPhysics) {
@@ -1330,7 +1330,7 @@ describe('runs example ', function () {
       options.physics = false;
     }
 
-    var network = new vis.Network(container, data, options);
+    var network = new Network(container, data, options);
     return network;
   };
 

--- a/test/PointItem.test.js
+++ b/test/PointItem.test.js
@@ -1,10 +1,8 @@
 var assert = require('assert');
-var vis = require('../dist/vis');
 var jsdom = require('mocha-jsdom');
-var moment = vis.moment;
-var timeline = vis.timeline;
+var moment = require('../lib/module/moment');
 var PointItem = require("../lib/timeline/component/item/PointItem");
-var Range = timeline.Range;
+var Range = require('../lib/timeline/Range');
 var TestSupport = require('./TestSupport');
 
 describe('Timeline PointItem', function () {

--- a/test/TestSupport.js
+++ b/test/TestSupport.js
@@ -1,5 +1,4 @@
-var vis = require('../dist/vis');
-var DataSet = vis.DataSet;
+var DataSet = require('../lib/DataSet');
 
 module.exports = {
   buildMockItemSet: function() {
@@ -35,8 +34,8 @@ module.exports = {
       },
       hiddenDates: [],
       util: {}
-    }
-    body.dom.rollingModeBtn = document.createElement('div')
+    };
+    body.dom.rollingModeBtn = document.createElement('div');
     return body
   }
-}
+};

--- a/test/TimeStep.test.js
+++ b/test/TimeStep.test.js
@@ -1,9 +1,7 @@
 var assert = require('assert');
-var vis = require('../dist/vis');
-var jsdom = require('mocha-jsdom')
-var moment = vis.moment;
-var timeline = vis.timeline;
-var TimeStep = timeline.TimeStep;
+var jsdom = require('mocha-jsdom');
+var moment = require('../lib/module/moment');
+var TimeStep = require('../lib/timeline/TimeStep');
 var TestSupport = require('./TestSupport');
 
 describe('TimeStep', function () {

--- a/test/TimelineItemSet.test.js
+++ b/test/TimelineItemSet.test.js
@@ -1,16 +1,19 @@
 var assert = require('assert');
-var vis = require('../dist/vis');
+var DataSet = require('../lib/DataSet');
+var DateUtil = require('../lib/timeline/DateUtil');
+var Range = require('../lib/timeline/Range');
+var ItemSet = require('../lib/timeline/component/ItemSet');
+
 
 describe('Timeline ItemSet', function () {
   before(function () {
-    delete require.cache[require.resolve('../dist/vis')]
     this.jsdom = require('jsdom-global')();
-    this.vis = require('../dist/vis');
-    var TestSupport = require('./TestSupport');
-    var rangeBody = TestSupport.buildSimpleTimelineRangeBody();
-    this.testrange = new this.vis.timeline.Range(rangeBody);
+    this.TestSupport = require('./TestSupport');
+
+    var rangeBody = this.TestSupport.buildSimpleTimelineRangeBody();
+    this.testrange = new Range(rangeBody);
     this.testrange.setRange(new Date(2017, 1, 26, 13, 26, 3, 320), new Date(2017, 1, 26, 13, 26, 4, 320), false, false, null);
-    this.testitems =  new this.vis.DataSet({
+    this.testitems =  new DataSet({
       type: {
         start: 'Date',
         end: 'Date'
@@ -19,11 +22,11 @@ describe('Timeline ItemSet', function () {
     // add single items with different date types
     this.testitems.add({id: 1, content: 'Item 1', start: new Date(2017, 1, 26, 13, 26, 3, 600), type: 'point'});
     this.testitems.add({id: 2, content: 'Item 2', start: new Date(2017, 1, 26, 13, 26, 5, 600), type: 'point'});
-  })
+  });
 
   after(function () {
     this.jsdom();
-  })
+  });
 
   var getBasicBody = function() {
     var body = {
@@ -57,20 +60,20 @@ describe('Timeline ItemSet', function () {
       },
       util: {
       }
-    }
+    };
     return body;
   };
 
   it('should initialise with minimal data', function () {
     var body = getBasicBody();
-    var itemset = new this.vis.timeline.components.ItemSet(body, {});
+    var itemset = new ItemSet(body, {});
     assert(itemset);
   });
 
   it('should redraw() and have the right classNames', function () {
     var body = getBasicBody();
     body.range = this.testrange;
-    var itemset = new this.vis.timeline.components.ItemSet(body, {});
+    var itemset = new ItemSet(body, {});
     itemset.redraw();
     assert.equal(itemset.dom.frame.className, 'vis-itemset');
     assert.equal(itemset.dom.background.className, 'vis-background');
@@ -81,14 +84,13 @@ describe('Timeline ItemSet', function () {
 
   it('should start with no items', function () {
     var body = getBasicBody();
-    var itemset = new this.vis.timeline.components.ItemSet(body, {});
+    var itemset = new ItemSet(body, {});
     assert.equal(itemset.getItems(), null);
   });
 
   it('should store items correctly', function() {
     var body = getBasicBody();
     body.range = this.testrange;
-    var DateUtil = this.vis.timeline.DateUtil;
     body.util.toScreen = function(time) {
       return DateUtil.toScreen({
         body: {
@@ -101,7 +103,7 @@ describe('Timeline ItemSet', function () {
         }
       }, time, 900)
     };
-    var itemset = new this.vis.timeline.components.ItemSet(body, {});
+    var itemset = new ItemSet(body, {});
     itemset.setItems(this.testitems);
     assert.equal(itemset.getItems().length, 2);
     assert.deepEqual(itemset.getItems(), this.testitems);

--- a/test/TimelineItemSet.test.js
+++ b/test/TimelineItemSet.test.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var vis = require('../dist/vis');
 
 describe('Timeline ItemSet', function () {
   before(function () {

--- a/test/TimelineRange.test.js
+++ b/test/TimelineRange.test.js
@@ -1,9 +1,7 @@
 var assert = require('assert');
-var vis = require('../dist/vis');
-var jsdom = require('mocha-jsdom')
-var moment = vis.moment;
-var timeline = vis.timeline;
-var Range = timeline.Range;
+var jsdom = require('mocha-jsdom');
+var moment = require('../lib/module/moment');
+var Range = require('../lib/timeline/Range');
 var TestSupport = require('./TestSupport');
 
 describe('Timeline Range', function () {


### PR DESCRIPTION
…html code coverage report using the command `npm run-script test-cov`

Added to test output is a table showing test coverage output:
```bash
---------------------------------------------|----------|----------|----------|----------|----------------|
File                                         |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------------------------------------|----------|----------|----------|----------|----------------|
All files                                    |    45.82 |    35.42 |    42.66 |    46.16 |                |
 lib                                         |    67.55 |    58.24 |    58.04 |    67.62 |                |
  DataSet.js                                 |    74.33 |    64.41 |    80.77 |    74.26 |... 879,920,925 |
  DataView.js                                |    83.02 |    66.67 |    58.33 |    83.02 |... 292,293,295 |
  Queue.js                                   |    96.92 |    90.63 |      100 |    96.92 |         73,135 |
  hammerUtil.js                              |       50 |        0 |    28.57 |       50 |... 59,61,63,66 |
  util.js                                    |    57.07 |    51.44 |    48.28 |    56.86 |... 6,1578,1580 |
 lib/graph3d                                 |    51.29 |    33.48 |    50.72 |    52.15 |                |
  Camera.js                                  |    89.87 |       50 |    90.91 |    94.59 |   40,43,56,115 |
  DataGroup.js                               |    67.25 |    47.96 |       65 |    69.09 |... 487,495,496 |
  Filter.js                                  |    15.29 |        0 |        0 |    15.66 |... 206,209,210 |
  Graph3d.js                                 |    49.35 |    23.03 |    52.13 |    49.68 |... 7,2390,2391 |
  Point2d.js                                 |      100 |       50 |      100 |      100 |            7,8 |
  Point3d.js                                 |    42.31 |      100 |       50 |    42.31 |... 65,66,67,69 |
  Range.js                                   |    80.77 |    78.57 |    83.33 |       84 |    43,44,60,69 |
  Settings.js                                |    71.76 |    58.02 |    93.33 |    73.23 |... 430,448,449 |
  Slider.js                                  |    13.69 |        0 |        0 |    14.65 |... 343,344,346 |
  StepNumber.js                              |    84.21 |     62.5 |    90.91 |    83.33 |... 138,154,161 |
  options.js                                 |      100 |      100 |      100 |      100 |                |
 lib/module                                  |    45.36 |    33.78 |    63.64 |    44.09 |                |
  hammer.js                                  |    66.67 |       25 |      100 |    66.67 |       27,28,29 |
  moment.js                                  |      100 |    66.67 |      100 |      100 |              3 |
  uuid.js                                    |    42.53 |    32.84 |    42.86 |    40.96 |... 191,203,204 |
 lib/network                                 |     52.1 |    54.73 |     25.4 |     54.2 |                |
  CachedImage.js                             |        0 |        0 |        0 |        0 |... 146,147,153 |
  Images.js                                  |    14.29 |        0 |       25 |    15.15 |... 108,109,110 |
  Network.js                                 |    61.31 |       60 |    16.44 |    70.43 |... 539,540,542 |
  NetworkUtil.js                             |    93.88 |    72.73 |        0 |    93.02 |       10,41,75 |
  dotparser.js                               |    70.22 |    64.36 |    54.29 |    70.22 |... 936,937,940 |
  gephiParser.js                             |     2.33 |        0 |        0 |      2.5 |... 63,64,65,68 |
  locales.js                                 |      100 |      100 |      100 |      100 |                |
  options.js                                 |      100 |      100 |      100 |      100 |                |
  shapes.js                                  |     0.72 |     7.14 |        0 |     0.73 |... 286,287,289 |
 lib/network/modules                         |    52.92 |    39.09 |    62.28 |    52.83 |                |
  Canvas.js                                  |    67.74 |    55.29 |    17.65 |    72.83 |... 432,454,463 |
  CanvasRenderer.js                          |       50 |    36.14 |    53.85 |    49.36 |... 399,400,405 |
  Clustering.js                              |    68.31 |    58.73 |    96.55 |    69.47 |... 1,1369,1385 |
  EdgesHandler.js                            |    75.71 |    68.14 |       60 |    76.47 |... 418,419,421 |
  Groups.js                                  |    86.49 |    77.78 |      100 |    86.49 | 91,92,93,94,95 |
  InteractionHandler.js                      |    12.41 |     0.68 |    16.67 |    12.46 |... 716,717,718 |
  KamadaKawai.js                             |    96.86 |    58.62 |      100 |    96.43 | 31,32,33,35,36 |
  LayoutEngine.js                            |    72.61 |    52.39 |    74.42 |    72.42 |... 4,1706,1726 |
  ManipulationSystem.js                      |     12.2 |        5 |     8.33 |    12.05 |... 8,1239,1240 |
  NodesHandler.js                            |    55.17 |    46.23 |    66.67 |    55.23 |... 505,506,509 |
  PhysicsEngine.js                           |    73.82 |    64.54 |    71.43 |    74.07 |... 786,787,788 |
  SelectionHandler.js                        |     7.96 |     2.78 |      100 |     7.99 |... 850,851,854 |
  View.js                                    |    51.06 |     36.9 |       50 |    53.08 |... 279,289,297 |
 lib/network/modules/components              |    44.53 |    46.42 |    17.14 |    45.51 |                |
  DirectionStrategy.js                       |    32.65 |    32.14 |       50 |     37.5 |... 233,234,239 |
  Edge.js                                    |    48.72 |       50 |      100 |    47.02 |... 731,741,748 |
  NavigationHandler.js                       |    16.88 |    14.29 |      6.9 |    19.51 |... 269,270,271 |
  Node.js                                    |    60.18 |    50.63 |      100 |    59.81 |... 646,648,650 |
 lib/network/modules/components/algorithms   |      100 |    85.71 |      100 |      100 |                |
  FloydWarshall.js                           |      100 |    85.71 |      100 |      100 |             38 |
 lib/network/modules/components/edges        |       20 |    17.21 |       80 |    21.08 |                |
  BezierEdgeDynamic.js                       |       65 |    63.33 |      100 |    66.67 |... 163,174,189 |
  BezierEdgeStatic.js                        |     2.08 |     1.39 |      100 |     2.27 |... 199,200,202 |
  CubicBezierEdge.js                         |     2.63 |        0 |        0 |     3.03 |... 113,114,116 |
  StraightEdge.js                            |     7.69 |       25 |      100 |     7.69 |... 80,81,83,98 |
 lib/network/modules/components/edges/util   |     6.41 |     0.77 |    66.67 |     6.65 |                |
  BezierEdgeBase.js                          |     3.17 |     3.13 |      100 |     3.33 |... 146,147,155 |
  CubicBezierEdgeBase.js                     |        4 |        0 |        0 |     4.55 |... 52,54,55,58 |
  EdgeBase.js                                |     8.44 |        0 |      100 |      8.7 |... 590,591,592 |
  EndPoints.js                               |        0 |        0 |      100 |        0 |... 222,223,226 |
 lib/network/modules/components/nodes        |    93.55 |     62.5 |      100 |    93.33 |                |
  Cluster.js                                 |    93.55 |     62.5 |      100 |    93.33 |          38,41 |
 lib/network/modules/components/nodes/shapes |     25.1 |    28.91 |    33.33 |     25.1 |                |
  Box.js                                     |    52.17 |    91.67 |      100 |    52.17 |... 56,82,83,85 |
  Circle.js                                  |    65.22 |       75 |      100 |    65.22 |... 57,58,81,82 |
  CircularImage.js                           |     3.03 |        0 |        0 |     3.03 |... ,96,107,108 |
  Database.js                                |     5.56 |        0 |        0 |     5.56 |... 54,56,57,67 |
  Diamond.js                                 |       25 |        0 |        0 |       25 |       16,30,40 |
  Dot.js                                     |       40 |       50 |      100 |       40 |       30,40,41 |
  Ellipse.js                                 |    36.36 |    91.67 |      100 |    36.36 |... 67,68,69,70 |
  Hexagon.js                                 |       25 |        0 |        0 |       25 |       16,30,40 |
  Icon.js                                    |    35.14 |    27.78 |      100 |    35.14 |... 109,111,123 |
  Image.js                                   |     2.63 |        0 |        0 |     2.63 |... 107,108,119 |
  Square.js                                  |       25 |        0 |        0 |       25 |       16,30,40 |
  Star.js                                    |       25 |        0 |        0 |       25 |       16,30,40 |
  Text.js                                    |     6.25 |        0 |        0 |     6.25 |... 52,56,58,68 |
  Triangle.js                                |       25 |        0 |        0 |       25 |       16,30,40 |
  TriangleDown.js                            |       25 |        0 |        0 |       25 |       16,30,40 |
 lib/network/modules/components/nodes/util   |    41.95 |    32.56 |      100 |    41.95 |                |
  CircleImageBase.js                         |    11.32 |    11.11 |      100 |    11.32 |... 185,186,188 |
  NodeBase.js                                |    53.76 |    35.71 |      100 |    53.76 |... 200,202,204 |
  ShapeBase.js                               |    60.71 |    63.64 |      100 |    60.71 |... 58,59,60,63 |
 lib/network/modules/components/physics      |     73.2 |    54.33 |     62.5 |    72.34 |                |
  BarnesHutSolver.js                         |    84.21 |    76.12 |      100 |     83.7 |... 480,481,482 |
  CentralGravitySolver.js                    |      100 |       50 |      100 |      100 |             54 |
  FA2BasedCentralGravitySolver.js            |    14.29 |        0 |        0 |    14.29 |... 29,30,31,32 |
  FA2BasedRepulsionSolver.js                 |     7.69 |        0 |        0 |     7.69 |... 40,41,43,44 |
  HierarchicalRepulsionSolver.js             |    96.67 |    66.67 |      100 |    96.67 |             62 |
  HierarchicalSpringSolver.js                |    59.65 |        0 |      100 |    59.65 |... 77,79,80,81 |
  RepulsionSolver.js                         |        0 |        0 |        0 |        0 |... 73,74,75,76 |
  SpringSolver.js                            |      100 |    72.22 |      100 |      100 | 40,42,53,82,87 |
 lib/network/modules/components/shared       |    76.88 |    69.18 |      100 |    77.31 |                |
  ComponentUtil.js                           |       50 |    46.15 |      100 |       50 |... 115,116,118 |
  Label.js                                   |    60.07 |    52.58 |      100 |       60 |... 791,792,795 |
  LabelAccumulator.js                        |    98.68 |    88.64 |      100 |      100 |... 124,177,195 |
  LabelSplitter.js                           |    91.15 |    85.02 |      100 |    91.73 |... 393,401,425 |
 lib/shared                                  |    15.78 |    18.73 |     2.33 |    16.39 |                |
  Activator.js                               |    18.33 |        0 |        0 |    18.33 |... 149,151,153 |
  ColorPicker.js                             |     1.06 |        0 |        0 |     1.12 |... 562,565,566 |
  Configurator.js                            |     0.57 |        0 |        0 |      0.6 |... 729,730,732 |
  Popup.js                                   |        0 |        0 |        0 |        0 |... 120,121,128 |
  Validator.js                               |    91.18 |     87.5 |       50 |    92.54 |... 164,167,181 |
 lib/timeline                                |    26.95 |    15.39 |    27.63 |    25.29 |                |
  DateUtil.js                                |     9.39 |     5.38 |    18.75 |     9.58 |... 507,508,511 |
  Range.js                                   |    27.05 |    17.15 |    22.22 |    28.45 |... 886,888,893 |
  Stack.js                                   |    15.38 |     1.08 |    36.36 |    15.38 |... 269,274,289 |
  TimeStep.js                                |    39.86 |    22.82 |    36.36 |    36.59 |... 723,724,726 |
 lib/timeline/component                      |    33.97 |    13.85 |    31.07 |    34.37 |                |
  BackgroundGroup.js                         |       90 |       50 |      100 |       90 |          41,42 |
  Component.js                               |       80 |       25 |       40 |       80 |       19,20,30 |
  Group.js                                   |    43.92 |    26.51 |    48.21 |    44.39 |... 926,927,928 |
  ItemSet.js                                 |    27.92 |     8.85 |    20.35 |    28.23 |... 7,2378,2381 |
 lib/timeline/component/item                 |    30.88 |     18.6 |    28.26 |    31.12 |                |
  BackgroundItem.js                          |    22.89 |        0 |        0 |    22.89 |... 229,230,233 |
  BoxItem.js                                 |    10.97 |        0 |        0 |    11.41 |... 341,349,357 |
  Item.js                                    |    38.84 |    33.73 |       40 |    38.99 |... 500,508,516 |
  PointItem.js                               |    83.51 |    52.27 |    88.89 |    83.51 |... 257,258,261 |
  RangeItem.js                               |    11.25 |        0 |        0 |    11.25 |... 385,386,388 |
---------------------------------------------|----------|----------|----------|----------|----------------|
```
And the html code coverage is a much more detailed:

Index:
<img width="1207" alt="screen shot 2017-10-14 at 8 10 37 pm" src="https://user-images.githubusercontent.com/1480524/31580378-0d7f9248-b11c-11e7-9823-73888c7116bb.png">

Individual file:
<img width="843" alt="screen shot 2017-10-14 at 8 12 17 pm" src="https://user-images.githubusercontent.com/1480524/31580379-1608d8c0-b11c-11e7-9d12-58301176a663.png">

My hope is that after this merges, we can look at adding something to the build process, to show code coverage report diffs for each incoming PR (Using codecov.io or something similar).

I find this very useful for identifying where I should target to add more unit tests, and to verify how well we're testing things. Based on the current state of the report, I'd say we have some work to do. 