### PR TITLE
Normalize mouse wheel deltas

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -176,6 +176,11 @@ Core.prototype._create = function (container) {
    * @param {WheelEvent} event
    */
   function onMouseWheel(event) {
+
+    // Reasonable default wheel deltas
+    const LINE_HEIGHT = 40;
+    const PAGE_HEIGHT = 800;
+
     if (this.isActive()) {
       this.emit('mousewheel', event);
     }
@@ -202,6 +207,17 @@ Core.prototype._create = function (container) {
     }
     if ( 'deltaX' in event ) {
       deltaX = event.deltaX;
+    }
+
+    // Normalize deltas
+    if (event.deltaMode) {
+      if (event.deltaMode === 1) {   // delta in LINE units
+        deltaX *= LINE_HEIGHT;
+        deltaY *= LINE_HEIGHT;
+      } else {                       // delta in PAGE units
+        deltaX *= LINE_HEIGHT;
+        deltaY *= PAGE_HEIGHT;
+      }
     }
 
     // Prevent scrolling when zooming (no zoom key, or pressing zoom key)
@@ -241,15 +257,12 @@ Core.prototype._create = function (container) {
     }
   }
 
-  if (this.dom.centerContainer.addEventListener) {
-    // IE9, Chrome, Safari, Opera
-    this.dom.centerContainer.addEventListener("mousewheel", onMouseWheel.bind(this), false);
-    // Firefox
-    this.dom.centerContainer.addEventListener("DOMMouseScroll", onMouseWheel.bind(this), false);
-  } else {
-    // IE 6/7/8
-    this.dom.centerContainer.attachEvent("onmousewheel", onMouseWheel.bind(this));
-  }
+  // Add modern wheel event listener
+  const wheelType = "onwheel" in document.createElement("div") ? "wheel" : // Modern browsers support "wheel"
+    document.onmousewheel !== undefined ? "mousewheel" : // Webkit and IE support at least "mousewheel"
+    this.dom.centerContainer.addEventListener ? "DOMMouseScroll" : // Older Firefox versions like "DOMMouseScroll"
+    "onmousewheel" // All the rest should be comfortable with "onmousewheel"
+  this.dom.centerContainer.addEventListener(wheelType, onMouseWheel.bind(this), false);
 
   /**
    *

--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -258,11 +258,15 @@ Core.prototype._create = function (container) {
   }
 
   // Add modern wheel event listener
-  const wheelType = "onwheel" in document.createElement("div") ? "wheel" : // Modern browsers support "wheel"
-    document.onmousewheel !== undefined ? "mousewheel" : // Webkit and IE support at least "mousewheel"
-    this.dom.centerContainer.addEventListener ? "DOMMouseScroll" : // Older Firefox versions like "DOMMouseScroll"
-    "onmousewheel" // All the rest should be comfortable with "onmousewheel"
-  this.dom.centerContainer.addEventListener(wheelType, onMouseWheel.bind(this), false);
+  if (this.dom.centerContainer.addEventListener) {
+    const wheel = "onwheel" in document.createElement("div") ? "wheel" : // Modern browsers support "wheel"
+      document.onmousewheel !== undefined ? "mousewheel" : // Webkit and IE support at least "mousewheel"
+      "DOMMouseScroll"; // Older Firefox versions like "DOMMouseScroll"
+    this.dom.centerContainer.addEventListener(wheel, onMouseWheel.bind(this), false);
+  } else {
+    // IE 6/7/8
+    this.dom.centerContainer.attachEvent("onmousewheel", onMouseWheel.bind(this));
+  }
 
   /**
    *


### PR DESCRIPTION
This fix normalizes the mouse wheel delta values and enables reasonable scrolling  in Firefox (see #3792). Timeline now uses the [wheel event](https://developer.mozilla.org/en-US/docs/Web/Events/wheel) if supported by the browser.

Relevant examples: `timeline/other/horizontalScroll.html` and `verticalScroll.html`