### PR TITLE
edit edge: restore original controlNodes position when dragged into nothing

### DIFF
--- a/lib/network/modules/ManipulationSystem.js
+++ b/lib/network/modules/ManipulationSystem.js
@@ -992,6 +992,13 @@ class ManipulationSystem {
       }
     }
     else {
+      let controlNodeFrom = this.body.nodes[this.temporaryIds.nodes[0]];
+      let controlNodeTo   = this.body.nodes[this.temporaryIds.nodes[1]];
+      controlNodeFrom.x = edge.from.x;
+      controlNodeFrom.y = edge.from.y;
+      controlNodeTo.x   = edge.to.x;
+      controlNodeTo.y   = edge.to.y;
+
       edge.updateEdgeType();
       this.body.emitter.emit('restorePhysics');
     }


### PR DESCRIPTION
When editing an edge, if it's dragged into something that is not a node, the position of the control nodes will not be immediately updated, ending up with something like this. 

<img width="618" alt="screen shot 2018-05-14 at 11 02 49" src="https://user-images.githubusercontent.com/6430318/39987952-69c8080a-5766-11e8-8d16-4e5566c2e721.png">

As far as I can tell, this PR should fix that.

PS: fiy, I am using vis at work in order to create some kind of a graph editor. This is why I would like to change the `ManipulationSystem` in order to make it UI-indipendent, or at least to add the possibility for it to be UI-indipendent, so that it could be easily integrated with custom UI elements. Any help, suggestions or insights  would be very welcome (:
EDIT: found out it can already be made independent of the menu buttons, I'll just add some functionality to it