### PR TITLE
Fix `useDefaultGroups` option in Groups module

### DIFF
--- a/lib/network/modules/Groups.js
+++ b/lib/network/modules/Groups.js
@@ -59,6 +59,8 @@ class Groups {
           if (optionFields.indexOf(groupName) === -1) {
             let group = options[groupName];
             this.add(groupName, group);
+          } else {
+            this.options[groupName] = options[groupName];
           }
         }
       }
@@ -90,8 +92,7 @@ class Groups {
         // create new group
         let index = this.groupIndex % this.groupsArray.length;
         this.groupIndex++;
-        group = {};
-        group.color = this.groups[this.groupsArray[index]];
+        group = this.groups[this.groupsArray[index]];
         this.groups[groupname] = group;
       }
       else {


### PR DESCRIPTION
The docs (http://visjs.org/docs/network/groups.html#) indicate that if `useDefaultGroups` is passed as false, it will iterate through the provided groups to use as defaults instead. But the code doesn't seem to match that description, as `useDefaultGroups` is ignored, and the code that handles it being false doesn't seem quite right (it should fetch the full group, not just the color)