### PR TITLE
Fix: Network nodes ignoring widthConstraint after hover

### DIFF
--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -713,7 +713,7 @@ class Label {
    */
   _processLabelText(ctx, selected, hover, inText) {
     let splitter = new LabelSplitter(ctx, this, selected, hover);
-    return splitter.process(inText);
+    return splitter.process(ctx, inText);
   }
 
 

--- a/lib/network/modules/components/shared/Label.js
+++ b/lib/network/modules/components/shared/Label.js
@@ -735,7 +735,7 @@ class Label {
       state.width = this.fontOptions.minWdt;
     }
 
-    this.size.labelHeight =state.height;
+    this.size.labelHeight = state.height;
     if ((this.fontOptions.minHgt > 0) && (state.height < this.fontOptions.minHgt)) {
       state.height = this.fontOptions.minHgt;
     }

--- a/lib/network/modules/components/shared/LabelSplitter.js
+++ b/lib/network/modules/components/shared/LabelSplitter.js
@@ -336,15 +336,22 @@ class LabelSplitter {
    * In order not to break existing functionality, for the time being this behaviour will
    * be retained in any code changes. 
    *
+   * @param {CanvasRenderingContext2D} ctx
    * @param {string} text  text to split
    * @returns {Array<line>}
    */
-  process(text) {
+  process(ctx, text) {
     if (!ComponentUtil.isValidLabel(text)) {
       return this.lines.finalize();
     }
 
     var font = this.parent.fontOptions;
+
+    // Set the context's font to match the label's main font,
+    // otherwise measurements will be incorrect.
+    let fontString = "";
+    fontString += font.size + "px " + font.face;
+    ctx.font = fontString.replace(/"/g, "");
 
     // Normalize the end-of-line's to a single representation - order important
     text = text.replace(/\r\n/g, '\n');  // Dos EOL's

--- a/test/network/hoverLabelSplitterEdgeCase.html
+++ b/test/network/hoverLabelSplitterEdgeCase.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html>
+<head>
+  <title>Label Splitter Text Measurement Test</title>
+
+  <script src="../../dist/vis-network.min.js" type="text/javascript"></script>
+  <link href="../../dist/vis-network.min.css" rel="stylesheet" type="text/css">
+
+  <style type="text/css">
+    #visualization {
+      width: 600px;
+      height: 400px;
+      border: 1px solid lightgray;
+    }
+  </style>
+</head>
+
+<body>
+
+<p><a href="https://github.com/almende/vis/issues/3928" target="_blank">Bug #3928</a> meant that nodes would change size after being hovered if they had a widthConstraint specified.</p>
+<p>This was due to the context's font not being set to the correct value when the label was evaluated during edges update, so the line would be split based on incorrect measurements.</p>
+
+<div id="visualization"><div class="vis-network"></div></div>
+
+<script type="text/javascript">
+var nodes = new vis.DataSet([{
+  id: 1,
+  label: 'Short Label',
+}, {
+  id: 2,
+  label: 'This is a very long label that should wrap',
+}]);
+
+var edges = new vis.DataSet([{
+  from: 1,
+  to: 2,
+}]);
+
+var data = {
+  nodes: nodes,
+  edges: edges,
+};
+
+let options = {
+  physics: {
+      enabled: false,
+  },
+  nodes: {
+    shadow: true,
+    shape: "box",
+    color: {
+      border: "lightgray",
+      background: "white",
+      hover: {
+        background: "white",
+        border: "lightgray",
+      },
+    },
+    font: {
+      face: "tahoma",
+      size: 25,
+    },
+    labelHighlightBold: true,
+    shapeProperties: {
+      borderRadius: 2,
+    },
+    chosen: {
+      node: function(values, id, selected, hovering) {
+        if (hovering) {
+          values.borderWidth = 2;
+          values.borderColor = "gray";
+        }
+      },
+    },
+    widthConstraint: {
+      maximum: 180,
+    }
+  },
+  edges: {
+    arrows: {
+      to: {
+        enabled: true,
+      }
+    },
+    width: 3,
+  },
+};
+
+var container = document.getElementById('visualization');
+var network = new vis.Network(container, data, options);
+</script>
+</body>
+</html>


### PR DESCRIPTION
There is an issue where the `widthConstraint` value of a node appears to be ignored after the mouse has hovered over a node.

I tracked this down to the `ctx` not being initialized correctly the second time the nodes are refreshed, leading to an incorrect font face and size being supplied to the method that splits long text strings, which causes the measurements for the calculated pixel size of the string to be entirely incorrect.

This bug has been reported in a few different issues - see the discussion thread on this #3928 for my investigation and reasoning for the fix. I basically just pass the context through in another couple of places to ensure it's set before the string split is calculated.

I've added an example HTML file to validate the issue as [hoverLabelSplitterEdgeCase.html](https://github.com/moppius/vis/blob/fix3928/test/network/hoverLabelSplitterEdgeCase.html) in the existing **test/network/** folder.

This PR should fix #3872 & #3928.
