### PR TITLE
Fixes issue 3397 - Updates url for gephi's json exporter plugin

### DIFF
--- a/docs/network/index.html
+++ b/docs/network/index.html
@@ -1564,7 +1564,7 @@ Thus, to get the topmost item, get the value at index 0.
 
         <p>
             Network can import data straight from an exported json file from gephi. You can get the JSON exporter here:
-            <a href="https://marketplace.gephi.org/plugin/json-exporter/" target="_blank">https://marketplace.gephi.org/plugin/json-exporter/</a>.
+            <a href="https://gephi.org/plugins/#/plugin/jsonexporter-plugin" target="_blank">https://gephi.org/plugins/#/plugin/jsonexporter-plugin</a>.
             An example exists showing how to get a JSON file into Vis:
         </p>
 

--- a/examples/network/data/importingFromGephi.html
+++ b/examples/network/data/importingFromGephi.html
@@ -63,7 +63,7 @@
   options available for the import are
   available through the checkboxes. You can download the Gephi JSON exporter
   here:
-  <a href="https://marketplace.gephi.org/plugin/json-exporter/" target="_blank">https://marketplace.gephi.org/plugin/json-exporter/</a>.
+  <a href="https://gephi.org/plugins/#/plugin/jsonexporter-plugin" target="_blank">https://gephi.org/plugins/#/plugin/jsonexporter-plugin</a>.
   All of Gephi's attributes are also contained within the node elements. This
   means you can access all of this data through the DataSet.
   <br/>


### PR DESCRIPTION
Not sure how this commit was reverted, but here it is again.

Should I make this PR against master & develop as well?