### PR TITLE
Improvment on clustering performance

### DIFF
--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -1222,7 +1222,7 @@ class ClusterEngine {
   _updateState() {
     let nodeId;
     let deletedNodeIds = [];
-    let deletedEdgeIds = [];
+    let deletedEdgeIds = {};
 
     /**
      * Utility function to iterate over clustering nodes only
@@ -1273,7 +1273,7 @@ class ClusterEngine {
     util.forEach(this.clusteredEdges, (edgeId) => {
       let edge = this.body.edges[edgeId];
       if (edge === undefined || !edge.endPointsValid()) {
-        deletedEdgeIds.push(edgeId);
+        deletedEdgeIds[edgeId] = true;
       }
     });
 
@@ -1282,8 +1282,8 @@ class ClusterEngine {
     // So the cluster nodes also need to be scanned for invalid edges
     eachClusterNode(function(clusterNode) {
       util.forEach(clusterNode.containedEdges, (edge, edgeId) => {
-        if (!edge.endPointsValid() && deletedEdgeIds.indexOf(edgeId) === -1) {
-          deletedEdgeIds.push(edgeId);
+        if (!edge.endPointsValid() && !deletedEdgeIds[edgeId]) {
+          deletedEdgeIds[edgeId] = true;
         }
       });
     });
@@ -1309,7 +1309,7 @@ class ClusterEngine {
       }
 
       if (!edge.endPointsValid() || !isValid) {
-        deletedEdgeIds.push(edgeId);
+        deletedEdgeIds[edgeId] = true;
       }
     });
 
@@ -1325,7 +1325,7 @@ class ClusterEngine {
           }
 
           edge.clusteringEdgeReplacingIds = this._filter(edge.clusteringEdgeReplacingIds, function(id) {
-            return deletedEdgeIds.indexOf(id) === -1;
+            return !deletedEdgeIds[id];
           });
         });
 

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -1273,7 +1273,7 @@ class ClusterEngine {
     util.forEach(this.clusteredEdges, (edgeId) => {
       let edge = this.body.edges[edgeId];
       if (edge === undefined || !edge.endPointsValid()) {
-        deletedEdgeIds[edgeId] = true;
+        deletedEdgeIds[edgeId] = edgeId;
       }
     });
 
@@ -1283,7 +1283,7 @@ class ClusterEngine {
     eachClusterNode(function(clusterNode) {
       util.forEach(clusterNode.containedEdges, (edge, edgeId) => {
         if (!edge.endPointsValid() && !deletedEdgeIds[edgeId]) {
-          deletedEdgeIds[edgeId] = true;
+          deletedEdgeIds[edgeId] = edgeId;
         }
       });
     });
@@ -1309,7 +1309,7 @@ class ClusterEngine {
       }
 
       if (!edge.endPointsValid() || !isValid) {
-        deletedEdgeIds[edgeId] = true;
+        deletedEdgeIds[edgeId] = edgeId;
       }
     });
 

--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -161,8 +161,7 @@ class ClusterEngine {
 
     // collect the nodes that will be in the cluster
     util.forEach(this.body.nodes, (node, nodeId) => {
-      let clonedOptions = NetworkUtil.cloneOptions(node);
-      if (options.joinCondition(clonedOptions) === true) {
+      if (node.options && options.joinCondition(node.options) === true) {
         childNodesObj[nodeId] = node;
 
         // collect the edges that will be in the cluster


### PR DESCRIPTION
With this pull request, my network that was taking around 10s to load (due to clustering) and then more 3 seconds each time I was moving my nodes, now takes 1s to load and the moving is fluid again.

I basically used an object instead of an array that was causing a huge bottleneck on `_updateState` due to the heavy use of `indexOf` and I also removed one `deepExtend` that was not necessary (it was _just_ cloning all the nodes options in the network. And it actually needed to clone **none**).

Let me know what you guys think.

Regards