### PR TITLE
Fix currentTimeTick table in docs

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1568,6 +1568,7 @@ timeline.off('select', onSelect);
 
     <tr>
       <td>currentTimeTick</td>
+      <td>Has no properties</td>
       <td>Fired when the current time bar redraws. The rate depends on the zoom level.</td>
     </tr>
 


### PR DESCRIPTION
Noticed that this event was missing a column in the table, so fixed it.