### PR TITLE
Optimized isAlphaNumeric for performance

### DIFF
--- a/lib/network/dotparser.js
+++ b/lib/network/dotparser.js
@@ -16,8 +16,8 @@
  * ====
  *
  * For label handling, this is an incomplete implementation. From docs (quote #3015):
- * 
- * > the escape sequences "\n", "\l" and "\r" divide the label into lines, centered, 
+ *
+ * > the escape sequences "\n", "\l" and "\r" divide the label into lines, centered,
  * > left-justified, and right-justified, respectively.
  *
  * Source: http://www.graphviz.org/content/attrs#kescString
@@ -110,14 +110,31 @@ function nextPreview() {
   return dot.charAt(index + 1);
 }
 
-var regexAlphaNumeric = /[a-zA-Z_0-9.:#]/;
 /**
- * Test whether given character is alphabetic or numeric
+ * Test whether given character is alphabetic or numeric ( a-zA-Z_0-9.:# )
  * @param {string} c
  * @return {Boolean} isAlphaNumeric
  */
 function isAlphaNumeric(c) {
-  return regexAlphaNumeric.test(c);
+  var charCode = c.charCodeAt(0);
+
+  if(charCode < 47){ // #.
+    return charCode === 35 || charCode === 46;
+  }
+  if(charCode < 59) { // 0-9 and :
+    return charCode > 47;
+  }
+  if(charCode < 91) { // A-Z
+    return charCode > 64;
+  }
+  if (charCode < 96) { // _
+    return charCode === 95;
+  }
+  if(charCode < 123) { // a-z
+    return charCode > 96;
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
Optimized isAlphaNumeric to use charcodes instead if regex. This gives the function a worst case 60%+ performance on V8 and 40%+ on Spidermonkey