### PR TITLE
feat: added the ability to set the size of an icon when using a dot s…

### DIFF
--- a/lib/network/modules/components/nodes/util/ShapeBase.js
+++ b/lib/network/modules/components/nodes/util/ShapeBase.js
@@ -52,11 +52,12 @@ class ShapeBase extends NodeBase {
     this.initContextForDraw(ctx, values);
     ctx[shape](x, y, values.size);
     this.performFill(ctx, values);
-    
+
     if (this.options.icon !== undefined) {
       if (this.options.icon.code !== undefined) {
+        var iconScale = (this.options.icon.scale || 0.5);
         ctx.font = (selected ? "bold " : "")
-            + (this.height / 2) + "px "
+            + Math.round(this.height * iconScale) + "px "
             + (this.options.icon.face || 'FontAwesome');
         ctx.fillStyle = this.options.icon.color || "black";
         ctx.textAlign = "center";


### PR DESCRIPTION
This is a small change allowing the icon size to be scaled relative to the node when using the dot shape.

The existing "icon.size" property is ignored when using a "dot" shape so this new option is intended to enable specifying the icon size relative to the shape size.

To use this a "scale" setting can be added to the icon settings:
```

{
    shape: 'dot',
    size: 30,
    icon: {
        face: 'FontAwesome',
        color: '#2B7CE9',
        scale: 0.9,
    }
}
```

**Thank you for contributing to vis.js!!**

Please make sure to check the following requirements before creating a pull request:

* [ ] All pull requests must be to the [develop branch](https://github.com/almende/vis/tree/develop). Pull requests to the `master` branch will be closed!
* [ ] Make sure your changes are based on the latest version of the [develop branch](https://github.com/almende/vis/tree/develop). (Use e.g. `git fetch && git rebase origin develop` to update your feature branch).
* [ ] Provide an additional or update an example to demonstrate your changes or new features.
* [ ] Update the documentation if you introduced new behavior or changed existing behavior.
* [ ] Reference issue numbers of issues that your pull request addresses. (If you write something like `fixes #1781` in your git commit message this issue gets closed automatically by merging your pull request).
* [ ] Expect review comments and change requests by reviewer.
* [ ] Delete this checklist from your pull request.
