### PR TITLE
added Array check before edgesData.forEach since edgesData can be null

### DIFF
--- a/lib/network/modules/EdgesHandler.js
+++ b/lib/network/modules/EdgesHandler.js
@@ -464,14 +464,14 @@ class EdgesHandler {
      let edges = this.body.edges;
      let edgesData = this.body.data.edges;
      let addIds = [];
-
-     edgesData.forEach((edgeData, edgeId) => {
-         let edge = edges[edgeId];
-         if(edge===undefined) {
-           addIds.push(edgeId);
-         }
-     });
-     
+     if (Array.isArray(edgesData)) {
+         edgesData.forEach((edgeData, edgeId) => {
+             let edge = edges[edgeId];
+             if (edge === undefined) {
+                 addIds.push(edgeId);
+             }
+         });
+     }
      this.add(addIds,true);
    }  
 }


### PR DESCRIPTION
Discovered a small bug in EdgesHandler where this.body.data.edges was sometimes null and thus broke _addMissingEdges by attempting a forEach on null.
That this can be null is documented in EdgesHandler.js:
...line 257
  // TODO: is this null or undefined or false?
    if (this.body.data.edges) {
      // subscribe to new dataset
...

Added a simple Array.isArray() guard clause around the forEach section.
My app now works fine on 4.21.0