### PR TITLE
Move showManipulationToolbar outside if statement

### DIFF
--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -1156,8 +1156,8 @@ class ManipulationSystem {
         this.options.addNode(defaultData, (finalizedData) => {
           if (finalizedData !== null && finalizedData !== undefined && this.inMode === 'addNode') { // if for whatever reason the mode has changes (due to dataset change) disregard the callback
             this.body.data.nodes.getDataSet().add(finalizedData);
-            this.showManipulatorToolbar();
           }
+          this.showManipulatorToolbar();
         });
       }
       else {


### PR DESCRIPTION
This change allows for add node mode to be disabled and the manipulation toolbar to be displayed when undefined or null are passed into the callback function.