### PR TITLE
Documented isActive()

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -1388,6 +1388,12 @@ document.getElementById('myTimeline').onclick = function (event) {
     </tr>
 
     <tr>
+      <td>isActive()</td>
+      <td>Boolean</td>
+      <td>Denotes whether the timeline is currently active. This method only returns <code>false</code> if the timline has the <code>{clickToUse:true}</code> option enabled and the timeline is currently unselected.</td>
+    </tr>
+	  
+    <tr>
       <td>moveTo(time [, options, callback])</td>
       <td>none</td>
       <td>Move the window such that given time is centered on screen. Parameter <code>time</code> can be a <code>Date</code>, <code>Number</code>, or <code>String</code>. Available options:


### PR DESCRIPTION
> Documented the helper method to provide support for the edge case of detecting the currently active Timeline from a collection of Timelines.


**Why?**
I hit an edge case using Timelines in which a page contained a collection of them all using the _clickToUse_ feature. This meant that only one Timeline was going to be active at a given time. I wanted to perform a specific operation using the currently active Timeline. After poking around I found _isActive()_.

I realise this is likely meant to be a helper method, but given its usefulness in my case I felt I should just document it instead.