### PR TITLE
Replace babel-preset-es2015 with babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015"],
+  "presets": ["env"],
   "plugins": [
     "transform-es3-property-literals",
     "transform-es3-member-expression-literals",

--- a/README.md
+++ b/README.md
@@ -211,9 +211,11 @@ exports.Timeline = require('./lib/timeline/Timeline');
 
 Then create a custom bundle using browserify, like:
 
-    $ browserify custom.js -t [ babelify --presets [es2015] ] -o dist/vis-custom.js -s vis
+    $ browserify custom.js -t [ babelify --presets [env] ] -o dist/vis-custom.js -s vis
 
-This will generate a custom bundle *vis-custom.js*, which exposes the namespace `vis` containing only `DataSet` and `Timeline`. The generated bundle can be minified using uglifyjs:
+This will generate a custom bundle *vis-custom.js*, which exposes the namespace `vis` containing only `DataSet` and `Timeline`. You can pass additional options to babelify and browserify as needed (e.g. to customise the browsers that are supported).
+
+The generated bundle can be minified using uglifyjs:
 
     $ uglifyjs dist/vis-custom.js -o dist/vis-custom.min.js
 
@@ -236,7 +238,7 @@ The custom bundle can now be loaded like:
 
 The default bundle `vis.js` is standalone and includes external dependencies such as *hammer.js* and *moment.js*. When these libraries are already loaded by the application, vis.js does not need to include these dependencies itself too. To build a custom bundle of vis.js excluding *moment.js* and *hammer.js*, run browserify in the root of the project:
 
-    $ browserify index.js -t [ babelify --presets [es2015] ] -o dist/vis-custom.js -s vis -x moment -x hammerjs
+    $ browserify index.js -t [ babelify --presets [env] ] -o dist/vis-custom.js -s vis -x moment -x hammerjs
 
 This will generate a custom bundle *vis-custom.js*, which exposes the namespace `vis`, and has *moment.js* and *hammer.js* excluded. The generated bundle can be minified with uglifyjs:
 
@@ -327,7 +329,7 @@ module: {
       loader: 'babel-loader',
       query: {
         cacheDirectory: true,
-        presets: [ "babel-preset-es2015" ].map(require.resolve),
+        presets: [ "babel-preset-env" ].map(require.resolve),
         plugins: [
           "transform-es3-property-literals", // #2452
           "transform-es3-member-expression-literals", // #2566
@@ -383,7 +385,7 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 
 ## License
 
-Copyright (C) 2010-2017 Almende B.V. and Contributors
+Copyright (C) 2010-2018 Almende B.V. and Contributors
 
 Vis.js is dual licensed under both
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.7.0",
     "babel-runtime": "^6.23.0",
     "babelify": "^7.3.0",
     "clean-css": "^4.1.7",


### PR DESCRIPTION
This replaces the previous custom module with the more "framework-like" env approach, as shown at https://babeljs.io/env/

I admit that the main reason for this was the make the `npm install` step slightly less chatty. It makes no difference (that I know of) to anything other than custom builds.