### PR TITLE
make method names in docs selectable again

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -167,11 +167,6 @@ span.right-caret {
 
 tr.toggle {
     -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
     cursor:pointer;
 }
 


### PR DESCRIPTION
It is very incovenient when you can't select and copy-paste method name. The fact that I [see](http://visjs.org/docs/network/#methodInformation) `getConnectedNodes` but can't select it is annoying, so let's make the titles selectable again. The fact that the hidden area will get toggled on selection isn't that problematic compared to not being able to select-copy-paste.