### PR TITLE
Add support for graphviz edge "dir"

### DIFF
--- a/examples/network/data/dotLanguage/dotEdgeStyles.html
+++ b/examples/network/data/dotLanguage/dotEdgeStyles.html
@@ -158,6 +158,9 @@
     ' ahs -> diamond[label="diamond", arrowhead=diamond]; \n' +
     ' ahs -> tee[label="tee", arrowhead=tee]; \n' +
     ' ahs -> vee[label="vee", arrowhead=vee]; \n' +
+    ' ahs -> both[label="both", dir=both]; \n' +
+    ' ahs -> back[label="back", dir=back]; \n' +
+    ' ahs -> none[label="none", dir=none]; \n' +
     '}';
 
   // create a network

--- a/lib/network/dotparser.js
+++ b/lib/network/dotparser.js
@@ -740,13 +740,38 @@ function parseAttributeList() {
         vee: 'vee'
       };
 
+      var dirTypes = {
+        forward: ["to"],
+        back: ["from"],
+        both: ["to", "from"],
+        none: []
+      };
+
       if (name === 'arrowhead') {
         var arrowType = arrowTypes[value];
         name = 'arrows';
         value = {to: {enabled:true, type: arrowType}};
       }
 
-      setValue(attr, name, value); // name can be a path
+      if (name === 'dir') {
+        // First set all arrows to disabled
+        var status = {enabled: false};
+        var prop = "";
+        for (prop in dirTypes["both"]) {
+          name = `arrows.${dirTypes["both"][prop]}`;
+          setValue(attr, name, status);
+        }
+
+        var dirType = dirTypes[value];
+        for (prop in dirType) {
+          name = `arrows.${dirType[prop]}`;
+          status = {enabled: true};
+          setValue(attr, name, status); // name can be a path
+        }
+
+      } else {
+        setValue(attr, name, value); // name can be a path
+      }
 
       getToken();
       if (token ==',') {


### PR DESCRIPTION
If the "dir" attribute is present in the edge, disable both arrows,
and selectively re-enable them based on dir.