### PR TITLE
Network interaction: fire (de)select event when node is dragged

### DIFF
--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -302,11 +302,13 @@ class InteractionHandler {
 
     if (node !== undefined && this.options.dragNodes === true) {
       this.drag.nodeId = node.id;
-      // select the clicked node if not yet selected
-      if (node.isSelected() === false) {
-        this.selectionHandler.unselectAll();
-        this.selectionHandler.selectObject(node);
-      }
+
+      // handle selection of dragged node
+      let multiselect = this.selectionHandler.options.multiselect &&
+        (event.changedPointers[0].ctrlKey || event.changedPointers[0].metaKey);
+      // update the selection only if node being dragged isn't selected already
+      if (!node.isSelected())
+        this.checkSelectionChanges(this.drag.pointer, event, multiselect);
 
       // after select to contain the node
       this.selectionHandler._generateClickEvent('dragStart', event, this.drag.pointer);


### PR DESCRIPTION
The node being dragged would be selected but no (de)select events would be fired.
In addition, now, if multiselect is on and an unselected node is dragged while pressing Ctrl it will be added to the selection.