### PR TITLE
Fix for #3006

### DIFF
--- a/lib/shared/Configurator.js
+++ b/lib/shared/Configurator.js
@@ -357,7 +357,7 @@ class Configurator {
 
     let input = document.createElement('input');
     input.className = 'vis-configuration vis-config-rangeinput';
-    input.value = range.value;
+    input.value = Number(range.value);
 
     var me = this;
     range.onchange = function () {input.value = this.value; me._update(Number(this.value), path);};


### PR DESCRIPTION
HP Fortify re[ports the method _makeRange() in vis.js sends unvalidated data to a web browser.
Fixes issue #3006.