### PR TITLE
Added `pointer-events: none` for read-only timeline items

### DIFF
--- a/lib/timeline/component/css/item.css
+++ b/lib/timeline/component/css/item.css
@@ -189,6 +189,10 @@
   cursor: e-resize;
 }
 
+.vis-item.vis-readonly {
+  pointer-events: none;
+}
+
 .vis-range.vis-item.vis-readonly .vis-drag-left,
 .vis-range.vis-item.vis-readonly .vis-drag-right {
   cursor: auto;


### PR DESCRIPTION
Without this, read-only items accept mouse events. If an item is dynamically removed on horizontal drag, dragging stops and the crossed arrows cursor remains.