### PR TITLE
[Timeline] Align current time

### DIFF
--- a/docs/graph2d/index.html
+++ b/docs/graph2d/index.html
@@ -783,6 +783,13 @@ onRender: function(item, group, graph2d) {
         </tr>
 
         <tr>
+            <td>alignCurrentTime</td>
+            <td>String</td>
+            <td>none</td>
+            <td>If set, the current time bar will be aligned to the start of the chosen unit of time. Available values are 'year', 'month', 'quarter', 'week', 'isoWeek', 'day', 'date', 'hour', 'minute' or 'second'. If not provided, the current time bar will be updated at every tick.</td>
+        </tr>
+
+        <tr>
             <td>autoResize</td>
             <td>Boolean</td>
             <td>true</td>

--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -516,6 +516,13 @@ var options = {
     </tr>
 
     <tr>
+      <td>alignCurrentTime</td>
+      <td>String</td>
+      <td>none</td>
+      <td>If set, the current time bar will be aligned to the start of the chosen unit of time. Available values are 'year', 'month', 'quarter', 'week', 'isoWeek', 'day', 'date', 'hour', 'minute' or 'second'. If not provided, the current time bar will be updated at every tick.</td>
+    </tr>
+
+    <tr>
       <td>autoResize</td>
       <td>boolean</td>
       <td><code>true</code></td>

--- a/lib/timeline/component/CurrentTime.js
+++ b/lib/timeline/component/CurrentTime.js
@@ -8,6 +8,7 @@ var locales = require('../locales');
  * @param {{range: Range, dom: Object, domProps: Object}} body
  * @param {Object} [options]        Available parameters:
  *                                  {Boolean} [showCurrentTime]
+ *                                  {String}  [alignCurrentTime]
  * @constructor CurrentTime
  * @extends Component
  */
@@ -18,6 +19,7 @@ function CurrentTime (body, options) {
   this.defaultOptions = {
     rtl: false,
     showCurrentTime: true,
+    alignCurrentTime: undefined,
 
     moment: moment,
     locales: locales,
@@ -61,11 +63,12 @@ CurrentTime.prototype.destroy = function () {
  * Set options for the component. Options will be merged in current options.
  * @param {Object} options  Available parameters:
  *                          {boolean} [showCurrentTime]
+ *                          {String}  [alignCurrentTime]
  */
 CurrentTime.prototype.setOptions = function(options) {
   if (options) {
     // copy all options that we know
-    util.selectiveExtend(['rtl', 'showCurrentTime', 'moment', 'locale', 'locales'], this.options, options);
+    util.selectiveExtend(['rtl', 'showCurrentTime', 'alignCurrentTime', 'moment', 'locale', 'locales'], this.options, options);
   }
 };
 
@@ -87,6 +90,11 @@ CurrentTime.prototype.redraw = function() {
     }
 
     var now = this.options.moment(new Date().valueOf() + this.offset);
+
+    if (this.options.alignCurrentTime) {
+      now = now.startOf(this.options.alignCurrentTime);
+    }
+
     var x = this.body.util.toScreen(now);
 
     var locale = this.options.locales[this.options.locale];

--- a/lib/timeline/optionsGraph2d.js
+++ b/lib/timeline/optionsGraph2d.js
@@ -25,6 +25,7 @@ let allOptions = {
   },
 
   //globals :
+  alignCurrentTime: {string, 'undefined': 'undefined'},  
   yAxisOrientation: {string:['left','right']},
   defaultGroup: {string},
   sort: {'boolean': bool},

--- a/lib/timeline/optionsGraph2d.js
+++ b/lib/timeline/optionsGraph2d.js
@@ -170,6 +170,7 @@ let allOptions = {
 
 let configureOptions = {
   global: {
+    alignCurrentTime: ['none', 'year', 'month', 'quarter', 'week', 'isoWeek', 'day', 'date', 'hour', 'minute', 'second'],   
     //yAxisOrientation: ['left','right'], // TDOO: enable as soon as Grahp2d doesn't crash when changing this on the fly
     sort: true,
     sampling: true,

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -180,6 +180,7 @@ let allOptions = {
 let configureOptions = {
   global: {
     align:  ['center', 'left', 'right'],
+    alignCurrentTime: ['none', 'year', 'month', 'quarter', 'week', 'isoWeek', 'day', 'date', 'hour', 'minute', 'second'],
     direction:  false,
     autoResize: true,
     clickToUse: false,

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -25,6 +25,7 @@ let allOptions = {
 
   //globals :
   align: {string},
+  alignCurrentTime: {string, 'undefined': 'undefined'},
   rtl: { 'boolean': bool, 'undefined': 'undefined'},
   rollingMode: {
     follow: { 'boolean': bool },


### PR DESCRIPTION
Here's another simple feature I'd love to see in the main branch :)

This PR adds a global option called `alignCurrentTime` that allows you to specify the unit of time that the current time bar should be aligned to. For example, when setting that parameter to `day` you can align the current time bar to the start of the day. It's really useful when you don't need a high level of precision and you just want to render a today marker in the timeline (which by definition cannot fall between two days).

It's not mandatory, so if not provided the current time bar will have the same behavior it has today.

Cheers,
Francesco