### PR TITLE
[Timeline] Vertical group labels

### DIFF
--- a/docs/timeline/index.html
+++ b/docs/timeline/index.html
@@ -687,6 +687,13 @@ function (option, path) {
     </tr>
 
     <tr>
+      <td>groupLabelDirection</td>
+      <td>String</td>
+      <td>'horizontal'</td>
+      <td>Set the text direction of group labels. The possible values are 'horizontal' and 'vertical'.</td>
+    </tr>
+
+    <tr>
       <td>groupOrder</td>
       <td>String or Function</td>
       <td>'order'</td>

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -90,6 +90,9 @@ Group.prototype._create = function() {
   } else {
     label.className = 'vis-label';
   }
+  if (this.itemSet.options.groupLabelDirection === 'vertical') {
+    label.className += ' vertical';
+  }
   this.dom.label = label;
 
   var inner = document.createElement('div');
@@ -397,8 +400,9 @@ Group.prototype._redrawItems = function(forceRestack, lastIsVisible, margin, ran
 Group.prototype._didResize = function(resized, height) {
   resized = util.updateProperty(this, 'height', height) || resized;
   // recalculate size of label
-  var labelWidth = this.dom.inner.clientWidth;
-  var labelHeight = this.dom.inner.clientHeight;
+  var boundingRect = this.dom.inner.getBoundingClientRect();
+  var labelWidth = boundingRect.width;
+  var labelHeight = boundingRect.height;
   resized = util.updateProperty(this.props.label, 'width', labelWidth) || resized;
   resized = util.updateProperty(this.props.label, 'height', labelHeight) || resized;
   return resized;

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -371,7 +371,8 @@ ItemSet.prototype.setOptions = function(options) {
     var fields = [
       'type', 'rtl', 'align', 'order', 'stack', 'stackSubgroups', 'selectable', 'multiselect',
       'multiselectPerGroup', 'groupOrder', 'dataAttributes', 'template', 'groupTemplate', 'visibleFrameTemplate',
-      'hide', 'snap', 'groupOrderSwap', 'showTooltips', 'tooltip', 'tooltipOnItemUpdateTime', 'groupHeightMode', 'onTimeout'
+      'hide', 'snap', 'groupOrderSwap', 'showTooltips', 'tooltip', 'tooltipOnItemUpdateTime', 'groupHeightMode',
+      'onTimeout', 'groupLabelDirection'
     ];
     util.selectiveExtend(fields, this.options, options);
 

--- a/lib/timeline/component/css/labelset.css
+++ b/lib/timeline/component/css/labelset.css
@@ -25,6 +25,12 @@
   cursor: pointer;
 }
 
+.vis-labelset .vis-label.vertical {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .vis-labelset .vis-label:last-child {
   border-bottom: none;
 }
@@ -36,4 +42,15 @@
 
 .vis-labelset .vis-label .vis-inner.vis-hidden {
   padding: 0;
+}
+
+.vis-labelset .vis-label.vertical .vis-inner {
+  padding-top: 0;
+  padding-bottom: 0;
+  white-space: nowrap;
+  -webkit-transform: rotate(-90deg);
+  -moz-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  -o-transform: rotate(-90deg);
+  transform: rotate(-90deg);
 }

--- a/lib/timeline/optionsTimeline.js
+++ b/lib/timeline/optionsTimeline.js
@@ -83,6 +83,7 @@ let allOptions = {
   },
   moment: {'function': 'function'},
   groupHeightMode: {string},  
+  groupLabelDirection: {string},
   groupOrder: {string, 'function': 'function'},
   groupEditable: {
     add: { 'boolean': bool, 'undefined': 'undefined'},
@@ -221,6 +222,7 @@ let configureOptions = {
       }
     },
     groupHeightMode: ['auto', 'fixed'],
+    groupLabelDirection: ['horizontal', 'vertical'],
     //groupOrder: {string, 'function': 'function'},
     groupsDraggable: false,
     height: '',


### PR DESCRIPTION
Hi everyone,
this PR adds a global option called `groupLabelDirection` and if you set it to `vertical` guess what happens next...

![image](https://user-images.githubusercontent.com/29624992/35509615-1d6ca6be-04f5-11e8-9176-deecdd57fa4c.png)

Pretty straightforward. This time I decided **not** to introduce a group-level parameter because imo if you override only some groups behaviour the timeline turns into a mess (but let me know what you think).

Also for the CSS positioning I used flexbox, which is supported by almost everyone nowadays. Here's the full compatibility report: https://caniuse.com/#search=flex

Cheers,
Francesco