### PR TITLE
micah/4039/hide edges on zoom

### DIFF
--- a/docs/network/interaction.html
+++ b/docs/network/interaction.html
@@ -57,6 +57,7 @@ var options = {
     dragNodes:true,
     dragView: true,
     hideEdgesOnDrag: false,
+    hideEdgesOnZoom: false,
     hideNodesOnDrag: false,
     hover: false,
     hoverConnectedEdges: true,
@@ -95,6 +96,7 @@ network.setOptions(options);
         <tr><td>dragNodes</td>              <td>Boolean</td>            <td><code>true</code></td>      <td>When true, the nodes that are not fixed can be dragged by the user.</td></tr>
         <tr><td>dragView</td>               <td>Boolean</td>            <td><code>true</code></td>      <td>When true, the view can be dragged around by the user.</td></tr>
         <tr><td>hideEdgesOnDrag</td>        <td>Boolean</td>            <td><code>false</code></td>     <td>When true, the edges are not drawn when dragging the view. This can greatly speed up responsiveness on dragging, improving user experience.</td></tr>
+        <tr><td>hideEdgesOnZoom</td>        <td>Boolean</td>            <td><code>false</code></td>     <td>When true, the edges are not drawn when zooming the view. This can greatly speed up responsiveness on zooming, improving user experience.</td></tr>
         <tr><td>hideNodesOnDrag</td>        <td>Boolean</td>            <td><code>false</code></td>     <td>When true, the nodes are not drawn when dragging the view. This can greatly speed up responsiveness on dragging, improving user experience.</td></tr>
         <tr><td>hover</td>                  <td>Boolean</td>            <td><code>false</code></td>     <td>When true, the nodes use their hover colors when the mouse moves over them.</td></tr>
         <tr><td>hoverConnectedEdges</td>     <td>Boolean</td>            <td><code>true</code></td>      <td>When true, on hovering over a node, it's connecting edges are highlighted.</td></tr>

--- a/examples/network/exampleApplications/neighbourhoodHighlight.html
+++ b/examples/network/exampleApplications/neighbourhoodHighlight.html
@@ -68,7 +68,8 @@
       physics: false,
       interaction: {
         tooltipDelay: 200,
-        hideEdgesOnDrag: true
+        hideEdgesOnDrag: true,
+        hideEdgesOnZoom: true,
       }
     };
     var data = {nodes:nodesDataset, edges:edgesDataset} // Note: data is coming from ./datasources/WorldCup2014.js

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -64,6 +64,7 @@ class CanvasRenderer {
     this.allowRedraw = true;
 
     this.dragging = false;
+    this.zooming = false;
     this.options = {};
     this.defaultOptions = {
       hideEdgesOnDrag: false,
@@ -81,6 +82,8 @@ class CanvasRenderer {
   bindEventListeners() {
     this.body.emitter.on("dragStart", () => { this.dragging = true; });
     this.body.emitter.on("dragEnd", () => { this.dragging = false; });
+    this.body.emitter.on("zoomStart", () => {this.zooming = true; });
+    this.body.emitter.on("zoomEnd", () => {this.zooming = false; });
     this.body.emitter.on("_resizeNodes", () => { this._resizeNodes(); });
     this.body.emitter.on("_redraw", () => {
       if (this.renderingActive === false) {
@@ -90,7 +93,6 @@ class CanvasRenderer {
     this.body.emitter.on("_blockRedraw", () => {this.allowRedraw = false;});
     this.body.emitter.on("_allowRedraw", () => {this.allowRedraw = true; this.redrawRequested = false;});
     this.body.emitter.on("_requestRedraw", this._requestRedraw.bind(this));
-    this.body.emitter.on("_requestRedrawZoom", this._requestRedrawZoom.bind(this));
     this.body.emitter.on("_startRendering", () => {
       this.renderRequests += 1;
       this.renderingActive = true;
@@ -228,12 +230,12 @@ class CanvasRenderer {
    * Redraw the network with the current data on zoom
    * @private
    */
-  _requestRedrawZoom() {
-    if (this.redrawRequested !== true && this.renderingActive === false && this.allowRedraw === true) {
-      this.redrawRequested = true;
-      this._requestNextFrame(() => {this._redrawZoom(false);}, 0);
-    }
-  }
+  // _requestRedrawZoom() {
+  //   if (this.redrawRequested !== true && this.renderingActive === false && this.allowRedraw === true) {
+  //     this.redrawRequested = true;
+  //     this._requestNextFrame(() => {this._redrawZoom(false);}, 0);
+  //   }
+  // }
 
   /**
    * Redraw the network with the current data
@@ -276,6 +278,7 @@ class CanvasRenderer {
       ctx.closePath();
 
       if (hidden === false) {
+        // same for zoom
         if (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) {
           this._drawEdges(ctx);
         }
@@ -305,62 +308,62 @@ class CanvasRenderer {
    *                                   Only the nodes are drawn after which they are quickly drawn over.
    * @private
    */
-  _redrawZoom(hidden = false) {
-    if (this.allowRedraw === true) {
-      this.body.emitter.emit("initRedraw");
+  // _redrawZoom(hidden = false) {
+  //   if (this.allowRedraw === true) {
+  //     this.body.emitter.emit("initRedraw");
 
-      this.redrawRequested = false;
+  //     this.redrawRequested = false;
 
-      // when the container div was hidden, this fixes it back up!
-      if (this.canvas.frame.canvas.width === 0 || this.canvas.frame.canvas.height === 0) {
-        this.canvas.setSize();
-      }
+  //     // when the container div was hidden, this fixes it back up!
+  //     if (this.canvas.frame.canvas.width === 0 || this.canvas.frame.canvas.height === 0) {
+  //       this.canvas.setSize();
+  //     }
 
-      this.canvas.setTransform();
+  //     this.canvas.setTransform();
 
-      let ctx = this.canvas.getContext();
+  //     let ctx = this.canvas.getContext();
 
-      // clear the canvas
-      let w = this.canvas.frame.canvas.clientWidth;
-      let h = this.canvas.frame.canvas.clientHeight;
-      ctx.clearRect(0, 0, w, h);
+  //     // clear the canvas
+  //     let w = this.canvas.frame.canvas.clientWidth;
+  //     let h = this.canvas.frame.canvas.clientHeight;
+  //     ctx.clearRect(0, 0, w, h);
 
-      // if the div is hidden, we stop the redraw here for performance.
-      if (this.canvas.frame.clientWidth === 0) {
-        return;
-      }
+  //     // if the div is hidden, we stop the redraw here for performance.
+  //     if (this.canvas.frame.clientWidth === 0) {
+  //       return;
+  //     }
 
-      // set scaling and translation
-      ctx.save();
-      ctx.translate(this.body.view.translation.x, this.body.view.translation.y);
-      ctx.scale(this.body.view.scale, this.body.view.scale);
+  //     // set scaling and translation
+  //     ctx.save();
+  //     ctx.translate(this.body.view.translation.x, this.body.view.translation.y);
+  //     ctx.scale(this.body.view.scale, this.body.view.scale);
 
-      ctx.beginPath();
-      this.body.emitter.emit("beforeDrawing", ctx);
-      ctx.closePath();
+  //     ctx.beginPath();
+  //     this.body.emitter.emit("beforeDrawing", ctx);
+  //     ctx.closePath();
 
-//      if (hidden === false) {
-//        if (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) {
-//          this._drawEdges(ctx);
-//        }
-//      }
+  //    if (hidden === false) {
+  //      if (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) {
+  //        this._drawEdges(ctx);
+  //      }
+  //    }
 
-      if (this.dragging === false || (this.dragging === true && this.options.hideNodesOnDrag === false)) {
-        this._drawNodes(ctx, hidden);
-      }
+  //     if (this.dragging === false || (this.dragging === true && this.options.hideNodesOnDrag === false)) {
+  //       this._drawNodes(ctx, hidden);
+  //     }
 
-      ctx.beginPath();
-      this.body.emitter.emit("afterDrawing", ctx);
-      ctx.closePath();
+  //     ctx.beginPath();
+  //     this.body.emitter.emit("afterDrawing", ctx);
+  //     ctx.closePath();
 
 
-      // restore original scaling and translation
-      ctx.restore();
-      if (hidden === true) {
-        ctx.clearRect(0, 0, w, h);
-      }
-    }
-  }
+  //     // restore original scaling and translation
+  //     ctx.restore();
+  //     if (hidden === true) {
+  //       ctx.clearRect(0, 0, w, h);
+  //     }
+  //   }
+  // }
 
   /**
    * Redraw all nodes

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -287,7 +287,6 @@ class CanvasRenderer {
         this._drawNodes(ctx, hidden);
       }
 
-
       ctx.beginPath();
       this.body.emitter.emit("afterDrawing", ctx);
       ctx.closePath();
@@ -300,6 +299,7 @@ class CanvasRenderer {
       }
     }
   }
+
 
   /**
    * Redraw all nodes

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -90,6 +90,7 @@ class CanvasRenderer {
     this.body.emitter.on("_blockRedraw", () => {this.allowRedraw = false;});
     this.body.emitter.on("_allowRedraw", () => {this.allowRedraw = true; this.redrawRequested = false;});
     this.body.emitter.on("_requestRedraw", this._requestRedraw.bind(this));
+    this.body.emitter.on("_requestRedrawZoom", this._requestRedrawZoom.bind(this));
     this.body.emitter.on("_startRendering", () => {
       this.renderRequests += 1;
       this.renderingActive = true;
@@ -224,6 +225,17 @@ class CanvasRenderer {
   }
 
   /**
+   * Redraw the network with the current data on zoom
+   * @private
+   */
+  _requestRedrawZoom() {
+    if (this.redrawRequested !== true && this.renderingActive === false && this.allowRedraw === true) {
+      this.redrawRequested = true;
+      this._requestNextFrame(() => {this._redrawZoom(false);}, 0);
+    }
+  }
+
+  /**
    * Redraw the network with the current data
    * @param {boolean} [hidden=false] | Used to get the first estimate of the node sizes.
    *                                   Only the nodes are drawn after which they are quickly drawn over.
@@ -286,6 +298,69 @@ class CanvasRenderer {
     }
   }
 
+  /**
+   * Redraw the network with the current data
+   * do not draw the edges
+   * @param {boolean} [hidden=false] | Used to get the first estimate of the node sizes.
+   *                                   Only the nodes are drawn after which they are quickly drawn over.
+   * @private
+   */
+  _redrawZoom(hidden = false) {
+    if (this.allowRedraw === true) {
+      this.body.emitter.emit("initRedraw");
+
+      this.redrawRequested = false;
+
+      // when the container div was hidden, this fixes it back up!
+      if (this.canvas.frame.canvas.width === 0 || this.canvas.frame.canvas.height === 0) {
+        this.canvas.setSize();
+      }
+
+      this.canvas.setTransform();
+
+      let ctx = this.canvas.getContext();
+
+      // clear the canvas
+      let w = this.canvas.frame.canvas.clientWidth;
+      let h = this.canvas.frame.canvas.clientHeight;
+      ctx.clearRect(0, 0, w, h);
+
+      // if the div is hidden, we stop the redraw here for performance.
+      if (this.canvas.frame.clientWidth === 0) {
+        return;
+      }
+
+      // set scaling and translation
+      ctx.save();
+      ctx.translate(this.body.view.translation.x, this.body.view.translation.y);
+      ctx.scale(this.body.view.scale, this.body.view.scale);
+
+      ctx.beginPath();
+      this.body.emitter.emit("beforeDrawing", ctx);
+      ctx.closePath();
+
+//      if (hidden === false) {
+//        if (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) {
+//          this._drawEdges(ctx);
+//        }
+//      }
+
+      if (this.dragging === false || (this.dragging === true && this.options.hideNodesOnDrag === false)) {
+        this._drawNodes(ctx, hidden);
+      }
+
+      ctx.beginPath();
+      this.body.emitter.emit("afterDrawing", ctx);
+      ctx.closePath();
+
+
+      // restore original scaling and translation
+      ctx.restore();
+      if (hidden === true) {
+        ctx.clearRect(0, 0, w, h);
+      }
+    }
+  }
 
   /**
    * Redraw all nodes

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -235,17 +235,6 @@ class CanvasRenderer {
   }
 
   /**
-   * Redraw the network with the current data on zoom
-   * @private
-   */
-  // _requestRedrawZoom() {
-  //   if (this.redrawRequested !== true && this.renderingActive === false && this.allowRedraw === true) {
-  //     this.redrawRequested = true;
-  //     this._requestNextFrame(() => {this._redrawZoom(false);}, 0);
-  //   }
-  // }
-
-  /**
    * Redraw the network with the current data
    * @param {boolean} [hidden=false] | Used to get the first estimate of the node sizes.
    *                                   Only the nodes are drawn after which they are quickly drawn over.
@@ -310,70 +299,6 @@ class CanvasRenderer {
       }
     }
   }
-
-  /**
-   * Redraw the network with the current data
-   * do not draw the edges
-   * @param {boolean} [hidden=false] | Used to get the first estimate of the node sizes.
-   *                                   Only the nodes are drawn after which they are quickly drawn over.
-   * @private
-   */
-  // _redrawZoom(hidden = false) {
-  //   if (this.allowRedraw === true) {
-  //     this.body.emitter.emit("initRedraw");
-
-  //     this.redrawRequested = false;
-
-  //     // when the container div was hidden, this fixes it back up!
-  //     if (this.canvas.frame.canvas.width === 0 || this.canvas.frame.canvas.height === 0) {
-  //       this.canvas.setSize();
-  //     }
-
-  //     this.canvas.setTransform();
-
-  //     let ctx = this.canvas.getContext();
-
-  //     // clear the canvas
-  //     let w = this.canvas.frame.canvas.clientWidth;
-  //     let h = this.canvas.frame.canvas.clientHeight;
-  //     ctx.clearRect(0, 0, w, h);
-
-  //     // if the div is hidden, we stop the redraw here for performance.
-  //     if (this.canvas.frame.clientWidth === 0) {
-  //       return;
-  //     }
-
-  //     // set scaling and translation
-  //     ctx.save();
-  //     ctx.translate(this.body.view.translation.x, this.body.view.translation.y);
-  //     ctx.scale(this.body.view.scale, this.body.view.scale);
-
-  //     ctx.beginPath();
-  //     this.body.emitter.emit("beforeDrawing", ctx);
-  //     ctx.closePath();
-
-  //    if (hidden === false) {
-  //      if (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) {
-  //        this._drawEdges(ctx);
-  //      }
-  //    }
-
-  //     if (this.dragging === false || (this.dragging === true && this.options.hideNodesOnDrag === false)) {
-  //       this._drawNodes(ctx, hidden);
-  //     }
-
-  //     ctx.beginPath();
-  //     this.body.emitter.emit("afterDrawing", ctx);
-  //     ctx.closePath();
-
-
-  //     // restore original scaling and translation
-  //     ctx.restore();
-  //     if (hidden === true) {
-  //       ctx.clearRect(0, 0, w, h);
-  //     }
-  //   }
-  // }
 
   /**
    * Redraw all nodes

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -82,8 +82,11 @@ class CanvasRenderer {
   bindEventListeners() {
     this.body.emitter.on("dragStart", () => { this.dragging = true; });
     this.body.emitter.on("dragEnd", () => { this.dragging = false; });
-    this.body.emitter.on("zoomStart", () => {this.zooming = true; });
-    this.body.emitter.on("zoomEnd", () => {this.zooming = false; });
+    this.body.emitter.on("zoom", () => {
+      this.zooming = true;
+      window.clearTimeout(this.zoomTimeoutId)
+      this.zoomTimeoutId = window.setTimeout(() => { this.zooming = false; }), 250)
+    });
     this.body.emitter.on("_resizeNodes", () => { this._resizeNodes(); });
     this.body.emitter.on("_redraw", () => {
       if (this.renderingActive === false) {
@@ -115,6 +118,7 @@ class CanvasRenderer {
       }
       this.body.emitter.off();
     });
+
 
   }
 
@@ -279,7 +283,10 @@ class CanvasRenderer {
 
       if (hidden === false) {
         // same for zoom
-        if (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) {
+        if (
+          (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) || 
+          (this.zooming === false || (this.zooming === true && this.options.hideEdgesOnZoom === false))
+        ) {
           this._drawEdges(ctx);
         }
       }

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -90,8 +90,6 @@ class CanvasRenderer {
         this.zooming = false;
         this._requestRedraw.bind(this)()
       }, 250) 
-      console.log('this.zooming',)
-      console.log(this.zoomTimeoutId)
     });
     this.body.emitter.on("_resizeNodes", () => { this._resizeNodes(); });
     this.body.emitter.on("_redraw", () => {

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -86,7 +86,12 @@ class CanvasRenderer {
     this.body.emitter.on("zoom", () => {
       this.zooming = true;
       window.clearTimeout(this.zoomTimeoutId)
-      this.zoomTimeoutId = window.setTimeout(() => { this.zooming = false; }, 250) 
+      this.zoomTimeoutId = window.setTimeout(() => { 
+        this.zooming = false;
+        this._requestRedraw.bind(this)()
+      }, 250) 
+      console.log('this.zooming',)
+      console.log(this.zoomTimeoutId)
     });
     this.body.emitter.on("_resizeNodes", () => { this._resizeNodes(); });
     this.body.emitter.on("_redraw", () => {
@@ -283,9 +288,8 @@ class CanvasRenderer {
       ctx.closePath();
 
       if (hidden === false) {
-        // same for zoom
         if (
-          (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) || 
+          (this.dragging === false || (this.dragging === true && this.options.hideEdgesOnDrag === false)) && 
           (this.zooming === false || (this.zooming === true && this.options.hideEdgesOnZoom === false))
         ) {
           this._drawEdges(ctx);

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -68,7 +68,8 @@ class CanvasRenderer {
     this.options = {};
     this.defaultOptions = {
       hideEdgesOnDrag: false,
-      hideNodesOnDrag: false
+      hideEdgesOnZoom: false,
+      hideNodesOnDrag: false,
     };
     util.extend(this.options, this.defaultOptions);
 
@@ -85,7 +86,7 @@ class CanvasRenderer {
     this.body.emitter.on("zoom", () => {
       this.zooming = true;
       window.clearTimeout(this.zoomTimeoutId)
-      this.zoomTimeoutId = window.setTimeout(() => { this.zooming = false; }), 250)
+      this.zoomTimeoutId = window.setTimeout(() => { this.zooming = false; }, 250) 
     });
     this.body.emitter.on("_resizeNodes", () => { this._resizeNodes(); });
     this.body.emitter.on("_redraw", () => {
@@ -128,7 +129,7 @@ class CanvasRenderer {
    */
   setOptions(options) {
     if (options !== undefined) {
-      let fields = ['hideEdgesOnDrag','hideNodesOnDrag'];
+      let fields = ['hideEdgesOnDrag', 'hideEdgesOnZoom', 'hideNodesOnDrag'];
       util.selectiveDeepExtend(fields,this.options, options);
     }
   }

--- a/lib/network/modules/CanvasRenderer.js
+++ b/lib/network/modules/CanvasRenderer.js
@@ -287,6 +287,7 @@ class CanvasRenderer {
         this._drawNodes(ctx, hidden);
       }
 
+
       ctx.beginPath();
       this.body.emitter.emit("afterDrawing", ctx);
       ctx.closePath();

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -482,7 +482,7 @@ class InteractionHandler {
         this.drag.pointer.y = postScaleDragPointer.y;
       }
 
-      this.body.emitter.emit('_requestRedraw');
+      this.body.emitter.emit('_requestRedrawZoom');
 
       if (scaleOld < scale) {
         this.body.emitter.emit('zoom', {direction: '+', scale: this.body.view.scale, pointer: pointer});

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -78,7 +78,7 @@ class InteractionHandler {
   setOptions(options) {
     if (options !== undefined) {
       // extend all but the values in fields
-      let fields = ['hideEdgesOnDrag','hideNodesOnDrag','keyboard','multiselect','selectable','selectConnectedEdges'];
+      let fields = ['hideEdgesOnDrag', 'hideEdgesOnZoom', 'hideNodesOnDrag','keyboard','multiselect','selectable','selectConnectedEdges'];
       util.selectiveNotDeepExtend(fields, this.options, options);
 
       // merge the keyboard options in.

--- a/lib/network/modules/InteractionHandler.js
+++ b/lib/network/modules/InteractionHandler.js
@@ -482,7 +482,7 @@ class InteractionHandler {
         this.drag.pointer.y = postScaleDragPointer.y;
       }
 
-      this.body.emitter.emit('_requestRedrawZoom');
+      this.body.emitter.emit('_requestRedraw');
 
       if (scaleOld < scale) {
         this.body.emitter.emit('zoom', {direction: '+', scale: this.body.view.scale, pointer: pointer});

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -152,6 +152,7 @@ let allOptions = {
     dragNodes: { boolean: bool },
     dragView: { boolean: bool },
     hideEdgesOnDrag: { boolean: bool },
+    hideEdgesOnZoom: { boolean: bool },
     hideNodesOnDrag: { boolean: bool },
     hover: { boolean: bool },
     keyboard: {

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -561,6 +561,7 @@ let configureOptions = {
     dragNodes: true,
     dragView: true,
     hideEdgesOnDrag: false,
+    hideEdgesOnZoom: false,
     hideNodesOnDrag: false,
     hover: false,
     keyboard: {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "async": "^2.5.0",
-    "babel-core": "^6.25.0",
+    "babel-core": "^6.26.3",
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",


### PR DESCRIPTION
This PR adds a new network interaction option to hide edges on zoom, `hideEdgesOnZoom`

This new option is patterned after the existing `hideEdgesOnDrag` option.

fix #4039 

## 📄 steps to test
- `cd vis`
- run a local server on port `8080`
- visit the **Dynamic Data - Neighbourhood Highlight** example at  http://localhost:8080/examples/network/exampleApplications/neighbourhoodHighlight.html
- scroll to zoom
- notice that edges are not shown during zooming, and are shown again when zooming ends ✨  

![hide-edges-on-zoom-1](https://user-images.githubusercontent.com/2119400/43025275-ed0c7e28-8c25-11e8-8ad2-1b96f31cd395.gif)


