### PR TITLE
fix: Network edges `dashes` isArray comparison, for inheritied styling options.

### DIFF
--- a/lib/network/modules/components/edges/util/EdgeBase.js
+++ b/lib/network/modules/components/edges/util/EdgeBase.js
@@ -110,7 +110,9 @@ class EdgeBase {
   _drawDashedLine(ctx, values, viaNode, fromPoint, toPoint) {  // eslint-disable-line no-unused-vars
     ctx.lineCap = 'round';
     let pattern = [5,5];
-    if (Array.isArray(values.dashes) === true) {
+
+    // Loose "isArray" comparison, to handle default inherited dashes.
+    if (values.dashes && values.dashes.length) {
       pattern = values.dashes;
     }
 


### PR DESCRIPTION
This fixes being able to declare a default edge dash-array via: `edges.dashes` in the options. 

Something in the guts of the option values converts arrays into array-like objects, that do not pass the `Array.isArray` comparison.  The change in this pull-request loosens the comparison to ensure that the dashes property exists, and has `.length`.