### PR TITLE
[Timeline] Group height mode

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -473,7 +473,7 @@ var groups = [
       <td>heightMode</td>
       <td>String</td>
       <td>no</td>
-      <td>This field is optional. If set this overrides the global <code>groupHeightMode</code> configuration option for this group.</td>
+      <td>This field is optional. Can be 'auto' (default) or 'fixed'. If set this overrides the global <code>groupHeightMode</code> configuration option for this group.</td>
     </tr>
   </table>
 

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -469,6 +469,12 @@ var groups = [
       <td>no</td>
       <td>Assuming the group has nested groups, this will set the initial state of the group - shown or collapsed. The <code>showNested</code> is defaulted to <code>true</code>.</td>
     </tr>
+    <tr>
+      <td>heightMode</td>
+      <td>String</td>
+      <td>no</td>
+      <td>This field is optional. If set this overrides the global <code>groupHeightMode</code> configuration option for this group.</td>
+    </tr>
   </table>
 
 
@@ -662,6 +668,13 @@ function (option, path) {
       <td>boolean</td>
       <td><code>false</code></td>
       <td>If true, groups can be dragged to change their order. Only applicable when the Timeline has groups. For this option to work properly the groupOrder and groupOrderSwap options have to be set as well.</td>
+    </tr>
+
+    <tr>
+      <td>groupHeightMode</td>
+      <td>String</td>
+      <td>'auto'</td>
+      <td>Specifies how the height of a group is calculated. Choose from 'auto' and 'fixed'. If it is set to 'auto' the height will be calculated based on the visible items. While if it is set to 'fixed' the group will keep the same height even if there are no visible items in the window.</td>
     </tr>
 
     <tr>

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -43,6 +43,12 @@ function Group (groupId, data, itemSet) {
     }
   }
 
+  if (data && data.heightMode) {
+    this.heightMode = data.heightMode;
+  } else {
+    this.heightMode = itemSet.options.groupHeightMode;
+  }
+
   this.nestedInGroup = null;
 
   this.dom = {};
@@ -501,12 +507,19 @@ Group.prototype._isGroupVisible = function (range, margin) {
  */
 Group.prototype._calculateHeight = function (margin) {
   // recalculate the height of the group
-  var height;
-  var itemsInRange = this.visibleItems;
-  if (itemsInRange.length > 0) {
-    var min = itemsInRange[0].top;
-    var max = itemsInRange[0].top + itemsInRange[0].height;
-    util.forEach(itemsInRange, function (item) {
+  var height, items;
+
+  if (this.heightMode === 'fixed') {
+    items = util.toArray(this.items);
+  } else {
+    // default or 'auto'
+    items = this.visibleItems;
+  }
+
+  if (items.length > 0) {
+    var min = items[0].top;
+    var max = items[0].top + items[0].height;
+    util.forEach(items, function (item) {
       min = Math.min(min, item.top);
       max = Math.max(max, (item.top + item.height));
     });
@@ -514,7 +527,7 @@ Group.prototype._calculateHeight = function (margin) {
       // there is an empty gap between the lowest item and the axis
       var offset = min - margin.axis;
       max -= offset;
-      util.forEach(itemsInRange, function (item) {
+      util.forEach(items, function (item) {
         item.top -= offset;
       });
     }

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -367,7 +367,7 @@ ItemSet.prototype.setOptions = function(options) {
     var fields = [
       'type', 'rtl', 'align', 'order', 'stack', 'stackSubgroups', 'selectable', 'multiselect',
       'multiselectPerGroup', 'groupOrder', 'dataAttributes', 'template', 'groupTemplate', 'visibleFrameTemplate',
-      'hide', 'snap', 'groupOrderSwap', 'showTooltips', 'tooltip', 'tooltipOnItemUpdateTime'
+      'hide', 'snap', 'groupOrderSwap', 'showTooltips', 'tooltip', 'tooltipOnItemUpdateTime', 'groupHeightMode'
     ];
     util.selectiveExtend(fields, this.options, options);
 

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -74,6 +74,7 @@ let allOptions = {
     __type__: {object}
   },
   moment: {'function': 'function'},
+  groupHeightMode: {string},  
   groupOrder: {string, 'function': 'function'},
   groupEditable: {
     add: { 'boolean': bool, 'undefined': 'undefined'},
@@ -208,7 +209,7 @@ let configureOptions = {
         year:       ''
       }
     },
-
+    groupHeightMode: ['auto', 'fixed'],
     //groupOrder: {string, 'function': 'function'},
     groupsDraggable: false,
     height: '',


### PR DESCRIPTION
Hi everyone, long time lurker here, I absolutely love this project and since I have made several changes to the library over the past few months (for a project at work) I think it's time to say thank you with a couple of PRs.

Here's the first one: it adds a global parameter called `groupHeightMode` that can be overriden by a group and can have two values: 'auto' or 'fixed'. Basically it specifies how the height of a group gets calculated. If it's set to 'auto' the height is calculated based on the visibile items, like always. On the other hand, with the 'fixed' value the group keeps the same height even if there are no visible items in the timeline at that moment.

I think it's a nice feature to have, hope to see it in some future version :)