### PR TITLE
BUGFIX: No group info returned to mouse events when cursorY == group top

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -2317,7 +2317,7 @@ ItemSet.prototype.groupFromTarget = function(event) {
     var group = this.groups[groupId];
     var foreground = group.dom.foreground;
     var top = util.getAbsoluteTop(foreground);
-    if (clientY > top && clientY < top + foreground.offsetHeight) {
+    if (clientY >= top && clientY < top + foreground.offsetHeight) {
       return group;
     }
 


### PR DESCRIPTION
When the mouse was over a group-label's very top pixels, no group id was returned in mouse events.
This was due to checking if the cursor's Y coordinate is higher than the group element's top position, and not equal or higher.
