### PR TITLE
Adding refreshData parameter on cluster update methods

### DIFF
--- a/lib/network/modules/Clustering.js
+++ b/lib/network/modules/Clustering.js
@@ -902,13 +902,16 @@ class ClusterEngine {
   * @param {vis.Edge.id} clusteredNodeId
   * @param {object} newOptions
   */
-  updateClusteredNode(clusteredNodeId, newOptions) {
+  updateClusteredNode(clusteredNodeId, newOptions, refreshData = true) {
     if (clusteredNodeId === undefined) {throw new Error("No clusteredNodeId supplied to updateClusteredNode.");}
     if (newOptions === undefined) {throw new Error("No newOptions supplied to updateClusteredNode.");}
     if (this.body.nodes[clusteredNodeId] === undefined)   {throw new Error("The clusteredNodeId supplied to updateClusteredNode does not exist.");}
 
     this.body.nodes[clusteredNodeId].setOptions(newOptions);
-    this.body.emitter.emit('_dataChanged');
+    
+    if (refreshData === true) {
+      this.body.emitter.emit('_dataChanged');
+    }
   }
 
   /**
@@ -916,7 +919,7 @@ class ClusterEngine {
   * @param {vis.Edge.id} startEdgeId
   * @param {object} newOptions
   */
-  updateEdge(startEdgeId, newOptions) {
+  updateEdge(startEdgeId, newOptions, refreshData = true) {
     if (startEdgeId === undefined) {throw new Error("No startEdgeId supplied to updateEdge.");}
     if (newOptions === undefined) {throw new Error("No newOptions supplied to updateEdge.");}
     if (this.body.edges[startEdgeId] === undefined)   {throw new Error("The startEdgeId supplied to updateEdge does not exist.");}
@@ -926,7 +929,10 @@ class ClusterEngine {
       var edge = this.body.edges[allEdgeIds[i]];
       edge.setOptions(newOptions);
     }
-    this.body.emitter.emit('_dataChanged');
+
+    if (refreshData === true) {
+      this.body.emitter.emit('_dataChanged');
+    }
   }
 
   /**


### PR DESCRIPTION
Following another cluster methods that use the `refreshData` parameter.
This is really useful when you want to update several edges and clustered nodes and don't call the update methods for each time you do.