### PR TITLE
Fix for partial hidden large pop ups

### DIFF
--- a/lib/shared/Popup.js
+++ b/lib/shared/Popup.js
@@ -18,7 +18,7 @@ class Popup {
     // create the frame
     this.frame = document.createElement('div');
     this.frame.className = 'vis-tooltip';
-    this.container.appendChild(this.frame);
+    document.body.appendChild(this.frame);
   }
 
   /**


### PR DESCRIPTION
I got a scenario where the pop ups get partial hided because of their content plus the location of the pop up div. So I changed the parent element that do the "appendChild" of the div and got a nice result.

I put two images here to show the new behavior

With current version:
![antes](https://user-images.githubusercontent.com/2043739/33885824-a2ac9018-df2b-11e7-90c1-a061cde1017b.png)

And with my code
![depois](https://user-images.githubusercontent.com/2043739/33885810-996e7d7c-df2b-11e7-9bce-a78a2058d2c2.png)


So, that is! Thanks for the vis.js

Att
Abs

p.s: Sorry for the delay to submit one the correct branch.