### PR TITLE
Added option hierarchical.layout.userControlsFreeAxis (revision 2)

### DIFF
--- a/docs/network/layout.html
+++ b/docs/network/layout.html
@@ -66,7 +66,8 @@ var options = {
       edgeMinimization: true,
       parentCentralization: true,
       direction: 'UD',        // UD, DU, LR, RL
-      sortMethod: 'hubsize'   // hubsize, directed
+      sortMethod: 'hubsize',   // hubsize, directed
+      userControlsFreeAxis: false
     }
   }
 }
@@ -103,6 +104,20 @@ network.setOptions(options);
         <tr parent="hierarchical" class="hidden"><td class="indent">hierarchical.sortMethod</td><td>String</td><td><code>'hubsize'</code></td>  <td>The algorithm used to ascertain the levels of the nodes based on the data. The possible options are: <code>hubsize, directed</code>. <br><br>
             Hubsize takes the nodes with the most edges and puts them at the top. From that the rest of the hierarchy is evaluated. <br><br>
             Directed adheres to the to and from data of the edges. A --> B so B is a level lower than A.</td></tr>
+        <tr parent="hierarchical" class="hidden">
+                <td class="indent">hierarchical.userControlsFreeAxis</td>
+                <td>Boolean</td>
+                <td><code>false</code></td>
+                <td>Whether or not the value specified by a node's <code>Dataset</code> <code>x</code> or <code>y</code> values will affect a node's layout along its "free" axis.<br><br>
+                    If the hierarchical layout <code>direction</code> is either <code>"DU"</code> or <code>"UD"</code>, vis.js will layout the node using the Node's <code>x</code> property,
+                    or if <code>direction</code>is either <code>"LR"</code> or <code>"RL"</code>, vis.js will use the node's <code>y</code> property.<br><br>
+                    If the property vis wants to use (e.g., the <code>x</code> or <code>y</code> property on the node within the target <code>Dataset</code>)
+                    is undefined, the default behavior is invoked, as though this option were set to <code>false</code>. This provides the ability to initally utilize Vis's default layout,
+                    then later call <code>Network.storePositions()</code> and have the hierarchical layout engine respect the retreived values.<br><br>
+                    This option is helpful because updating a hierarchically layed-out graph will trigger a redraw, and without this option, if a node has been moved along its free axis,
+                    it will be returned to its default position.<br><br>
+                    This option is useful with physics disabled.</td>
+        </tr>
     </table>
 
 </div>

--- a/lib/network/modules/LayoutEngine.js
+++ b/lib/network/modules/LayoutEngine.js
@@ -743,11 +743,18 @@ class LayoutEngine {
             this._determineLevelsCustomCallback();
           }
         }
-
+        
+        //
+        // to be iterated over later, in the userControlsFreeAxis option section
+        // we iterate over nodeIds once to call ensureLevel, so we might as well
+        // capture them now
+        //
+        let nodeIds = [];
 
         // fallback for cases where there are nodes but no edges
         for (let nodeId in this.body.nodes) {
           if (this.body.nodes.hasOwnProperty(nodeId)) {
+            nodeIds.push(nodeId);
             this.hierarchical.ensureLevel(nodeId);
           }
         }
@@ -765,6 +772,33 @@ class LayoutEngine {
 
         // shift to center so gravity does not have to do much
         this._shiftToCenter();
+
+        //
+        // if option hierarchical.userControlsFreeAxis is set (to true)
+        // we will attempt to set each node's free axis position based on Dataset value
+        // if the node's free axis position is undefined, we skip it and keep the original LayoutEngine-generated value
+        //
+        // the free axis in direction DU/UD is x
+        // the free axis in direction LR/RL is y
+        //
+        if (this.options.hierarchical.userControlsFreeAxis) {
+          let direction = this.options.hierarchical.direction;
+          let dataSet = this.body.data.nodes.getDataSet();
+          let freeAxis = "";
+           if (direction === "UD" || direction === "DU") {
+            freeAxis = "x";
+          }
+          else { // direction === "LR" || direction == "RL", any other values are caught as errors earlier in the program
+            freeAxis = "y";
+          }
+           for (let nodeId of nodeIds) {
+            let targetPosition = dataSet._data[nodeId][freeAxis];
+            if (targetPosition !== undefined) {
+                this.body.nodes[nodeId][freeAxis] = targetPosition;
+              }
+          }
+        }
+        
       }
     }
   }

--- a/lib/network/options.js
+++ b/lib/network/options.js
@@ -183,6 +183,7 @@ let allOptions = {
       parentCentralization: { boolean: bool },
       direction: { string: ['UD', 'DU', 'LR', 'RL'] },   // UD, DU, LR, RL
       sortMethod: { string: ['hubsize', 'directed'] }, // hubsize, directed
+      userControlsFreeAxis: { boolean: bool },
       __type__: { object, boolean: bool }
     },
     __type__: { object }
@@ -553,7 +554,8 @@ let configureOptions = {
       edgeMinimization: true,
       parentCentralization: true,
       direction: ['UD', 'DU', 'LR', 'RL'],   // UD, DU, LR, RL
-      sortMethod: ['hubsize', 'directed'] // hubsize, directed
+      sortMethod: ['hubsize', 'directed'], // hubsize, directed
+      userControlsFreeAxis: false
     }
   },
   interaction: {


### PR DESCRIPTION
Sorry for polluting your pull requests, this is a revised version of my pull request from yesterday containing only the relevant commit.

This commit solves a question I asked on stackoverflow: https://stackoverflow.com/questions/53127971/how-can-i-set-node-positions-in-a-hierarchical-layout

Here we override the `LayoutEngine` logic if a user has BOTH specified this option and supplied a "free axis" value in any of their nodes within the `Dataset` they've bound to `Network`. The "free axis" is `x` if `hierarchical.direction` is `"DU"` / `"UD"`, and `y` if it's `"LR"` / `"RL"`. Undefined values for the free axis leave `LayoutEngine` doing what it did prior to this commit.

In addition I added some documentation for this in './docs/network/layout.html'.

* [ ] Provide an additional or update an example to demonstrate your changes or new features.
* [x] Update the documentation if you introduced new behavior or changed existing behavior.
* [x] Expect review comments and change requests by reviewer.
