### PR TITLE
Prevent items from being repeatedly redrawn while off screen

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -282,9 +282,9 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
       var redrawQueueLength = 0;
 
       util.forEach(this.items, function (item, key) {
-        if (!item.displayed) {
+        if (!item.displayed && (item.isVisible(range) || !item.dom)) {
           var returnQueue = true;
-          redrawQueue[key] = item.redraw(returnQueue);
+          redrawQueue[key] = item.show(returnQueue);
           redrawQueueLength = redrawQueue[key].length;
           me.visibleItems.push(item);
         }
@@ -301,7 +301,9 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
       }
 
       util.forEach(this.items, function (item) {
-        item.repositionX(limitSize);
+        if(item.displayed) {
+          item.repositionX(limitSize);
+        }
       });
 
       if (this.doInnerStack && this.itemSet.options.stackSubgroups) {

--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -228,9 +228,9 @@ BoxItem.prototype.redraw = function(returnQueue) {
  * Show the item in the DOM (when not already displayed). The items DOM will
  * be created when needed.
  */
-BoxItem.prototype.show = function() {
+BoxItem.prototype.show = function(returnQueue) {
   if (!this.displayed) {
-    this.redraw();
+    return this.redraw(returnQueue);
   }
 };
 

--- a/lib/timeline/component/item/BoxItem.js
+++ b/lib/timeline/component/item/BoxItem.js
@@ -225,8 +225,10 @@ BoxItem.prototype.redraw = function(returnQueue) {
 };
 
 /**
- * Show the item in the DOM (when not already displayed). The items DOM will
+ * Show the item in the DOM (when not already visible). The items DOM will
  * be created when needed.
+ * @param {boolean} [returnQueue=false]  whether to return a queue of functions to execute instead of just executing them
+ * @return {boolean} the redraw queue if returnQueue=true
  */
 BoxItem.prototype.show = function(returnQueue) {
   if (!this.displayed) {

--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -208,9 +208,9 @@ PointItem.prototype.redraw = function(returnQueue) {
  * Show the item in the DOM (when not already visible). The items DOM will
  * be created when needed.
  */
-PointItem.prototype.show = function() {
+PointItem.prototype.show = function(returnQueue) {
   if (!this.displayed) {
-    this.redraw();
+    return this.redraw(returnQueue);
   }
 };
 

--- a/lib/timeline/component/item/PointItem.js
+++ b/lib/timeline/component/item/PointItem.js
@@ -207,6 +207,8 @@ PointItem.prototype.redraw = function(returnQueue) {
 /**
  * Show the item in the DOM (when not already visible). The items DOM will
  * be created when needed.
+ * @param {boolean} [returnQueue=false]  whether to return a queue of functions to execute instead of just executing them
+ * @return {boolean} the redraw queue if returnQueue=true
  */
 PointItem.prototype.show = function(returnQueue) {
   if (!this.displayed) {

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -191,6 +191,8 @@ RangeItem.prototype.redraw = function(returnQueue) {
 /**
  * Show the item in the DOM (when not already visible). The items DOM will
  * be created when needed.
+ * @param {boolean} [returnQueue=false]  whether to return a queue of functions to execute instead of just executing them
+ * @return {boolean} the redraw queue if returnQueue=true
  */
 RangeItem.prototype.show = function(returnQueue) {
   if (!this.displayed) {

--- a/lib/timeline/component/item/RangeItem.js
+++ b/lib/timeline/component/item/RangeItem.js
@@ -192,9 +192,9 @@ RangeItem.prototype.redraw = function(returnQueue) {
  * Show the item in the DOM (when not already visible). The items DOM will
  * be created when needed.
  */
-RangeItem.prototype.show = function() {
+RangeItem.prototype.show = function(returnQueue) {
   if (!this.displayed) {
-    this.redraw();
+    return this.redraw(returnQueue);
   }
 };
 


### PR DESCRIPTION
This fixes #3249 again, because my previous PR #3250 got overwritten. (Possibly by #3475) Additionally, this time I feel that this change is a bit more robust than my previous one.

## The problem

When an item is outside of the currently visible range, it is hidden by Group.prototype._checkIfVisible(). This detaches the item from the DOM. The next time the group containing the item is drawn, Group.prototype._redrawItems calls RangeItem.prototype.redraw(), which in turn calls RangeItem.prototype._appendDomElement(). This function detects that the item is not attached to the DOM and re-attaches it, triggering a reflow event.

In my application I have several thousand items which are offscreen at a given time, and so this unnecessary redrawing degrades performance quite significantly.

## My solution

Currently when a group is drawn, each item is shown (and redrawn) if it currently not displayed. With my change, each item is shown if it's currently not displayed AND it either should be visible, or it's never been visible before.

This correctly gets the size of elements when they are first added, doesn't update the size of the element while it's not visible but immediately updates the size once the element becomes visible again.

## Performance impact

It's hard to produce a minimal example illustrating this issue because it only really becomes noticeable when you have thousands of items, each one with a non-trivial template. I hope it will be sufficient to provide some performance numbers from my own app:

Before this patch, when I panned/zoomed the timeline in my application I would dip to 7-10fps. Now, my app only dips to 16-17fps. (I'm still working on improving performance in my app)