### PR TITLE
Fix mouse offset when parent has position:relative

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1538,12 +1538,12 @@ ItemSet.prototype._onDrag = function (event) {
 
     var me = this;
     var snap = this.options.snap || null;
-    var xOffset;
+    var xOffset = this.body.dom.root.getBoundingClientRect().x;
 
     if (this.options.rtl) {
-      xOffset = this.body.dom.root.offsetLeft + this.body.domProps.right.width;
+      xOffset += this.body.domProps.right.width;
     } else {
-      xOffset = this.body.dom.root.offsetLeft + this.body.domProps.left.width;
+      xOffset += this.body.domProps.left.width;
     }
 
     var scale = this.body.util.getScale();


### PR DESCRIPTION
Fix issue when parent has `position: relative`. `offsetLeft` is offset from the nearest relatively positioned parent, so a relative parent that has any sort of left offset will cause the mouse position to be wrong. This issue isn't noticeable in most cases because it's taking the difference between the time you start dragging at and the current time under the mouse, and most timelines are linear. It does cause issues with non-linear timelines though, such as when some periods are hidden.

[JSFiddle](https://jsfiddle.net/soL5470h/1/)

### Examples

Old code with left margin
![broken-margin](https://user-images.githubusercontent.com/7794502/47166513-fb36e500-d2c1-11e8-85e3-ccea91efcc51.gif)
Fixed code with left margin
![fixed-margin](https://user-images.githubusercontent.com/7794502/47166528-025df300-d2c2-11e8-8a3c-17230ac19d28.gif)
Old code with scroll
![broken-scroll](https://user-images.githubusercontent.com/7794502/47166533-0558e380-d2c2-11e8-9e2b-4def203d6f8b.gif)
Fixed code with scroll
![fixed-scroll](https://user-images.githubusercontent.com/7794502/47166537-07bb3d80-d2c2-11e8-899d-fa70a40c397c.gif)