### PR TITLE
fixed bug that did not allocate the correct array if there is a remov…

### DIFF
--- a/lib/timeline/component/LineGraph.js
+++ b/lib/timeline/component/LineGraph.js
@@ -338,7 +338,7 @@ LineGraph.prototype._onAdd = function (ids) {
   this._onUpdate(ids);
 };
 LineGraph.prototype._onRemove = function (ids) {
-  this._onUpdate(ids);
+  this._updateAllGroupData(ids, undefined, true);
 };
 LineGraph.prototype._onUpdateGroups = function (groupIds) {
   this._updateAllGroupData(null, groupIds);
@@ -429,7 +429,7 @@ LineGraph.prototype._updateGroup = function (group, groupId) {
  * @param  {Array} groupIds
  * @private
  */
-LineGraph.prototype._updateAllGroupData = function (ids, groupIds) {
+LineGraph.prototype._updateAllGroupData = function (ids, groupIds, removedItems = false) {
   if (this.itemsData != null) {
     var groupsContent = {};
     var items = this.itemsData.get();
@@ -454,7 +454,7 @@ LineGraph.prototype._updateAllGroupData = function (ids, groupIds) {
 
     //Pre-load arrays from existing groups if items are not changed (not in ids)
     var existingItemsMap = {};
-    if (!groupIds && ids) {
+    if (!groupIds && ids && removedItems !== true) {
       for (groupId in this.groups) {
         if (this.groups.hasOwnProperty(groupId)) {
           group = this.groups[groupId];


### PR DESCRIPTION
Hi guys,

I encountered an issue where I have a vis dataset loaded into a graph2d and on removal (.clear() method) of all items, the graph did not redraw correctly. On updating afterwards it threw an Error.

Took quite a bit of digging but it turns out the optimization of the memory allocation does not account for deleted items. the onRemove method forwards to the onUpdate method which should not be done anymore if the group update blindly expects the items to be updated, not deleted.

This is more of an indication, you don't need to accept the request. Normally, this request would go to develop but I really didnt feel like comparing develop branches :)

Cheers