### PR TITLE
fix: Prevent trying to read the value of a null element

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -425,7 +425,7 @@ Timeline.prototype.focus = function(id, options) {
   var end = null;
   itemsData.forEach(function (itemData) {
     var s = itemData.start.valueOf();
-    var e = 'end' in itemData ? itemData.end.valueOf() : itemData.start.valueOf();
+    var e = 'end' in itemData && itemData.end !== null ? itemData.end.valueOf() : itemData.start.valueOf();
 
     if (start === null || s < start) {
       start = s;


### PR DESCRIPTION
Hello,
In one of my project, I need to dynamically update the timeline where items may loose their ``end`` time. As it is not possible to simply delete the ``end`` key then update the timeline (see steps to reproduce), I have to set it to either ``null`` or ``undefined``. Doing so can, in some case, throw an error.

This fix adds the condition that the end time is not set to ``null`` before calling the function ``valueOf()``

Steps to reproduce:
- Create a item with both ``start`` end ``end`` set
- Set ``item.end = null`` and update the timeline
    - Setting it to ``null`` is required because if we remove the ``end`` key, it will be reset to the old value during the update process
- An error is raised because ``itemData.end === null``

What are your thoughts about it?