### PR TITLE
add style options of fill & stroke per point for Graph3d

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1521,7 +1521,17 @@ Graph3d.prototype._getColorsRegular = function(point) {
  */
 Graph3d.prototype._getColorsColor = function(point) {
   // calculate the color based on the value
-  var color, borderColor;
+  var color, borderColor, pointStyle;
+   if (point && point.point && point.point.data && point.point.data.style) {
+    pointStyle = point.point.data.style;
+  }
+  if (pointStyle && typeof pointStyle === 'object' &&
+      pointStyle.fill && pointStyle.stroke ) {
+    return {
+      fill: pointStyle.fill,
+      border: pointStyle.stroke
+    }
+  }
 
   if (typeof point.point.value === "string") {
     color = point.point.value;


### PR DESCRIPTION
Graph3d data points can now support the following `style` object in addition to numbers:

```
{
  "x":1,
  "y":0,
  "z":3686,
  "style": {
    "fill":"red",
    "stroke":"#000"
  }
}
```