### PR TITLE
[Timeline] Fix react integration, fix content applying mechanics

### DIFF
--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -139,6 +139,10 @@ Group.prototype.setData = function(data) {
       this.dom.inner.removeChild(this.dom.inner.firstChild);
     }
     this.dom.inner.appendChild(content);
+  } else if (content instanceof Object && content.isReactComponent) {
+    // Do nothing. Component was rendered into the node be ReactDOM.render.
+    // That branch is necessary for evasion of a second call templateFunction.
+    // Supports only React < 16(due to the asynchronous nature of React 16).
   } else if (content instanceof Object) {
     templateFunction(data, this.dom.inner);
   } else if (content !== undefined && content !== null) {
@@ -160,7 +164,7 @@ Group.prototype.setData = function(data) {
     if (!this.nestedGroups || this.nestedGroups != data.nestedGroups) {
       this.nestedGroups = data.nestedGroups;
     }
-    
+
     if (data.showNested !== undefined || this.showNested === undefined) {
       if (data.showNested == false) {
         this.showNested = false;
@@ -344,20 +348,20 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
 
       if (this.doInnerStack && this.itemSet.options.stackSubgroups) {
         // Order the items within each subgroup
-        for(subgroup in this.subgroups) {            
+        for(subgroup in this.subgroups) {
           visibleSubgroups[subgroup] = this.subgroups[subgroup].items.slice().sort(function (a, b) {
             return me.itemSet.options.order(a.data, b.data);
           });
         }
 
-        stack.stackSubgroupsWithInnerStack(visibleSubgroups, margin, this.subgroups);          
+        stack.stackSubgroupsWithInnerStack(visibleSubgroups, margin, this.subgroups);
       }
       else {
         // order all items and force a restacking
         var customOrderedItems = this.orderedItems.byStart.slice().sort(function (a, b) {
           return me.itemSet.options.order(a.data, b.data);
         });
-        this.shouldBailStackItems = stack.stack(customOrderedItems, margin, true, this._shouldBailItemsRedraw.bind(this));        
+        this.shouldBailStackItems = stack.stack(customOrderedItems, margin, true, this._shouldBailItemsRedraw.bind(this));
       }
 
       this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
@@ -366,8 +370,8 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
       this.visibleItems = this._updateItemsInRange(this.orderedItems, this.visibleItems, range);
 
       if (this.itemSet.options.stack) {
-        if (this.doInnerStack && this.itemSet.options.stackSubgroups) {                    
-          for(subgroup in this.subgroups) {            
+        if (this.doInnerStack && this.itemSet.options.stackSubgroups) {
+          for(subgroup in this.subgroups) {
             visibleSubgroups[subgroup] = this.subgroups[subgroup].items;
           }
 
@@ -668,7 +672,6 @@ Group.prototype._addToSubgroup = function(item, subgroupId) {
   }
 
   this.subgroups[subgroupId].items.push(item);
-  
 };
 
 Group.prototype._updateSubgroupsSizes = function () {
@@ -680,8 +683,8 @@ Group.prototype._updateSubgroupsSizes = function () {
       var newEnd = initialEnd - 1;
 
       me.subgroups[subgroup].items.forEach(function(item) {
-        if (new Date(item.data.start) < new Date(newStart)) { 
-          newStart = item.data.start; 
+        if (new Date(item.data.start) < new Date(newStart)) {
+          newStart = item.data.start;
         }
 
         var itemEnd = item.data.end || item.data.start;

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -19,7 +19,7 @@ function Group (groupId, data, itemSet) {
   this.itemSet = itemSet;
   this.isVisible = null;
   this.stackDirty = true; // if true, items will be restacked on next redraw
-  
+
   if (data && data.nestedGroups) {
     this.nestedGroups = data.nestedGroups;
     if (data.showNested == false) {
@@ -135,7 +135,6 @@ Group.prototype.setData = function(data) {
   }
 
   if (content instanceof Element) {
-    this.dom.inner.appendChild(content);
     while (this.dom.inner.firstChild) {
       this.dom.inner.removeChild(this.dom.inner.firstChild);
     }


### PR DESCRIPTION
Hello!

Today i found two little problems with groups on timeline.
Commit messages i guess are pretty good explain what i did.

In the case of React, there was problem with unnecessary rerender of content.
[That](https://github.com/pyxarez/vis/blob/479ea519eba423ed531b57124a78578c480f0426/lib/timeline/component/Group.js#L132) is the place where content was already rendered
And [that](https://github.com/almende/vis/compare/develop...pyxarez:timeline-react-rendering?expand=1#diff-f4d829b4f8b61a3d664fc7a5eb70924dR147) is the place where it has rerendered all the time before my change.

Case was tested on the expalmple from the docs of vis.