### PR TITLE
fix(timeline): destroy hammer bindings of DragCenter and DeleteButton

### DIFF
--- a/lib/timeline/component/item/Item.js
+++ b/lib/timeline/component/item/Item.js
@@ -154,15 +154,15 @@ Item.prototype._repaintDragCenter = function () {
     var dragCenter = document.createElement('div');
     dragCenter.className = 'vis-drag-center';
     dragCenter.dragCenterItem = this;
-    var hammer = new Hammer(dragCenter);
+    this.hammerDragCenter = new Hammer(dragCenter);
 
-    hammer.on('tap', function (event) {
+    this.hammerDragCenter.on('tap', function (event) {
       me.parent.itemSet.body.emitter.emit('click',  {
         event: event,
         item: me.id
       });
     });
-    hammer.on('doubletap', function (event) {
+    this.hammerDragCenter.on('doubletap', function (event) {
       event.stopPropagation();
       me.parent.itemSet._onUpdateItem(me);
       me.parent.itemSet.body.emitter.emit('doubleClick', {
@@ -191,6 +191,11 @@ Item.prototype._repaintDragCenter = function () {
       this.dom.dragCenter.parentNode.removeChild(this.dom.dragCenter);
     }
     this.dom.dragCenter = null;
+
+    if (this.hammerDragCenter) {
+      this.hammerDragCenter.destroy();
+      this.hammerDragCenter = null;
+    }
   }
 };
 
@@ -216,8 +221,7 @@ Item.prototype._repaintDeleteButton = function (anchor) {
     }
     deleteButton.title = 'Delete this item';
 
-    // TODO: be able to destroy the delete button
-    new Hammer(deleteButton).on('tap', function (event) {
+    this.hammerDeleteButton = new Hammer(deleteButton).on('tap', function (event) {
       event.stopPropagation();
       me.parent.removeFromDataSet(me);
     });
@@ -231,6 +235,11 @@ Item.prototype._repaintDeleteButton = function (anchor) {
       this.dom.deleteButton.parentNode.removeChild(this.dom.deleteButton);
     }
     this.dom.deleteButton = null;
+
+    if (this.hammerDeleteButton) {
+      this.hammerDeleteButton.destroy();
+      this.hammerDeleteButton = null;
+    }
   }
 };
 


### PR DESCRIPTION
Hey,

Selecting an item in the timeline currently adds 6 listeners each time to the window element but never removes them. Even a few dozen have a huge effect on performance.

I added the destruction of the hammer.js bindings, which fixes the issue.

Best Regards,
Dustin