### PR TITLE
Timeline .focus() should also zoom in as well as zoom out. Fix vertical scroll when not using groups or rtl = true

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -463,7 +463,7 @@ Timeline.prototype.focus = function(id, options) {
         // The redraw shifted elements, so reset the animation to correct
         initialVerticalScroll = verticalScroll;
         startPos = me._getScrollTop() * -1;
-      }      
+      }
 
       var from = startPos;
       var to = initialVerticalScroll.scrollOffset;
@@ -492,13 +492,13 @@ Timeline.prototype.focus = function(id, options) {
       // Double check we ended at the proper scroll position
       setFinalVerticalPosition();
 
-      // Let the redraw settle and finalize the position.      
+      // Let the redraw settle and finalize the position.
       setTimeout(setFinalVerticalPosition, 100);
     };
 
     // calculate the new middle and interval for the window
     var middle = (start + end) / 2;
-    var interval = Math.max(this.range.end - this.range.start, (end - start) * 1.1);
+    var interval = (end - start) * 1.1;
 
     var animation = options && options.animation !== undefined ? options.animation : true;
 
@@ -569,14 +569,14 @@ function getItemVerticalScroll(timeline, item) {
     return false;
   }
 
-  var leftHeight = timeline.props.leftContainer.height;
-  var contentHeight = timeline.props.left.height;
-  
+  var itemsetHeight = timeline.options.rtl ? timeline.props.rightContainer.height : timeline.props.leftContainer.height;
+  var contentHeight = timeline.props.center.height;
+
   var group = item.parent;
   var offset = group.top;
   var shouldScroll = true;
   var orientation = timeline.timeAxis.options.orientation.axis;
-  
+
   var itemTop = function () {
   if (orientation == "bottom") {
       return group.height - item.top - item.height;
@@ -591,18 +591,18 @@ function getItemVerticalScroll(timeline, item) {
   var height = item.height;
 
   if (targetOffset < currentScrollHeight) {
-    if (offset + leftHeight <= offset + itemTop() + height) {
+    if (offset + itemsetHeight <= offset + itemTop() + height) {
       offset += itemTop() - timeline.itemSet.options.margin.item.vertical;
     }
   }
-  else if (targetOffset + height > currentScrollHeight + leftHeight) {
-    offset += itemTop() + height - leftHeight + timeline.itemSet.options.margin.item.vertical;
+  else if (targetOffset + height > currentScrollHeight + itemsetHeight) {
+    offset += itemTop() + height - itemsetHeight + timeline.itemSet.options.margin.item.vertical;
   }
   else {
     shouldScroll = false;
   }
 
-  offset = Math.min(offset, contentHeight - leftHeight);
+  offset = Math.min(offset, contentHeight - itemsetHeight);
 
   return { shouldScroll: shouldScroll, scrollOffset: offset, itemTop: targetOffset };
 }


### PR DESCRIPTION
Fixes #3389, #2475

