### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - "7"
+  - "node"
+  - "10"
+  - "8"
+  - "6"
 env:
   - CXX=g++-4.8
 addons:


### PR DESCRIPTION
Node.js 7 has already reached its EOL and is not one of the even release branches which become LTS.
We should test on the current LTS branches which are 6, 8 and 10. And also stable.

See https://github.com/nodejs/Release/blob/master/README.md