### PR TITLE
[Timeline] Allow normal page scrolling over timeline

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -204,8 +204,11 @@ Core.prototype._create = function (container) {
       deltaX = event.deltaX;
     }
 
-    // prevent scrolling when zoomKey defined or activated
+    // Prevent scrolling when zooming (no zoom key, or pressing zoom key)
     if (!this.options.zoomKey || event[this.options.zoomKey]) return;
+
+    // Don't preventDefault if you can't scroll
+    if (!this.options.verticalScroll && !this.options.horizontalScroll) return;
 
     // Prevent default actions caused by mouse wheel
     // (else the page and timeline both scroll)


### PR DESCRIPTION
Adds/fixes #3734. Since I believe that this should be the expected behaviour, I don't think it requires an extra example etc, if reviewers disagree, I can add one.

As the linked ticket states, you can't scroll the page while the mouse is over the timeline (even if the timeline is doing nothing with that scroll). This PR changes it so that as-long as the timeline isn't zooming or scrolling, then the page will scroll (Timeline won't eat the event).