### PR TITLE
Fix visibility of scale lines after toggling left axis groups

### DIFF
--- a/lib/timeline/component/DataAxis.js
+++ b/lib/timeline/component/DataAxis.js
@@ -163,6 +163,8 @@ DataAxis.prototype._create = function () {
   this.dom.lineContainer.style.width = '100%';
   this.dom.lineContainer.style.height = this.height;
   this.dom.lineContainer.style.position = 'relative';
+  this.dom.lineContainer.style.visibility = 'visible';
+  this.dom.lineContainer.style.display = 'block';
 
   // create svg element for graph drawing.
   this.svg = document.createElementNS('http://www.w3.org/2000/svg', "svg");
@@ -213,7 +215,7 @@ DataAxis.prototype._cleanupIcons = function () {
     DOMutil.cleanupElements(this.svgElements);
     this.iconsRemoved = true;
   }
-}
+};
 
 /**
  * Create the HTML DOM for the DataAxis
@@ -232,6 +234,7 @@ DataAxis.prototype.show = function () {
   if (!this.dom.lineContainer.parentNode) {
     this.body.dom.backgroundHorizontal.appendChild(this.dom.lineContainer);
   }
+  this.dom.lineContainer.style.display = 'block';
 };
 
 /**
@@ -243,9 +246,7 @@ DataAxis.prototype.hide = function () {
     this.dom.frame.parentNode.removeChild(this.dom.frame);
   }
 
-  if (this.dom.lineContainer.parentNode) {
-    this.dom.lineContainer.parentNode.removeChild(this.dom.lineContainer);
-  }
+  this.dom.lineContainer.style.display = 'none';
 };
 
 /**
@@ -382,6 +383,9 @@ DataAxis.prototype._redrawLabels = function () {
 
   if (this.master === false && this.masterAxis != undefined) {
     this.scale.followScale(this.masterAxis.scale);
+    this.dom.lineContainer.style.display = 'none';
+  } else{
+    this.dom.lineContainer.style.display = 'block';
   }
 
   //Is updated in side-effect of _redrawLabel():


### PR DESCRIPTION
Fixes visibility of horizontal scale lines after toggling groups on the left axis. Its functionality can be checked by running the following example:
https://gist.github.com/kbasten/de0fd0d2d264d0f6c8d6086f834ed959
This example does not show scale lines after hiding, then displaying the left groups in previous versions of vis.