### PR TITLE
handle preventDefault per-keybind #3906

### DIFF
--- a/lib/network/modules/components/NavigationHandler.js
+++ b/lib/network/modules/components/NavigationHandler.js
@@ -120,26 +120,50 @@ class NavigationHandler {
   }
 
   /**
-   *
-   * @param {string} action
+   * returns true if a keyuse ctrl, shift, or alt modifiers
+   * @param {KeyboardEvent} event 
+   * @return {boolean}
    */
-  bindToRedraw(action) {
-    if (this.boundFunctions[action] === undefined) {
-      this.boundFunctions[action] = this[action].bind(this);
-      this.body.emitter.on("initRedraw", this.boundFunctions[action]);
-      this.body.emitter.emit("_startRendering");
+  _shouldPreventDefault(event) {
+    if (!event.ctrlKey && !event.shiftKey && !event.altKey) {
+      return true;
     }
+    return false;
   }
 
   /**
-   *
+   * creates a key press function that initiates redrawing
    * @param {string} action
+   * @return {function(KeyboardEvent)}
+   */
+  bindToRedraw(action) {
+    return (event) => {
+      if (this._shouldPreventDefault(event)) {
+        event.preventDefault();
+      }
+      if (this.boundFunctions[action] === undefined) {
+        this.boundFunctions[action] = this[action].bind(this);
+        this.body.emitter.on("initRedraw", this.boundFunctions[action]);
+        this.body.emitter.emit("_startRendering");
+      }
+    };
+  }
+
+  /**
+   * creates a key press function that stops redrawing
+   * @param {string} action
+   * @return {function(KeyboardEvent)}
    */
   unbindFromRedraw(action) {
-    if (this.boundFunctions[action] !== undefined) {
-      this.body.emitter.off("initRedraw", this.boundFunctions[action]);
-      this.body.emitter.emit("_stopRendering");
-      delete this.boundFunctions[action];
+    return (event) => {
+      if (this._shouldPreventDefault(event)) {
+        event.preventDefault();
+      }
+      if (this.boundFunctions[action] !== undefined) {
+        this.body.emitter.off("initRedraw", this.boundFunctions[action]);
+        this.body.emitter.emit("_stopRendering");
+        delete this.boundFunctions[action];
+      }
     }
   }
 
@@ -224,7 +248,6 @@ class NavigationHandler {
     this.body.emitter.emit('zoom', { direction: '-', scale: this.body.view.scale, pointer: null });
   }
 
-
   /**
    * bind all keys using keycharm.
    */
@@ -235,40 +258,40 @@ class NavigationHandler {
 
     if (this.options.keyboard.enabled === true) {
       if (this.options.keyboard.bindToWindow === true) {
-        this.keycharm = keycharm({container: window, preventDefault: true});
+        this.keycharm = keycharm({container: window, preventDefault: false});
       }
       else {
-        this.keycharm = keycharm({container: this.canvas.frame, preventDefault: true});
+        this.keycharm = keycharm({container: this.canvas.frame, preventDefault: false});
       }
 
       this.keycharm.reset();
 
       if (this.activated === true) {
-        this.keycharm.bind("up",       () => {this.bindToRedraw("_moveUp")   ;}, "keydown");
-        this.keycharm.bind("down",     () => {this.bindToRedraw("_moveDown") ;}, "keydown");
-        this.keycharm.bind("left",     () => {this.bindToRedraw("_moveLeft") ;}, "keydown");
-        this.keycharm.bind("right",    () => {this.bindToRedraw("_moveRight");}, "keydown");
-        this.keycharm.bind("=",        () => {this.bindToRedraw("_zoomIn")   ;}, "keydown");
-        this.keycharm.bind("num+",     () => {this.bindToRedraw("_zoomIn")   ;}, "keydown");
-        this.keycharm.bind("num-",     () => {this.bindToRedraw("_zoomOut")  ;}, "keydown");
-        this.keycharm.bind("-",        () => {this.bindToRedraw("_zoomOut")  ;}, "keydown");
-        this.keycharm.bind("[",        () => {this.bindToRedraw("_zoomOut")  ;}, "keydown");
-        this.keycharm.bind("]",        () => {this.bindToRedraw("_zoomIn")   ;}, "keydown");
-        this.keycharm.bind("pageup",   () => {this.bindToRedraw("_zoomIn")   ;}, "keydown");
-        this.keycharm.bind("pagedown", () => {this.bindToRedraw("_zoomOut")  ;}, "keydown");
+        this.keycharm.bind("up", this.bindToRedraw("_moveUp"), "keydown");
+        this.keycharm.bind("down", this.bindToRedraw("_moveDown"), "keydown");
+        this.keycharm.bind("left", this.bindToRedraw("_moveLeft"), "keydown");
+        this.keycharm.bind("right", this.bindToRedraw("_moveRight"), "keydown");
+        this.keycharm.bind("=", this.bindToRedraw("_zoomIn"), "keydown");
+        this.keycharm.bind("num+", this.bindToRedraw("_zoomIn"), "keydown");
+        this.keycharm.bind("num-", this.bindToRedraw("_zoomOut"), "keydown");
+        this.keycharm.bind("-", this.bindToRedraw("_zoomOut"), "keydown");
+        this.keycharm.bind("[", this.bindToRedraw("_zoomOut"), "keydown");
+        this.keycharm.bind("]", this.bindToRedraw("_zoomIn"), "keydown");
+        this.keycharm.bind("pageup", this.bindToRedraw("_zoomIn"), "keydown");
+        this.keycharm.bind("pagedown", this.bindToRedraw("_zoomOut"), "keydown");
 
-        this.keycharm.bind("up",       () => {this.unbindFromRedraw("_moveUp")   ;}, "keyup");
-        this.keycharm.bind("down",     () => {this.unbindFromRedraw("_moveDown") ;}, "keyup");
-        this.keycharm.bind("left",     () => {this.unbindFromRedraw("_moveLeft") ;}, "keyup");
-        this.keycharm.bind("right",    () => {this.unbindFromRedraw("_moveRight");}, "keyup");
-        this.keycharm.bind("=",        () => {this.unbindFromRedraw("_zoomIn")   ;}, "keyup");
-        this.keycharm.bind("num+",     () => {this.unbindFromRedraw("_zoomIn")   ;}, "keyup");
-        this.keycharm.bind("num-",     () => {this.unbindFromRedraw("_zoomOut")  ;}, "keyup");
-        this.keycharm.bind("-",        () => {this.unbindFromRedraw("_zoomOut")  ;}, "keyup");
-        this.keycharm.bind("[",        () => {this.unbindFromRedraw("_zoomOut")  ;}, "keyup");
-        this.keycharm.bind("]",        () => {this.unbindFromRedraw("_zoomIn")   ;}, "keyup");
-        this.keycharm.bind("pageup",   () => {this.unbindFromRedraw("_zoomIn")   ;}, "keyup");
-        this.keycharm.bind("pagedown", () => {this.unbindFromRedraw("_zoomOut")  ;}, "keyup");
+        this.keycharm.bind("up", this.unbindFromRedraw("_moveUp"), "keyup");
+        this.keycharm.bind("down", this.unbindFromRedraw("_moveDown"), "keyup");
+        this.keycharm.bind("left", this.unbindFromRedraw("_moveLeft"), "keyup");
+        this.keycharm.bind("right", this.unbindFromRedraw("_moveRight"), "keyup");
+        this.keycharm.bind("=", this.unbindFromRedraw("_zoomIn"), "keyup");
+        this.keycharm.bind("num+", this.unbindFromRedraw("_zoomIn"), "keyup");
+        this.keycharm.bind("num-", this.unbindFromRedraw("_zoomOut"), "keyup");
+        this.keycharm.bind("-", this.unbindFromRedraw("_zoomOut"), "keyup");
+        this.keycharm.bind("[", this.unbindFromRedraw("_zoomOut"), "keyup");
+        this.keycharm.bind("]", this.unbindFromRedraw("_zoomIn"), "keyup");
+        this.keycharm.bind("pageup", this.unbindFromRedraw("_zoomIn"), "keyup");
+        this.keycharm.bind("pagedown", this.unbindFromRedraw("_zoomOut"), "keyup");
       }
     }
   }


### PR DESCRIPTION
By default, all keybinds are having their defaults prevented. This PR only calls preventDefault on keys that are not combined with ctrl, shift, or alt, because those are modifiers for normal browser hotkeys.

The same should probably be done for scroll events, considering that ctrl+scrollwheel will simultaneously zoom in/out on the canvas as well as the window. Perhaps there should be an interaction option that allows which keybinds should propogate?

Looking forward to feedback.
