### PR TITLE
[Timeline] Addittional fix for page scrolling over timeline

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -226,18 +226,21 @@ Core.prototype._create = function (container) {
     // Don't preventDefault if you can't scroll
     if (!this.options.verticalScroll && !this.options.horizontalScroll) return;
 
-    // Prevent default actions caused by mouse wheel
-    // (else the page and timeline both scroll)
-    event.preventDefault();
-
     if (this.options.verticalScroll && Math.abs(deltaY) >= Math.abs(deltaX)) {
       var current = this.props.scrollTop;
       var adjusted = current + deltaY;
 
       if (this.isActive()) {
-        this._setScrollTop(adjusted);
-        this._redraw();
-        this.emit('scroll', event);
+        var newScrollTop = this._setScrollTop(adjusted);
+
+        if (newScrollTop !== current) {
+          this._redraw();
+          this.emit('scroll', event);
+
+          // Prevent default actions caused by mouse wheel
+          // (else the page and timeline both scroll)
+          event.preventDefault();
+        }
       }
     } else if (this.options.horizontalScroll) {
       var delta = Math.abs(deltaX) >= Math.abs(deltaY) ? deltaX : deltaY;
@@ -254,6 +257,8 @@ Core.prototype._create = function (container) {
         event: event
       };
       this.range.setRange(newStart, newEnd, options);
+
+      event.preventDefault();
     }
   }
 


### PR DESCRIPTION
One more improvement (I hope so) for #3734.
After this fix, Timeline only does preventDefault on a vertical scroll event if the timeline has actually been scrolled. AFAIK this behaviour would be consistent with what all popular GUI systems do.