### PR TITLE
Allow setting title of customtime in constructor

### DIFF
--- a/lib/timeline/component/CustomTime.js
+++ b/lib/timeline/component/CustomTime.js
@@ -54,7 +54,7 @@ CustomTime.prototype = new Component();
 CustomTime.prototype.setOptions = function(options) {
   if (options) {
     // copy all options that we know
-    util.selectiveExtend(['moment', 'locale', 'locales', 'id', 'editable'], this.options, options);
+    util.selectiveExtend(['moment', 'locale', 'locales', 'id', 'editable', 'title'], this.options, options);
   }
 };
 


### PR DESCRIPTION
This allows setting of custom time bar title in the constructor, allowing calls like the following to correctly display the title.

`graph.addCustomTime(new Date(1531135747 * 1000), 'custom_id', { title: 'custom title' });`