### PR TITLE
fixed memory leak because eventlisteners weren't destroyed

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -527,6 +527,7 @@ Core.prototype.destroy = function () {
     }
   }
   this.listeners = null;
+  this.hammer && this.hammer.destroy();
   this.hammer = null;
 
   // give all components the opportunity to cleanup

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -483,6 +483,8 @@ ItemSet.prototype.destroy = function() {
   this.setItems(null);
   this.setGroups(null);
 
+  this.hammer && this.hammer.destroy();
+  this.groupHammer && this.groupHammer.destroy();
   this.hammer = null;
 
   this.body = null;


### PR DESCRIPTION
In Angular (2+) there was a memory leak because the hammers with their event listeners weren't destroyed. Fixed it by destroying the hammer before they were set to null.
fixes #3645 
