### PR TITLE
Fix hiding edge tooltip when a node is hovered

### DIFF
--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -619,6 +619,7 @@ class InteractionHandler {
       for (let i = 0; i < nodeIndices.length; i++) {
         node = nodes[nodeIndices[i]];
         if (node.isOverlappingWith(pointerObj) === true) {
+          nodeUnderCursor = true;
           if (node.getTitle() !== undefined) {
             overlappingNodes.push(nodeIndices[i]);
           }


### PR DESCRIPTION
When supplying an edge tooltip (`title`) without providing a node tooltip (`title`), the edge's tooltip will be displayed even though the node is hovered and the tooltip is in the background.

![screenshot from 2018-07-05 16-37-43](https://user-images.githubusercontent.com/889383/42329854-04539662-8072-11e8-9a96-d2018d1b45a7.png)

This PR fixes that behavior.