### PR TITLE
Proposed fix for bug 4079. Seed LayoutEngine random only at the beginning.

### DIFF
--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -390,7 +390,10 @@ class LayoutEngine {
       let prevHierarchicalState = hierarchical.enabled;
       util.selectiveDeepExtend(["randomSeed", "improvedLayout"],this.options, options);
       util.mergeOptions(this.options, options, 'hierarchical');
-      if (options.randomSeed !== undefined)     {this.initialRandomSeed = options.randomSeed;}
+      if (options.randomSeed !== undefined) {
+        this.initialRandomSeed = options.randomSeed;
+        this.randomSeed = this.initialRandomSeed;
+      }
 
       if (hierarchical.enabled === true) {
         if (prevHierarchicalState === true) {
@@ -524,7 +527,6 @@ class LayoutEngine {
    */
   positionInitially(nodesArray) {
     if (this.options.hierarchical.enabled !== true) {
-      this.randomSeed = this.initialRandomSeed;
       let radius = nodesArray.length + 50;
       for (let i = 0; i < nodesArray.length; i++) {
         let node = nodesArray[i];
@@ -689,6 +691,7 @@ class LayoutEngine {
   }
 
   /**
+   * Get the initial random seed used at the construction or option setting time.
    *
    * @returns {number|*}
    */


### PR DESCRIPTION
Proposed fix for bug #4079. Makes LayoutEngine seed it's random only at construction or configuration time, not every time nodes are added.