### PR TITLE
Adding updateClusteredNode to network.prototype

### DIFF
--- a/lib/network/Network.js
+++ b/lib/network/Network.js
@@ -497,6 +497,7 @@ Network.prototype.cluster             = function() {return this.clustering.clust
 Network.prototype.getNodesInCluster   = function() {return this.clustering.getNodesInCluster.apply(this.clustering,arguments);};
 Network.prototype.clusterByConnection = function() {return this.clustering.clusterByConnection.apply(this.clustering,arguments);};
 Network.prototype.clusterByHubsize    = function() {return this.clustering.clusterByHubsize.apply(this.clustering,arguments);};
+Network.prototype.updateClusteredNode = function() {return this.clustering.updateClusteredNode.apply(this.clustering,arguments);};
 
 /**
  * This method will cluster all nodes with 1 edge with their respective connected node.

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -899,7 +899,7 @@ class ClusterEngine {
 
   /**
   * Using a clustered nodeId, update with the new options
-  * @param {vis.Edge.id} clusteredNodeId
+  * @param {Node.id} clusteredNodeId
   * @param {object} newOptions
   */
   updateClusteredNode(clusteredNodeId, newOptions) {


### PR DESCRIPTION
Just noticed `updateClusteredNode` was not added to the `Network.prototype`. Got a hard time finding out that I could access it through `network.clustering.updateClusteredNode`.

Regards,