### PR TITLE
GWT interoperability / usage of typeof instead instanceof

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -447,7 +447,7 @@ ItemSet.prototype.setOptions = function(options) {
     var addCallback = (function (name) {
       var fn = options[name];
       if (fn) {
-        if (!(fn instanceof Function)) {
+	if (!(typeof fn === 'function')) {
           throw new Error('option ' + name + ' must be a function ' + name + '(item, callback)');
         }
         this.options[name] = fn;


### PR DESCRIPTION
When using the timeline from GWT, type determination for provided functions via the instanceof operator does not work.
Changed setOptions method to use typeof instead instanceof.